### PR TITLE
[router] Phase 0 Track 1: schemas + dataclasses

### DIFF
--- a/sage/cognition/router/__init__.py
+++ b/sage/cognition/router/__init__.py
@@ -1,0 +1,53 @@
+"""
+Thalamic router — schemas + data pipeline.
+
+Phase 0 Track 1 ships the schemas only. Feature extraction (Track 2),
+programmatic baseline (Track 3), dataset writer/reader (Track 4), and
+consciousness-loop integration (Track 5) follow in subsequent PRs.
+
+Spec: shared-context/arc-agi-3/phase2/brain-arch/thalamic-router-prd.md
+Sprint: shared-context/arc-agi-3/phase2/brain-arch/router-sprint-1-phase-0.md
+"""
+
+from sage.cognition.router.events import (
+    Event,
+    VALID_EVENT_KINDS,
+    ROUTER_KINDS,
+    WM_COMPATIBLE_KINDS,
+)
+from sage.cognition.router.inputs import (
+    RouterInput,
+    CARTRIDGE_EMBEDDING_DIM,
+    VALID_ATP_TRENDS,
+    VALID_METABOLIC_STATES,
+)
+from sage.cognition.router.outputs import (
+    RouterOutput,
+    VALID_ACTIONS,
+    VALID_RATIONALE_CODES,
+)
+from sage.cognition.router.record import (
+    RouterRecord,
+    ROUTER_SCHEMA_VERSION,
+)
+from sage.cognition.router.tiers import PluginTier
+
+__all__ = [
+    # Dataclasses
+    "Event",
+    "RouterInput",
+    "RouterOutput",
+    "RouterRecord",
+    # Enum
+    "PluginTier",
+    # Constants
+    "ROUTER_SCHEMA_VERSION",
+    "CARTRIDGE_EMBEDDING_DIM",
+    "VALID_ACTIONS",
+    "VALID_ATP_TRENDS",
+    "VALID_EVENT_KINDS",
+    "VALID_METABOLIC_STATES",
+    "VALID_RATIONALE_CODES",
+    "ROUTER_KINDS",
+    "WM_COMPATIBLE_KINDS",
+]

--- a/sage/cognition/router/events.py
+++ b/sage/cognition/router/events.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Router event stream — observable by metacog (Nomad) and training pipelines.
+===========================================================================
+
+Mirrors the pattern used in ``sage.cognition.working_memory.Event``:
+lightweight dataclass, ``to_dict()`` for JSON serialization, ``kind``
+drawn from a closed vocabulary.
+
+The router pipeline is a heavy event source (one decision per tick on every
+machine) so the schema stays tiny on purpose — no heavy payloads, just a
+kind, ids, a timestamp, and an optional human-readable reason.
+
+Spec: shared-context/arc-agi-3/phase2/brain-arch/thalamic-router-prd.md §2.7
+"""
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, Optional, Set
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Event kind vocabulary
+# ──────────────────────────────────────────────────────────────────────
+# The first seven kinds mirror working_memory.Event for observer-side
+# compatibility (a shared on_event callback can accept either).
+# The remaining kinds are router-specific.
+
+WM_COMPATIBLE_KINDS: Set[str] = {
+    "write",
+    "update",
+    "evict",
+    "clear",
+    "tick",
+    "consolidate",
+    "warn",
+}
+
+ROUTER_KINDS: Set[str] = {
+    "route",           # a decision was produced
+    "dispatch",        # a decision was actually executed (shadow mode: not emitted)
+    "veto",            # a decision was blocked (metacog / budget / unknown plugin)
+    "coerce_noop",     # invalid output coerced to noop per PRD §3.3 rule 5
+    "record_write",    # a RouterRecord was persisted
+    "record_backfill", # outcome backfilled onto an existing record
+}
+
+VALID_EVENT_KINDS: Set[str] = WM_COMPATIBLE_KINDS | ROUTER_KINDS
+
+
+@dataclass
+class Event:
+    """Mutation / decision event — observable by metacog.
+
+    Fields mirror ``sage.cognition.working_memory.Event`` so a single
+    ``on_event`` callback can subscribe to both streams.
+
+    Attributes:
+        kind: One of ``VALID_EVENT_KINDS``. Unknown kinds are rejected in
+            ``__post_init__`` to keep the vocabulary closed.
+        slot_id: Optional opaque id — a WM slot id, a record id, a plugin
+            name; whatever makes sense for the kind.
+        slot_type: Optional type tag — WM slot type, router action, plugin
+            tier; whatever makes sense for the kind.
+        timestamp: Wall-clock seconds (``time.time()``).
+        reason: Optional free-text explanation for the event.
+    """
+
+    kind: str
+    slot_id: Optional[str]
+    slot_type: Optional[str]
+    timestamp: float
+    reason: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.kind not in VALID_EVENT_KINDS:
+            raise ValueError(
+                f"unknown event kind {self.kind!r}; "
+                f"expected one of {sorted(VALID_EVENT_KINDS)}"
+            )
+        if not isinstance(self.timestamp, (int, float)):
+            raise TypeError(
+                f"timestamp must be numeric, got {type(self.timestamp).__name__}"
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Event":
+        return cls(
+            kind=data["kind"],
+            slot_id=data.get("slot_id"),
+            slot_type=data.get("slot_type"),
+            timestamp=float(data["timestamp"]),
+            reason=data.get("reason"),
+        )

--- a/sage/cognition/router/inputs.py
+++ b/sage/cognition/router/inputs.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+RouterInput — normative schema consumed by the thalamic router.
+===============================================================
+
+Every consciousness-loop tick, the router receives a ``RouterInput`` built
+from current kernel state (WM, SNARC, metabolic, episodic, cerebellum,
+RPE, metacog, sensory, cartridge). The schema is FIXED — PRD §3.1 is the
+binding contract; new fields require a coordinated schema-version bump.
+
+Feature extraction (turning live kernel state into a ``RouterInput``)
+lives in ``feature_extraction.py`` and is Track 2. This module only
+defines the shape + validation + serialization.
+
+Spec: shared-context/arc-agi-3/phase2/brain-arch/thalamic-router-prd.md §3.1
+"""
+
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Constants — closed vocabularies referenced by validation
+# ──────────────────────────────────────────────────────────────────────
+
+VALID_METABOLIC_STATES = {"wake", "focus", "rest", "dream", "crisis"}
+VALID_ATP_TRENDS = {"rising", "stable", "falling"}
+
+# Phase 0 stub — Andy's routing-role cartridge is not yet wired
+# (PRD §2.9, §4.9). Fields default to "no recall" so Phase 0 records
+# still carry the field and are replay-compatible once the cartridge
+# ships. Dimension matches nomic-embed-text (PRD §2.9).
+CARTRIDGE_EMBEDDING_DIM = 768
+
+
+def _zero_embedding() -> List[float]:
+    """Default factory for the cartridge_recall_embedding stub."""
+    return [0.0] * CARTRIDGE_EMBEDDING_DIM
+
+
+# ──────────────────────────────────────────────────────────────────────
+# RouterInput
+# ──────────────────────────────────────────────────────────────────────
+
+@dataclass
+class RouterInput:
+    """Structured snapshot of kernel state at one consciousness-loop tick.
+
+    Fields, order, and names track PRD §3.1 exactly. The schema is
+    deterministic-serializable: every field is JSON-safe, lists are
+    bounded by the plugin registry (``sensory_modalities``,
+    ``metacog_block_list``) or fixed-dimension (``cartridge_recall_embedding``).
+
+    Validation is intentionally permissive at construction time:
+    ``__post_init__`` enforces type + range where doing so is cheap, but
+    does NOT reject e.g. a too-high ``recall_count`` (since the real
+    bound depends on the caller's ``k``). Strict validation is the
+    caller's responsibility — the router itself treats garbage in as
+    "coerce to noop + warn" per PRD §3.3 rule 5 (enforced on the output
+    side, not here).
+    """
+
+    # ── Context identity ─────────────────────────────────────────────
+    tick: int
+    timestamp: float
+    goal_id: Optional[str]
+
+    # ── WM features (derived from wm.get_context) ────────────────────
+    wm_state_key: str                       # wm.stable_key(goal_id), 16-char hex
+    wm_slot_counts: Dict[str, int]
+    wm_goal_active: bool
+    wm_age_ticks: int
+    wm_pressure: float                      # 0-1: slot count / capacity
+
+    # ── Sensory features (current tick) ──────────────────────────────
+    sensory_modalities: List[str]
+    sensory_novelty: float                  # 0-1
+    sensory_urgency: float                  # 0-1
+
+    # ── SNARC ────────────────────────────────────────────────────────
+    snarc_surprise: float                   # 0-1
+    snarc_novelty: float                    # 0-1
+    snarc_arousal: float                    # 0-1
+    snarc_reward: float                     # -1..1
+    snarc_conflict: float                   # 0-1
+
+    # ── Metabolic ────────────────────────────────────────────────────
+    metabolic_state: str                    # enum (VALID_METABOLIC_STATES)
+    atp_level: float                        # 0-100
+    atp_trend: str                          # enum (VALID_ATP_TRENDS)
+
+    # ── Episodic recall (top-k similar episodes) ─────────────────────
+    recall_count: int
+    recall_best_similarity: float           # 0-1
+    recall_best_outcome: Optional[float]    # reward from best-match episode
+
+    # ── Habit availability ───────────────────────────────────────────
+    habit_available: bool
+    habit_confidence: float                 # 0-1
+
+    # ── RPE priors over decision types ───────────────────────────────
+    prior_invoke: float                     # 0-1
+    prior_habit: float                      # 0-1
+    prior_noop: float                       # 0-1
+
+    # ── Metacog constraints ──────────────────────────────────────────
+    metacog_block_list: List[str]
+
+    # ── Cartridge recall (Phase 0 stubs per PRD §2.9 / §4.9) ─────────
+    # Defaults describe "no recall" — this is the correct value for
+    # Phase 0 before Andy's routing-role cartridge is wired. Once the
+    # cartridge ships, the feature extractor populates these from
+    # ``router_cartridge.search(situation_text, k=3, role='routing')``.
+    cartridge_recall_count: int = 0
+    cartridge_recall_best_similarity: float = 0.0
+    cartridge_recall_embedding: List[float] = field(default_factory=_zero_embedding)
+
+    # ──────────────────────────────────────────────────────────────
+    # Validation
+    # ──────────────────────────────────────────────────────────────
+
+    def __post_init__(self) -> None:
+        # Type/shape guards that are cheap and catch the obvious bugs.
+        # Range checks on [0,1] floats are enforced because they're
+        # binding contracts (PRD §3.1 comments).
+        if not isinstance(self.tick, int) or self.tick < 0:
+            raise ValueError(f"tick must be non-negative int, got {self.tick!r}")
+        if not isinstance(self.timestamp, (int, float)):
+            raise TypeError(f"timestamp must be numeric, got {type(self.timestamp).__name__}")
+
+        if not isinstance(self.wm_state_key, str) or not self.wm_state_key:
+            raise ValueError("wm_state_key must be a non-empty string")
+        if not isinstance(self.wm_slot_counts, dict):
+            raise TypeError("wm_slot_counts must be dict[str, int]")
+        for k, v in self.wm_slot_counts.items():
+            if not isinstance(k, str) or not isinstance(v, int):
+                raise TypeError(f"wm_slot_counts entries must be str→int, got {k!r}→{v!r}")
+
+        _check_unit("wm_pressure", self.wm_pressure)
+        if not isinstance(self.wm_age_ticks, int) or self.wm_age_ticks < 0:
+            raise ValueError(f"wm_age_ticks must be non-negative int, got {self.wm_age_ticks!r}")
+
+        if not isinstance(self.sensory_modalities, list):
+            raise TypeError("sensory_modalities must be list[str]")
+        for m in self.sensory_modalities:
+            if not isinstance(m, str):
+                raise TypeError(f"sensory_modalities entries must be str, got {m!r}")
+        _check_unit("sensory_novelty", self.sensory_novelty)
+        _check_unit("sensory_urgency", self.sensory_urgency)
+
+        _check_unit("snarc_surprise", self.snarc_surprise)
+        _check_unit("snarc_novelty", self.snarc_novelty)
+        _check_unit("snarc_arousal", self.snarc_arousal)
+        _check_range("snarc_reward", self.snarc_reward, -1.0, 1.0)
+        _check_unit("snarc_conflict", self.snarc_conflict)
+
+        if self.metabolic_state not in VALID_METABOLIC_STATES:
+            raise ValueError(
+                f"metabolic_state must be in {sorted(VALID_METABOLIC_STATES)}, "
+                f"got {self.metabolic_state!r}"
+            )
+        _check_range("atp_level", self.atp_level, 0.0, 100.0)
+        if self.atp_trend not in VALID_ATP_TRENDS:
+            raise ValueError(
+                f"atp_trend must be in {sorted(VALID_ATP_TRENDS)}, "
+                f"got {self.atp_trend!r}"
+            )
+
+        if not isinstance(self.recall_count, int) or self.recall_count < 0:
+            raise ValueError(f"recall_count must be non-negative int, got {self.recall_count!r}")
+        _check_unit("recall_best_similarity", self.recall_best_similarity)
+        if self.recall_best_outcome is not None:
+            if not isinstance(self.recall_best_outcome, (int, float)):
+                raise TypeError("recall_best_outcome must be numeric or None")
+
+        if not isinstance(self.habit_available, bool):
+            raise TypeError("habit_available must be bool")
+        _check_unit("habit_confidence", self.habit_confidence)
+
+        _check_unit("prior_invoke", self.prior_invoke)
+        _check_unit("prior_habit", self.prior_habit)
+        _check_unit("prior_noop", self.prior_noop)
+
+        if not isinstance(self.metacog_block_list, list):
+            raise TypeError("metacog_block_list must be list[str]")
+        for p in self.metacog_block_list:
+            if not isinstance(p, str):
+                raise TypeError(f"metacog_block_list entries must be str, got {p!r}")
+
+        if not isinstance(self.cartridge_recall_count, int) or self.cartridge_recall_count < 0:
+            raise ValueError(
+                f"cartridge_recall_count must be non-negative int, got {self.cartridge_recall_count!r}"
+            )
+        _check_unit("cartridge_recall_best_similarity", self.cartridge_recall_best_similarity)
+        if not isinstance(self.cartridge_recall_embedding, list):
+            raise TypeError("cartridge_recall_embedding must be list[float]")
+        if len(self.cartridge_recall_embedding) != CARTRIDGE_EMBEDDING_DIM:
+            raise ValueError(
+                f"cartridge_recall_embedding must have length {CARTRIDGE_EMBEDDING_DIM}, "
+                f"got {len(self.cartridge_recall_embedding)}"
+            )
+        for v in self.cartridge_recall_embedding:
+            if not isinstance(v, (int, float)):
+                raise TypeError("cartridge_recall_embedding entries must be numeric")
+
+    # ──────────────────────────────────────────────────────────────
+    # Serialization
+    # ──────────────────────────────────────────────────────────────
+
+    def to_dict(self) -> Dict[str, Any]:
+        """JSON-serializable dict representation. Fields preserved in
+        declaration order."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RouterInput":
+        """Reconstruct from a dict produced by ``to_dict``.
+
+        Unknown keys are ignored (forward compatibility). Missing
+        optional fields fall back to defaults.
+        """
+        # Only pass keys we know about — this is the schema-version-aware
+        # read path. Older payloads missing cartridge_recall_* get defaults.
+        known = {
+            "tick", "timestamp", "goal_id",
+            "wm_state_key", "wm_slot_counts", "wm_goal_active",
+            "wm_age_ticks", "wm_pressure",
+            "sensory_modalities", "sensory_novelty", "sensory_urgency",
+            "snarc_surprise", "snarc_novelty", "snarc_arousal",
+            "snarc_reward", "snarc_conflict",
+            "metabolic_state", "atp_level", "atp_trend",
+            "recall_count", "recall_best_similarity", "recall_best_outcome",
+            "habit_available", "habit_confidence",
+            "prior_invoke", "prior_habit", "prior_noop",
+            "metacog_block_list",
+            "cartridge_recall_count",
+            "cartridge_recall_best_similarity",
+            "cartridge_recall_embedding",
+        }
+        filtered = {k: v for k, v in data.items() if k in known}
+        return cls(**filtered)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────
+
+def _check_unit(name: str, value: Any) -> None:
+    """Assert ``value`` is a number in [0, 1]."""
+    if not isinstance(value, (int, float)):
+        raise TypeError(f"{name} must be numeric, got {type(value).__name__}")
+    if not 0.0 <= float(value) <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+
+
+def _check_range(name: str, value: Any, lo: float, hi: float) -> None:
+    """Assert ``value`` is a number in [lo, hi]."""
+    if not isinstance(value, (int, float)):
+        raise TypeError(f"{name} must be numeric, got {type(value).__name__}")
+    if not lo <= float(value) <= hi:
+        raise ValueError(f"{name} must be in [{lo}, {hi}], got {value!r}")

--- a/sage/cognition/router/outputs.py
+++ b/sage/cognition/router/outputs.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""
+RouterOutput — normative schema produced by the thalamic router.
+================================================================
+
+Every consciousness-loop tick, the router emits one ``RouterOutput``.
+The decision space is closed and finite (PRD §1.2): ``invoke`` / ``habit``
+/ ``noop``. Validation rules from PRD §3.3 are enforced by
+``RouterOutput.validate()``.
+
+Spec: shared-context/arc-agi-3/phase2/brain-arch/thalamic-router-prd.md §3.2, §3.3
+"""
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, Optional, Tuple
+
+from sage.cognition.router.tiers import PluginTier
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Constants — closed vocabularies
+# ──────────────────────────────────────────────────────────────────────
+
+VALID_ACTIONS = {"invoke", "habit", "noop"}
+
+# PRD §3.2: "rationale_code is a small closed vocabulary like ...".
+# We seed the vocabulary with the examples called out in the PRD.
+# Additions are cheap (string literals) but should be coordinated so
+# Nomad's metacog can aggregate them without drift.
+VALID_RATIONALE_CODES = {
+    "high_novelty",
+    "habit_match",
+    "low_atp_rest",
+    "metacog_blocked",
+    "goal_driven",
+    "reflex",
+    "escalate_frontal",
+    "federate_peer",
+    # Fallbacks used when the programmatic baseline (Track 3) cannot
+    # classify more specifically, and by the validator on coercion:
+    "default",
+    "coerced_noop",
+}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# RouterOutput
+# ──────────────────────────────────────────────────────────────────────
+
+@dataclass
+class RouterOutput:
+    """Structured routing decision.
+
+    Fields, order, and names track PRD §3.2 exactly. See
+    ``validate()`` for the rule enforcement path and ``coerce_to_noop``
+    for the PRD §3.3 rule-5 escape hatch.
+    """
+
+    action: str                             # 'invoke' | 'habit' | 'noop'
+
+    # Per-action fields (None if not applicable)
+    plugin: Optional[str]
+    plugin_tier: Optional[str]              # PluginTier value or None
+    payload_hint: Optional[str]             # short canonical cue, NOT NL
+    habit_id: Optional[str]
+
+    # Metadata
+    confidence: float                       # 0-1
+    energy_estimate: float                  # expected ATP cost, ≥ 0
+    rationale_code: str                     # closed vocabulary
+
+    # ──────────────────────────────────────────────────────────────
+    # Lightweight type guards (not a substitute for validate())
+    # ──────────────────────────────────────────────────────────────
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.action, str):
+            raise TypeError("action must be str")
+        if not isinstance(self.confidence, (int, float)):
+            raise TypeError("confidence must be numeric")
+        if not isinstance(self.energy_estimate, (int, float)):
+            raise TypeError("energy_estimate must be numeric")
+        if not isinstance(self.rationale_code, str):
+            raise TypeError("rationale_code must be str")
+        # Optional fields — if set, must be str
+        for f_name in ("plugin", "plugin_tier", "payload_hint", "habit_id"):
+            v = getattr(self, f_name)
+            if v is not None and not isinstance(v, str):
+                raise TypeError(f"{f_name} must be str or None, got {type(v).__name__}")
+
+    # ──────────────────────────────────────────────────────────────
+    # PRD §3.3 validation
+    # ──────────────────────────────────────────────────────────────
+
+    def validate(self, *, known_plugins: Optional[set] = None,
+                 known_habits: Optional[set] = None) -> Tuple[bool, Optional[str]]:
+        """Enforce PRD §3.3 rules.
+
+        Returns ``(ok, reason)``:
+            - ``ok`` is True if the output is valid and may be dispatched.
+            - ``reason`` is a short machine-readable failure code when
+              ``ok`` is False. The caller (consciousness loop integration
+              in Track 5) uses it to emit a ``warn`` / ``coerce_noop``
+              event and substitute a noop.
+
+        ``known_plugins`` / ``known_habits`` are optional registries.
+        When provided, rule 1 / rule 2 check membership; when omitted,
+        the membership portion is skipped (useful for unit tests that
+        don't have a live registry).
+
+        PRD §3.3 rules:
+          1. If action == 'invoke': plugin must be set and in the registry.
+          2. If action == 'habit': habit_id must be set and exist in cerebellum.
+          3. If action == 'noop': all optional fields None.
+          4. confidence ∈ [0, 1], energy_estimate ≥ 0.
+          5. Invalid outputs are coerced to noop + warn event.  (Rule 5
+             is implemented by callers via ``coerce_to_noop``; validate()
+             only reports.)
+        """
+        # Rule 4 first — cheapest, catches NaN/out-of-range early.
+        if not 0.0 <= float(self.confidence) <= 1.0:
+            return False, "confidence_out_of_range"
+        if float(self.energy_estimate) < 0.0:
+            return False, "energy_estimate_negative"
+
+        if self.action not in VALID_ACTIONS:
+            return False, "unknown_action"
+
+        if self.rationale_code not in VALID_RATIONALE_CODES:
+            return False, "unknown_rationale_code"
+
+        # plugin_tier, if set, must be a valid PluginTier value.
+        if self.plugin_tier is not None and not PluginTier.is_valid(self.plugin_tier):
+            return False, "unknown_plugin_tier"
+
+        if self.action == "invoke":
+            # Rule 1
+            if not self.plugin:
+                return False, "invoke_missing_plugin"
+            if known_plugins is not None and self.plugin not in known_plugins:
+                return False, "invoke_unknown_plugin"
+            # habit_id must NOT be set
+            if self.habit_id is not None:
+                return False, "invoke_with_habit_id"
+
+        elif self.action == "habit":
+            # Rule 2
+            if not self.habit_id:
+                return False, "habit_missing_habit_id"
+            if known_habits is not None and self.habit_id not in known_habits:
+                return False, "habit_unknown_habit_id"
+            # plugin / plugin_tier / payload_hint must NOT be set
+            if self.plugin is not None or self.plugin_tier is not None or self.payload_hint is not None:
+                return False, "habit_with_plugin_fields"
+
+        elif self.action == "noop":
+            # Rule 3
+            if (self.plugin is not None or self.plugin_tier is not None
+                    or self.payload_hint is not None or self.habit_id is not None):
+                return False, "noop_with_optional_fields"
+
+        return True, None
+
+    def is_valid(self, *, known_plugins: Optional[set] = None,
+                 known_habits: Optional[set] = None) -> bool:
+        """Boolean shorthand around :meth:`validate`."""
+        ok, _ = self.validate(known_plugins=known_plugins, known_habits=known_habits)
+        return ok
+
+    def validate_or_raise(self, *, known_plugins: Optional[set] = None,
+                          known_habits: Optional[set] = None) -> None:
+        """Raise ``ValueError`` with the failure reason if validation fails.
+
+        Convenience for tests and callers that prefer exceptions over
+        return codes.
+        """
+        ok, reason = self.validate(known_plugins=known_plugins, known_habits=known_habits)
+        if not ok:
+            raise ValueError(f"RouterOutput invalid: {reason}")
+
+    # ──────────────────────────────────────────────────────────────
+    # Serialization
+    # ──────────────────────────────────────────────────────────────
+
+    def to_dict(self) -> Dict[str, Any]:
+        """JSON-serializable dict representation."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RouterOutput":
+        known = {
+            "action", "plugin", "plugin_tier", "payload_hint", "habit_id",
+            "confidence", "energy_estimate", "rationale_code",
+        }
+        filtered = {k: v for k, v in data.items() if k in known}
+        return cls(**filtered)
+
+    # ──────────────────────────────────────────────────────────────
+    # Factories
+    # ──────────────────────────────────────────────────────────────
+
+    @classmethod
+    def noop(
+        cls,
+        *,
+        confidence: float = 1.0,
+        energy_estimate: float = 0.0,
+        rationale_code: str = "default",
+    ) -> "RouterOutput":
+        """Construct a valid ``action='noop'`` output. Optional fields
+        left None."""
+        return cls(
+            action="noop",
+            plugin=None,
+            plugin_tier=None,
+            payload_hint=None,
+            habit_id=None,
+            confidence=float(confidence),
+            energy_estimate=float(energy_estimate),
+            rationale_code=rationale_code,
+        )
+
+    @classmethod
+    def coerce_to_noop(
+        cls, _bad: "RouterOutput", reason: str
+    ) -> "RouterOutput":
+        """PRD §3.3 rule 5: invalid outputs are coerced to noop.
+
+        The caller is responsible for emitting the corresponding warn
+        event — this method returns only the replacement output.
+        Rationale code is fixed to ``coerced_noop`` so metacog can
+        aggregate coercions as a first-class signal (mass coercion =
+        router drift or registry skew).
+
+        The ``reason`` string is captured in the output's rationale only
+        via the ``coerced_noop`` code; the detailed reason lives in the
+        emitted warn event (see ``events.py``).
+        """
+        del _bad, reason  # both are used by the caller to build the warn event
+        return cls.noop(
+            confidence=1.0,
+            energy_estimate=0.0,
+            rationale_code="coerced_noop",
+        )

--- a/sage/cognition/router/record.py
+++ b/sage/cognition/router/record.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+RouterRecord — the training-data unit written by the Phase 0 pipeline.
+======================================================================
+
+Every consciousness-loop decision is persisted as a ``RouterRecord``:
+``(RouterInput → RouterOutput + outcome)``. Outcome is backfilled later
+by Track 6 (SNARC trajectory + RPE signal over subsequent ticks), so the
+field is optional at write time.
+
+Schema versioning: every record carries ``schema_version``. The reader
+(Track 4) is schema-version-aware; additions to ``RouterInput`` /
+``RouterOutput`` require a bump and a migration strategy.
+
+Spec: shared-context/arc-agi-3/phase2/brain-arch/router-sprint-1-phase-0.md
+      (Track 1 deliverables)
+"""
+
+import time
+import uuid
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, Optional
+
+from sage.cognition.router.inputs import RouterInput
+from sage.cognition.router.outputs import RouterOutput
+
+
+# Bumped when the record schema (or any of its nested schemas) changes
+# in a non-backward-compatible way. Readers must reject unknown versions
+# loudly rather than silently coerce.
+ROUTER_SCHEMA_VERSION = "v0.1.0"
+
+
+def _default_record_id() -> str:
+    """uuid4 hex — canonical record identity."""
+    return uuid.uuid4().hex
+
+
+@dataclass
+class RouterRecord:
+    """One captured routing decision, suitable for training.
+
+    Construction defaults fill ``record_id``, ``schema_version``,
+    ``timestamp``, and ``machine`` (detected from env) so callers can
+    usually construct with just ``router_input`` + ``router_output``.
+    """
+
+    router_input: RouterInput
+    router_output: RouterOutput
+
+    # Identity + provenance
+    record_id: str = field(default_factory=_default_record_id)
+    schema_version: str = ROUTER_SCHEMA_VERSION
+    timestamp: float = field(default_factory=time.time)
+    machine: str = ""
+
+    # Backfilled by Track 6 — None at write time, populated later.
+    # Shape is intentionally open (Dict[str, Any]) so we can iterate on
+    # the outcome schema without another record-schema bump; a nested
+    # ``outcome_schema_version`` inside the dict will pin it when we
+    # freeze the shape.
+    outcome: Optional[Dict[str, Any]] = None
+
+    # ──────────────────────────────────────────────────────────────
+    # Validation
+    # ──────────────────────────────────────────────────────────────
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.record_id, str) or not self.record_id:
+            raise ValueError("record_id must be a non-empty string")
+        if not isinstance(self.schema_version, str) or not self.schema_version:
+            raise ValueError("schema_version must be a non-empty string")
+        if not isinstance(self.timestamp, (int, float)):
+            raise TypeError("timestamp must be numeric")
+        if not isinstance(self.machine, str):
+            raise TypeError("machine must be str")
+        if not isinstance(self.router_input, RouterInput):
+            raise TypeError("router_input must be a RouterInput instance")
+        if not isinstance(self.router_output, RouterOutput):
+            raise TypeError("router_output must be a RouterOutput instance")
+        if self.outcome is not None and not isinstance(self.outcome, dict):
+            raise TypeError("outcome must be dict or None")
+
+    # ──────────────────────────────────────────────────────────────
+    # Serialization
+    # ──────────────────────────────────────────────────────────────
+
+    def to_dict(self) -> Dict[str, Any]:
+        """JSON-serializable dict representation.
+
+        Nested dataclasses are expanded via their own ``to_dict`` rather
+        than relying on ``dataclasses.asdict`` — this preserves the
+        explicit forward-compatible read path in each nested class.
+        """
+        return {
+            "record_id": self.record_id,
+            "schema_version": self.schema_version,
+            "timestamp": self.timestamp,
+            "machine": self.machine,
+            "router_input": self.router_input.to_dict(),
+            "router_output": self.router_output.to_dict(),
+            "outcome": self.outcome,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RouterRecord":
+        """Reconstruct from a dict produced by ``to_dict``.
+
+        Schema versioning: we DO NOT reject unknown versions here; the
+        caller (Track 4 dataset reader) owns that policy because it may
+        want to route old records through a migration function.
+        """
+        return cls(
+            record_id=data["record_id"],
+            schema_version=data.get("schema_version", ROUTER_SCHEMA_VERSION),
+            timestamp=float(data["timestamp"]),
+            machine=data.get("machine", ""),
+            router_input=RouterInput.from_dict(data["router_input"]),
+            router_output=RouterOutput.from_dict(data["router_output"]),
+            outcome=data.get("outcome"),
+        )
+
+    # ──────────────────────────────────────────────────────────────
+    # Outcome backfill helper (Track 6 seam)
+    # ──────────────────────────────────────────────────────────────
+
+    def with_outcome(self, outcome: Dict[str, Any]) -> "RouterRecord":
+        """Return a copy of self with ``outcome`` set.
+
+        Non-mutating so Track 6 can re-emit a ``record_backfill`` event
+        without worrying about in-place aliasing with already-flushed
+        JSONL buffers.
+        """
+        if not isinstance(outcome, dict):
+            raise TypeError("outcome must be dict")
+        return RouterRecord(
+            record_id=self.record_id,
+            schema_version=self.schema_version,
+            timestamp=self.timestamp,
+            machine=self.machine,
+            router_input=self.router_input,
+            router_output=self.router_output,
+            outcome=dict(outcome),
+        )

--- a/sage/cognition/router/tests/test_schemas.py
+++ b/sage/cognition/router/tests/test_schemas.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""
+Unit tests for router Phase 0 Track 1 schemas.
+
+Covers:
+  - Construction with valid args (each dataclass)
+  - PRD §3.3 validation rules (per rule)
+  - JSON round-trip for every dataclass
+  - Schema versioning (required + non-empty)
+  - PluginTier enum coverage
+  - Validator edge cases called out in the sprint doc
+
+Run: ``python3 -m pytest sage/cognition/router/tests/test_schemas.py -v``
+"""
+
+import json
+import time
+
+import pytest
+
+from sage.cognition.router import (
+    CARTRIDGE_EMBEDDING_DIM,
+    Event,
+    PluginTier,
+    ROUTER_SCHEMA_VERSION,
+    RouterInput,
+    RouterOutput,
+    RouterRecord,
+    VALID_ACTIONS,
+    VALID_EVENT_KINDS,
+    VALID_RATIONALE_CODES,
+)
+from sage.cognition.router.events import ROUTER_KINDS, WM_COMPATIBLE_KINDS
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+def _sample_router_input(**overrides) -> RouterInput:
+    defaults = dict(
+        tick=42,
+        timestamp=1700000000.0,
+        goal_id="goal-xyz",
+        wm_state_key="0123456789abcdef",
+        wm_slot_counts={"goal": 1, "plan_step": 2},
+        wm_goal_active=True,
+        wm_age_ticks=3,
+        wm_pressure=0.5,
+        sensory_modalities=["vision", "time"],
+        sensory_novelty=0.1,
+        sensory_urgency=0.2,
+        snarc_surprise=0.3,
+        snarc_novelty=0.4,
+        snarc_arousal=0.5,
+        snarc_reward=-0.2,
+        snarc_conflict=0.1,
+        metabolic_state="focus",
+        atp_level=65.0,
+        atp_trend="stable",
+        recall_count=2,
+        recall_best_similarity=0.7,
+        recall_best_outcome=0.3,
+        habit_available=True,
+        habit_confidence=0.8,
+        prior_invoke=0.4,
+        prior_habit=0.4,
+        prior_noop=0.2,
+        metacog_block_list=["vision_plugin"],
+    )
+    defaults.update(overrides)
+    return RouterInput(**defaults)
+
+
+def _sample_invoke() -> RouterOutput:
+    return RouterOutput(
+        action="invoke",
+        plugin="vision_plugin",
+        plugin_tier=PluginTier.ROUTINE.value,
+        payload_hint="frame_diff",
+        habit_id=None,
+        confidence=0.9,
+        energy_estimate=8.0,
+        rationale_code="high_novelty",
+    )
+
+
+def _sample_habit() -> RouterOutput:
+    return RouterOutput(
+        action="habit",
+        plugin=None,
+        plugin_tier=None,
+        payload_hint=None,
+        habit_id="habit-abc",
+        confidence=0.85,
+        energy_estimate=0.5,
+        rationale_code="habit_match",
+    )
+
+
+def _sample_noop() -> RouterOutput:
+    return RouterOutput.noop(rationale_code="low_atp_rest")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# PluginTier enum
+# ──────────────────────────────────────────────────────────────────────
+
+def test_plugin_tier_values_cover_prd_spec():
+    """PRD §1.2 lists five tiers."""
+    assert set(PluginTier.values()) == {
+        "reflex", "routine", "specialized", "frontal_lobe", "federate"
+    }
+
+
+def test_plugin_tier_is_valid_accepts_known_rejects_unknown():
+    assert PluginTier.is_valid("reflex") is True
+    assert PluginTier.is_valid("frontal_lobe") is True
+    assert PluginTier.is_valid("hyperintelligence") is False
+    assert PluginTier.is_valid("") is False
+
+
+def test_plugin_tier_str_equality_and_json():
+    """str-Enum means the value is its own string."""
+    assert PluginTier.FRONTAL_LOBE == "frontal_lobe"
+    assert json.dumps(PluginTier.FRONTAL_LOBE.value) == '"frontal_lobe"'
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Event
+# ──────────────────────────────────────────────────────────────────────
+
+def test_event_accepts_wm_compatible_kinds():
+    for kind in WM_COMPATIBLE_KINDS:
+        ev = Event(kind=kind, slot_id=None, slot_type=None, timestamp=time.time())
+        assert ev.kind == kind
+
+
+def test_event_accepts_router_specific_kinds():
+    for kind in ROUTER_KINDS:
+        ev = Event(kind=kind, slot_id="rid", slot_type="route", timestamp=time.time())
+        assert ev.kind == kind
+        assert ev.kind in VALID_EVENT_KINDS
+
+
+def test_event_rejects_unknown_kind():
+    with pytest.raises(ValueError):
+        Event(kind="gossip", slot_id=None, slot_type=None, timestamp=time.time())
+
+
+def test_event_roundtrip():
+    ev = Event(
+        kind="route",
+        slot_id="rec-1",
+        slot_type="invoke",
+        timestamp=1700000000.5,
+        reason="routine tier",
+    )
+    d = ev.to_dict()
+    s = json.dumps(d)
+    back = Event.from_dict(json.loads(s))
+    assert back == ev
+
+
+# ──────────────────────────────────────────────────────────────────────
+# RouterInput — construction + validation
+# ──────────────────────────────────────────────────────────────────────
+
+def test_router_input_construction_defaults_cartridge_stubs():
+    """Phase 0 stub: cartridge_recall_* default to 'no recall'."""
+    ri = _sample_router_input()
+    assert ri.cartridge_recall_count == 0
+    assert ri.cartridge_recall_best_similarity == 0.0
+    assert len(ri.cartridge_recall_embedding) == CARTRIDGE_EMBEDDING_DIM
+    assert all(v == 0.0 for v in ri.cartridge_recall_embedding)
+
+
+def test_router_input_rejects_out_of_range_unit():
+    with pytest.raises(ValueError):
+        _sample_router_input(snarc_surprise=1.5)
+    with pytest.raises(ValueError):
+        _sample_router_input(wm_pressure=-0.1)
+
+
+def test_router_input_accepts_reward_in_signed_range():
+    # -1..1 is the PRD range for snarc_reward
+    _sample_router_input(snarc_reward=-1.0)
+    _sample_router_input(snarc_reward=1.0)
+    with pytest.raises(ValueError):
+        _sample_router_input(snarc_reward=-1.01)
+    with pytest.raises(ValueError):
+        _sample_router_input(snarc_reward=1.01)
+
+
+def test_router_input_rejects_unknown_metabolic_state():
+    with pytest.raises(ValueError):
+        _sample_router_input(metabolic_state="euphoric")
+
+
+def test_router_input_rejects_unknown_atp_trend():
+    with pytest.raises(ValueError):
+        _sample_router_input(atp_trend="oscillating")
+
+
+def test_router_input_rejects_wrong_cartridge_embedding_dim():
+    with pytest.raises(ValueError):
+        _sample_router_input(cartridge_recall_embedding=[0.0] * 512)
+
+
+def test_router_input_rejects_empty_wm_state_key():
+    with pytest.raises(ValueError):
+        _sample_router_input(wm_state_key="")
+
+
+def test_router_input_rejects_negative_tick():
+    with pytest.raises(ValueError):
+        _sample_router_input(tick=-1)
+
+
+def test_router_input_roundtrip_json():
+    ri = _sample_router_input()
+    s = json.dumps(ri.to_dict())
+    back = RouterInput.from_dict(json.loads(s))
+    assert back == ri
+
+
+def test_router_input_from_dict_ignores_unknown_keys():
+    """Forward compatibility: new fields in the payload don't break old readers."""
+    ri = _sample_router_input()
+    d = ri.to_dict()
+    d["new_field_from_future_schema"] = 42
+    back = RouterInput.from_dict(d)
+    assert back == ri
+
+
+def test_router_input_from_dict_fills_missing_cartridge_defaults():
+    """Old records written before cartridge fields existed still load."""
+    ri = _sample_router_input()
+    d = ri.to_dict()
+    d.pop("cartridge_recall_count")
+    d.pop("cartridge_recall_best_similarity")
+    d.pop("cartridge_recall_embedding")
+    back = RouterInput.from_dict(d)
+    assert back.cartridge_recall_count == 0
+    assert back.cartridge_recall_best_similarity == 0.0
+    assert len(back.cartridge_recall_embedding) == CARTRIDGE_EMBEDDING_DIM
+
+
+# ──────────────────────────────────────────────────────────────────────
+# RouterOutput — construction + validation (PRD §3.3)
+# ──────────────────────────────────────────────────────────────────────
+
+def test_router_output_invoke_valid():
+    out = _sample_invoke()
+    assert out.is_valid()
+
+
+def test_router_output_habit_valid():
+    out = _sample_habit()
+    assert out.is_valid()
+
+
+def test_router_output_noop_valid():
+    out = _sample_noop()
+    assert out.is_valid()
+
+
+def test_router_output_rule_1_invoke_requires_plugin():
+    """PRD §3.3 rule 1: invoke without plugin is invalid."""
+    out = RouterOutput(
+        action="invoke", plugin=None, plugin_tier=None, payload_hint=None,
+        habit_id=None, confidence=0.5, energy_estimate=1.0,
+        rationale_code="default",
+    )
+    ok, reason = out.validate()
+    assert not ok
+    assert reason == "invoke_missing_plugin"
+    with pytest.raises(ValueError):
+        out.validate_or_raise()
+
+
+def test_router_output_rule_1_invoke_unknown_plugin():
+    """PRD §3.3 rule 1: plugin must be in the registry when provided."""
+    out = _sample_invoke()
+    ok, reason = out.validate(known_plugins={"other_plugin"})
+    assert not ok
+    assert reason == "invoke_unknown_plugin"
+
+
+def test_router_output_rule_2_habit_requires_habit_id():
+    """PRD §3.3 rule 2: habit without habit_id is invalid."""
+    out = RouterOutput(
+        action="habit", plugin=None, plugin_tier=None, payload_hint=None,
+        habit_id=None, confidence=0.9, energy_estimate=0.5,
+        rationale_code="habit_match",
+    )
+    ok, reason = out.validate()
+    assert not ok
+    assert reason == "habit_missing_habit_id"
+
+
+def test_router_output_rule_2_habit_unknown_id():
+    out = _sample_habit()
+    ok, reason = out.validate(known_habits={"other_habit"})
+    assert not ok
+    assert reason == "habit_unknown_habit_id"
+
+
+def test_router_output_rule_3_noop_rejects_optional_fields():
+    """PRD §3.3 rule 3: noop with optional fields set is invalid."""
+    out = RouterOutput(
+        action="noop", plugin="vision_plugin", plugin_tier="routine",
+        payload_hint=None, habit_id=None, confidence=1.0,
+        energy_estimate=0.0, rationale_code="default",
+    )
+    ok, reason = out.validate()
+    assert not ok
+    assert reason == "noop_with_optional_fields"
+
+
+def test_router_output_rule_4_confidence_range():
+    """PRD §3.3 rule 4: confidence ∈ [0, 1]."""
+    out = RouterOutput(
+        action="noop", plugin=None, plugin_tier=None, payload_hint=None,
+        habit_id=None, confidence=1.5, energy_estimate=0.0,
+        rationale_code="default",
+    )
+    ok, reason = out.validate()
+    assert not ok
+    assert reason == "confidence_out_of_range"
+
+
+def test_router_output_rule_4_energy_nonneg():
+    """PRD §3.3 rule 4: energy_estimate ≥ 0."""
+    out = RouterOutput(
+        action="noop", plugin=None, plugin_tier=None, payload_hint=None,
+        habit_id=None, confidence=0.5, energy_estimate=-0.1,
+        rationale_code="default",
+    )
+    ok, reason = out.validate()
+    assert not ok
+    assert reason == "energy_estimate_negative"
+
+
+def test_router_output_rejects_unknown_action():
+    out = RouterOutput(
+        action="meditate", plugin=None, plugin_tier=None, payload_hint=None,
+        habit_id=None, confidence=0.5, energy_estimate=0.0,
+        rationale_code="default",
+    )
+    ok, reason = out.validate()
+    assert not ok
+    assert reason == "unknown_action"
+
+
+def test_router_output_rejects_unknown_tier_value():
+    out = RouterOutput(
+        action="invoke", plugin="plug", plugin_tier="mesozoic",
+        payload_hint=None, habit_id=None, confidence=0.5,
+        energy_estimate=1.0, rationale_code="default",
+    )
+    ok, reason = out.validate()
+    assert not ok
+    assert reason == "unknown_plugin_tier"
+
+
+def test_router_output_rejects_unknown_rationale():
+    out = RouterOutput(
+        action="noop", plugin=None, plugin_tier=None, payload_hint=None,
+        habit_id=None, confidence=1.0, energy_estimate=0.0,
+        rationale_code="vibes",
+    )
+    ok, reason = out.validate()
+    assert not ok
+    assert reason == "unknown_rationale_code"
+
+
+def test_router_output_invoke_with_habit_id_is_invalid():
+    """Cross-field: invoke must not carry habit_id."""
+    out = RouterOutput(
+        action="invoke", plugin="vision_plugin", plugin_tier="routine",
+        payload_hint=None, habit_id="h1", confidence=0.5,
+        energy_estimate=1.0, rationale_code="default",
+    )
+    ok, reason = out.validate()
+    assert not ok
+    assert reason == "invoke_with_habit_id"
+
+
+def test_router_output_habit_with_plugin_fields_is_invalid():
+    """Cross-field: habit must not carry plugin-side fields."""
+    out = RouterOutput(
+        action="habit", plugin="vision_plugin", plugin_tier=None,
+        payload_hint=None, habit_id="h1", confidence=0.5,
+        energy_estimate=1.0, rationale_code="habit_match",
+    )
+    ok, reason = out.validate()
+    assert not ok
+    assert reason == "habit_with_plugin_fields"
+
+
+def test_router_output_coerce_to_noop_produces_valid_noop():
+    bad = RouterOutput(
+        action="invoke", plugin=None, plugin_tier=None, payload_hint=None,
+        habit_id=None, confidence=0.5, energy_estimate=1.0,
+        rationale_code="default",
+    )
+    coerced = RouterOutput.coerce_to_noop(bad, reason="invoke_missing_plugin")
+    assert coerced.action == "noop"
+    assert coerced.is_valid()
+    assert coerced.rationale_code == "coerced_noop"
+
+
+def test_router_output_roundtrip_each_action():
+    for out in (_sample_invoke(), _sample_habit(), _sample_noop()):
+        s = json.dumps(out.to_dict())
+        back = RouterOutput.from_dict(json.loads(s))
+        assert back == out
+
+
+# ──────────────────────────────────────────────────────────────────────
+# RouterRecord — schema versioning + round-trip
+# ──────────────────────────────────────────────────────────────────────
+
+def test_router_record_schema_version_is_set_by_default():
+    rec = RouterRecord(
+        router_input=_sample_router_input(),
+        router_output=_sample_noop(),
+        machine="cbp",
+    )
+    assert rec.schema_version == ROUTER_SCHEMA_VERSION
+    assert rec.schema_version  # non-empty
+
+
+def test_router_record_schema_version_must_be_non_empty():
+    with pytest.raises(ValueError):
+        RouterRecord(
+            router_input=_sample_router_input(),
+            router_output=_sample_noop(),
+            schema_version="",
+        )
+
+
+def test_router_record_record_id_must_be_non_empty():
+    with pytest.raises(ValueError):
+        RouterRecord(
+            router_input=_sample_router_input(),
+            router_output=_sample_noop(),
+            record_id="",
+        )
+
+
+def test_router_record_outcome_defaults_to_none():
+    rec = RouterRecord(
+        router_input=_sample_router_input(),
+        router_output=_sample_noop(),
+    )
+    assert rec.outcome is None
+
+
+def test_router_record_roundtrip_json():
+    rec = RouterRecord(
+        router_input=_sample_router_input(),
+        router_output=_sample_invoke(),
+        machine="sprout",
+    )
+    s = json.dumps(rec.to_dict())
+    back = RouterRecord.from_dict(json.loads(s))
+    assert back.record_id == rec.record_id
+    assert back.schema_version == rec.schema_version
+    assert back.timestamp == rec.timestamp
+    assert back.machine == rec.machine
+    assert back.router_input == rec.router_input
+    assert back.router_output == rec.router_output
+    assert back.outcome == rec.outcome
+
+
+def test_router_record_with_outcome_is_non_mutating():
+    rec = RouterRecord(
+        router_input=_sample_router_input(),
+        router_output=_sample_invoke(),
+        machine="legion",
+    )
+    outcome = {"snarc_resolution": 0.4, "rpe_signal": 0.12}
+    rec2 = rec.with_outcome(outcome)
+    assert rec.outcome is None              # original untouched
+    assert rec2.outcome == outcome
+    assert rec2.record_id == rec.record_id  # identity preserved
+    assert rec2 is not rec
+
+
+def test_router_record_with_outcome_rejects_non_dict():
+    rec = RouterRecord(
+        router_input=_sample_router_input(),
+        router_output=_sample_noop(),
+    )
+    with pytest.raises(TypeError):
+        rec.with_outcome("not a dict")  # type: ignore[arg-type]
+
+
+def test_router_record_rejects_wrong_nested_types():
+    with pytest.raises(TypeError):
+        RouterRecord(
+            router_input={"not": "a RouterInput"},  # type: ignore[arg-type]
+            router_output=_sample_noop(),
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Module-level import contract
+# ──────────────────────────────────────────────────────────────────────
+
+def test_public_exports_cover_acceptance_criterion():
+    """Sprint doc acceptance: ``from sage.cognition.router import
+    RouterInput, RouterOutput, Event, RouterRecord, PluginTier`` works.
+    """
+    from sage.cognition import router
+    for name in ("RouterInput", "RouterOutput", "Event", "RouterRecord",
+                 "PluginTier", "ROUTER_SCHEMA_VERSION"):
+        assert hasattr(router, name), f"missing public export: {name}"
+
+
+def test_valid_actions_matches_prd():
+    assert VALID_ACTIONS == {"invoke", "habit", "noop"}
+
+
+def test_valid_rationale_codes_cover_prd_examples():
+    """PRD §3.2 calls out these rationale codes by name."""
+    for code in ("high_novelty", "habit_match", "low_atp_rest",
+                 "metacog_blocked", "goal_driven", "reflex",
+                 "escalate_frontal", "federate_peer"):
+        assert code in VALID_RATIONALE_CODES

--- a/sage/cognition/router/tiers.py
+++ b/sage/cognition/router/tiers.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Plugin tier enum for the thalamic router.
+=========================================
+
+Per PRD §1.2, every plugin invocation is classified by an ATP cost tier.
+The router emits the tier alongside the plugin name so downstream gating
+(e.g. step 6 Budget) can refuse high-tier invocations when ATP is low.
+
+Spec: shared-context/arc-agi-3/phase2/brain-arch/thalamic-router-prd.md §1.2
+"""
+
+from enum import Enum
+from typing import List
+
+
+class PluginTier(str, Enum):
+    """ATP cost tier for a plugin invocation.
+
+    Values match the string constants used in `RouterOutput.plugin_tier`
+    (PRD §3.2) exactly: 'reflex' | 'routine' | 'specialized' |
+    'frontal_lobe' | 'federate'.
+
+    Inheriting from ``str`` makes the enum JSON-serializable by default
+    (``json.dumps(PluginTier.REFLEX)`` → ``"reflex"``) and equal to its
+    string value so existing dict-comparison code keeps working.
+
+    Tier reference (from PRD §1.2):
+
+    +--------------+-------------------------+--------------+-------------+
+    | Tier         | Examples                | Typical ATP  | Latency     |
+    +==============+=========================+==============+=============+
+    | REFLEX       | habit cache, SNARC      | 0.1 - 1      | < 5 ms      |
+    | ROUTINE      | perception filters      | 1 - 10       | 5 - 100 ms  |
+    | SPECIALIZED  | game solvers, vision    | 10 - 50      | 50 - 500 ms |
+    | FRONTAL_LOBE | LLM reasoning           | 50 - 500     | 0.5 - 10 s  |
+    | FEDERATE     | peer SAGE invocation    | 100 - 1000   | 1 - 30 s    |
+    +--------------+-------------------------+--------------+-------------+
+    """
+
+    REFLEX = "reflex"
+    ROUTINE = "routine"
+    SPECIALIZED = "specialized"
+    FRONTAL_LOBE = "frontal_lobe"
+    FEDERATE = "federate"
+
+    @classmethod
+    def values(cls) -> List[str]:
+        """Return all tier string values in declaration order."""
+        return [t.value for t in cls]
+
+    @classmethod
+    def is_valid(cls, value: str) -> bool:
+        """Check whether ``value`` matches any tier."""
+        return value in cls._value2member_map_


### PR DESCRIPTION
## Track
Phase 0, Track 1 — Schemas + types
(per `shared-context/arc-agi-3/phase2/brain-arch/router-sprint-1-phase-0.md`)

## What this ships

New package `sage/cognition/router/`:

| File | Role | PRD section |
|---|---|---|
| `tiers.py` | `PluginTier` str-enum (`reflex`, `routine`, `specialized`, `frontal_lobe`, `federate`) | §1.2 |
| `events.py` | `Event` dataclass matching `working_memory.Event` shape; kinds = WM-compat (`write`/`update`/`evict`/`clear`/`tick`/`consolidate`/`warn`) + router-specific (`route`/`dispatch`/`veto`/`coerce_noop`/`record_write`/`record_backfill`) | §2.7 |
| `inputs.py` | `RouterInput` dataclass, all fields from §3.1 incl. Phase 0 cartridge_recall_* stubs | §3.1 |
| `outputs.py` | `RouterOutput` dataclass; `validate()`, `validate_or_raise()`, `coerce_to_noop()`, `noop()` factory | §3.2, §3.3 |
| `record.py` | `RouterRecord`: `record_id` (uuid), `schema_version` (`v0.1.0`), `timestamp`, `machine`, `router_input`, `router_output`, `outcome` (Optional — Track 6 seam) | sprint §Track 1 |
| `__init__.py` | Public exports (satisfies acceptance criterion for clean imports) | — |
| `tests/test_schemas.py` | 46 pytest unit tests | — |

## What this does NOT ship (deferred to other tracks)

- Feature extraction (`feature_extraction.py`) — Track 2
- Programmatic baseline (`baseline.py`) — Track 3
- Dataset writer/reader + SNARC-stratified sampling (`data/`) — Track 4
- Consciousness-loop shadow hook (`shadow.py`, `sage_consciousness.py` patch) — Track 5
- Outcome backfill (`outcome.py`) — Track 6 (this PR ships the `outcome: Optional[Dict]` field + `with_outcome()` seam only)

## Tests added

46 unit tests in `sage/cognition/router/tests/test_schemas.py`:

- **PluginTier (3)**: values match PRD §1.2; `is_valid` rejects unknown; str equality + JSON.
- **Event (4)**: accepts WM-compat kinds; accepts router-specific kinds; rejects unknown; JSON round-trip.
- **RouterInput (11)**: construction + cartridge stubs; unit-range rejection; signed-range for reward; unknown metabolic state; unknown atp_trend; wrong cartridge embedding dim; empty state_key; negative tick; JSON round-trip; forward-compat (unknown keys ignored); backward-compat (missing cartridge fields → defaults).
- **RouterOutput (17)**: valid invoke/habit/noop; PRD §3.3 rules 1-4 each; cross-field combos (invoke with habit_id, habit with plugin fields, noop with optional set); unknown action/tier/rationale; unknown plugin/habit against registry; `coerce_to_noop` produces valid noop; per-action JSON round-trip.
- **RouterRecord (8)**: schema_version default set + non-empty; record_id non-empty; outcome defaults None; JSON round-trip; `with_outcome` non-mutating; `with_outcome` type-checks; nested-type rejection.
- **Module contract (3)**: public exports present; VALID_ACTIONS matches PRD; rationale vocabulary covers PRD §3.2 examples.

## Test results

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
collected 46 items
...
========================= 46 passed, 1 warning in 1.43s ========================
```

Sanity: `python3 sage/cognition/working_memory.py` → `10/10 passed` (unaffected).

## Acceptance criteria from sprint doc

- [x] Tests pass (46/46)
- [x] Modules import cleanly: `from sage.cognition.router import RouterInput, RouterOutput, Event, RouterRecord, PluginTier`
- [x] PRD §3 schema matches code 1:1 (field-by-field verified against §3.1 and §3.2)
- [x] No torch dependency anywhere in the package
- [x] All payloads JSON-serializable (enforced via `to_dict`/`from_dict` round-trip tests)
- [x] `schema_version` field on every record, required + non-empty

## Reviewer notes

**Dataclasses and their PRD mapping:**
- `PluginTier` — PRD §1.2 (five tiers)
- `Event` — follows `working_memory.Event` convention; extended `kind` vocabulary per PRD §2.7
- `RouterInput` — PRD §3.1 (all 29 fields, exact names, declaration order preserved)
- `RouterOutput` — PRD §3.2 (all 8 fields); validation per §3.3 rules 1-5
- `RouterRecord` — sprint doc Track 1 spec

**Chosen defaults (called out explicitly):**
- `cartridge_recall_count = 0`, `cartridge_recall_best_similarity = 0.0`, `cartridge_recall_embedding = [0.0]*768` — the "no recall" identity, correct for Phase 0 per PRD §2.9/§4.9 (Andy's routing-role cartridge not yet wired). Once the cartridge ships, feature extraction populates these from `router_cartridge.search(..., role='routing')`.
- `CARTRIDGE_EMBEDDING_DIM = 768` — matches PRD §2.9 ("nomic-embed-text 768-dim").
- `ROUTER_SCHEMA_VERSION = "v0.1.0"` — initial version stamp.
- `VALID_RATIONALE_CODES` seeded with all codes named in PRD §3.2, plus `"default"` (fallback when baseline can't classify specifically) and `"coerced_noop"` (rule-5 stamp). Additions are cheap but should be coordinated so Nomad's metacog aggregation stays consistent.

**Design choices:**
- `Event` inherits `WM_COMPATIBLE_KINDS` so a single `on_event` callback can subscribe to both WM and router streams.
- `RouterOutput.validate()` returns `(ok, reason)`; `validate_or_raise()` is a convenience for tests/callers that prefer exceptions. Rule 5 (coerce to noop) is implemented by `coerce_to_noop()` — the caller owns the warn-event emission since the reason belongs in the event, not the rationale code.
- `RouterInput.from_dict()` ignores unknown keys (forward compat) and fills missing cartridge fields with defaults (backward compat). `RouterRecord.from_dict()` does NOT reject unknown `schema_version`; Track 4 dataset reader owns that policy because it may want to route old records through a migration function.
- `RouterRecord.with_outcome()` is non-mutating to avoid in-place aliasing with already-flushed JSONL buffers in Track 4/6.

**Deviations from PRD:** none.

**Open questions for human reviewer:**
1. Should `VALID_RATIONALE_CODES` be a registry (extensible at runtime) rather than a frozen set? Current frozen approach forces coordination; a registry would let Tracks 5/6 add codes without touching this file. Recommendation: keep frozen for now; revisit if additions become frequent.
2. `metabolic_state` and `atp_trend` are strict enums (reject unknown). Kernel might add a state (e.g. `hibernate`) before this module is updated. Alternative: accept unknown + warn. Current choice errs toward strictness so drift gets caught early — revisit if it causes friction.
3. `outcome: Optional[Dict[str, Any]]` is intentionally open. A nested `outcome_schema_version` inside the dict will pin the shape once Track 6 freezes it. OK?

## Dependencies

- None. This is Wave 1. Track 4 (data writer/reader) lands in parallel.
- Tracks 2, 3, 5, 6 depend on this PR being merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)