### PR TITLE
[router] Phase 0 Track 2: feature extraction

### DIFF
--- a/sage/cognition/router/feature_extraction.py
+++ b/sage/cognition/router/feature_extraction.py
@@ -1,0 +1,781 @@
+#!/usr/bin/env python3
+"""
+Router feature extraction — Phase 0 Track 2.
+=============================================
+
+Turns live kernel state into a normative ``RouterInput`` (PRD §3.1).
+
+Each component of the kernel (WM, SNARC, metabolic, episodic, cerebellum,
+RPE, metacog, sensory, plugin registry, cartridge) has its own
+sub-extractor — a pure function that takes the component (or ``None``)
+and returns a dict of the fields it owns. The top-level
+``extract_router_input`` assembles the final ``RouterInput`` from those
+dicts.
+
+Design rules (binding, from sprint doc + PRD):
+
+  1. **No torch**.  Router data pipeline must run on edge Sprout with
+     no torch overhead (sprint doc "Constraints").
+  2. **JSON-serializable**.  Every emitted value is deterministic-
+     serializable — ``RouterInput.__post_init__`` enforces this.
+  3. **Mock-friendly**.  Every sub-extractor accepts ``None`` and
+     returns sensible defaults.  Components that may be legitimately
+     absent in Phase 0 (RPE before Phase 4, episodic pre-integration,
+     cartridge pending Andy's routing-role wiring) must not raise.
+  4. **Feature vector length is fixed** regardless of which optional
+     components are ``None``.  This is a binding contract for the
+     router model: if the feature layout changes across calls, no
+     training corpus survives.
+  5. **Failure isolation**.  If a sub-extractor raises, log a warning
+     and return defaults — never propagate exceptions up into the
+     consciousness loop.  This mirrors the Track 5 integration-layer
+     philosophy (sprint doc: "pipeline failures must NEVER break the
+     consciousness loop").
+  6. **Pure functions**.  Sub-extractors MUST NOT mutate the
+     components they read.  Safe to call repeatedly.
+
+Spec:
+  shared-context/arc-agi-3/phase2/brain-arch/thalamic-router-prd.md §2, §3.1
+  shared-context/arc-agi-3/phase2/brain-arch/router-sprint-1-phase-0.md (Track 2)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, Iterable, List, Optional
+
+from sage.cognition.router.inputs import (
+    CARTRIDGE_EMBEDDING_DIM,
+    RouterInput,
+    VALID_ATP_TRENDS,
+    VALID_METABOLIC_STATES,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Module-level defaults (single source of truth)
+# ──────────────────────────────────────────────────────────────────────
+
+# Canonical "no WM" state_key.  16 hex chars matches ``wm.stable_key``
+# shape so downstream hashing invariants don't accidentally depend on
+# shorter strings.  We deliberately choose a constant rather than
+# "whatever an empty WM returns" so records from "missing WM" are
+# distinguishable from real ones.
+_EMPTY_WM_STATE_KEY = "0" * 16
+
+# WM capacity fallback.  Real WM objects always expose ``.capacity``
+# (Miller 4±3 upper; default 7), but a duck-typed stub may not.  If
+# ``capacity`` is missing or <=0, we treat pressure as 0.
+_DEFAULT_WM_CAPACITY = 7
+
+# Metabolic fallbacks when the controller is absent.
+_DEFAULT_METABOLIC_STATE = "wake"
+_DEFAULT_ATP_LEVEL = 0.0
+_DEFAULT_ATP_TREND = "stable"
+
+# SNARC/sensory defaults
+_DEFAULT_UNIT = 0.0
+
+# RPE default prior: uniform over the 3 decision classes.  Matches the
+# PriorTable default (0.5 center) reasonably — but more importantly,
+# sums to 1.0 so downstream consumers that interpret priors as a
+# distribution still see a valid distribution.
+_UNIFORM_PRIOR = 1.0 / 3.0
+
+# Cap the sensory_modalities list length defensively — plugin registry
+# should keep this small, but a bad caller could flood it.  RouterInput
+# docstring says "bounded by plugin registry size".
+_MAX_SENSORY_MODALITIES = 32
+_MAX_METACOG_BLOCK_LIST = 64
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Sub-extractors
+#
+# Each sub-extractor:
+#   - Takes the component (may be None) + any ancillary kwargs it needs
+#   - Returns a dict whose keys map 1:1 to RouterInput fields
+#   - Never raises on bad/None input (wraps its body in try/except and
+#     logs at WARNING if the component was provided but unusable)
+#   - Is pure — no mutation of the component
+# ──────────────────────────────────────────────────────────────────────
+
+def _extract_wm_features(
+    wm: Optional[Any],
+    *,
+    goal_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Extract ``wm_*`` fields from a ``WorkingMemory``-like object.
+
+    Fields owned (PRD §3.1):
+      - ``wm_state_key``     : ``wm.stable_key(goal_id)``, 16-char hex
+      - ``wm_slot_counts``   : per-type counts of active slots
+      - ``wm_goal_active``   : any "goal" slot present (optionally filtered
+                                to ``goal_id``)
+      - ``wm_age_ticks``     : ticks since last WM write (best-effort; 0
+                                if the component doesn't expose ticks)
+      - ``wm_pressure``      : len(slots) / capacity, clamped to [0, 1]
+
+    ``None`` input → defaults (``_EMPTY_WM_STATE_KEY``, empty counts,
+    no active goal, zero age, zero pressure).
+    """
+    if wm is None:
+        return {
+            "wm_state_key": _EMPTY_WM_STATE_KEY,
+            "wm_slot_counts": {},
+            "wm_goal_active": False,
+            "wm_age_ticks": 0,
+            "wm_pressure": 0.0,
+        }
+
+    try:
+        # wm.stable_key(goal_id) — deterministic hash.  Missing/raising
+        # → sentinel.  We don't re-hash ourselves; the PRD contract is
+        # "whatever wm.stable_key returns", 16-char hex.
+        try:
+            state_key = wm.stable_key(goal_id) if hasattr(wm, "stable_key") else _EMPTY_WM_STATE_KEY
+        except Exception as e:
+            logger.warning("wm.stable_key raised: %s", e)
+            state_key = _EMPTY_WM_STATE_KEY
+        if not isinstance(state_key, str) or not state_key:
+            state_key = _EMPTY_WM_STATE_KEY
+
+        # Per-type slot counts.  Read from ``.slots`` dict if present.
+        slot_counts: Dict[str, int] = {}
+        slots = getattr(wm, "slots", None)
+        if isinstance(slots, dict):
+            for slot in slots.values():
+                content_type = getattr(slot, "content_type", None)
+                if goal_id is not None:
+                    slot_goal = getattr(slot, "goal_id", None)
+                    if slot_goal != goal_id:
+                        continue
+                if isinstance(content_type, str):
+                    slot_counts[content_type] = slot_counts.get(content_type, 0) + 1
+
+        # ``wm_goal_active``: true if any "goal" slot exists for this
+        # ``goal_id`` (or any, if ``goal_id`` not provided).
+        wm_goal_active = slot_counts.get("goal", 0) > 0
+
+        # Capacity for pressure.  Fall back to default if missing.
+        capacity = getattr(wm, "capacity", _DEFAULT_WM_CAPACITY)
+        if not isinstance(capacity, int) or capacity <= 0:
+            capacity = _DEFAULT_WM_CAPACITY
+
+        # Current slot count.  If ``slots`` is None, pressure is 0.
+        current = len(slots) if isinstance(slots, dict) else 0
+        wm_pressure = min(1.0, max(0.0, current / capacity))
+
+        # Age since last write.  We approximate via
+        # ``max(slot.timestamp)`` deltas against ``time.time()`` *only*
+        # when the component exposes something tick-shaped.  Real WM
+        # tracks ``total_ticks`` but not "ticks since last write";
+        # returning 0 is a safe default that Phase 0 records can carry
+        # uniformly.  If the WM exposes a ``get_age_ticks`` method,
+        # prefer that.
+        wm_age_ticks = 0
+        if hasattr(wm, "get_age_ticks") and callable(wm.get_age_ticks):
+            try:
+                candidate = wm.get_age_ticks(goal_id) if goal_id is not None else wm.get_age_ticks()
+                if isinstance(candidate, int) and candidate >= 0:
+                    wm_age_ticks = candidate
+            except Exception as e:
+                logger.warning("wm.get_age_ticks raised: %s", e)
+
+        return {
+            "wm_state_key": state_key,
+            "wm_slot_counts": slot_counts,
+            "wm_goal_active": wm_goal_active,
+            "wm_age_ticks": wm_age_ticks,
+            "wm_pressure": float(wm_pressure),
+        }
+    except Exception as e:  # noqa: BLE001 — failure isolation is mandatory
+        logger.warning("_extract_wm_features raised: %s — falling back to defaults", e)
+        return _extract_wm_features(None, goal_id=goal_id)
+
+
+def _extract_snarc_features(snarc: Optional[Any]) -> Dict[str, Any]:
+    """Extract ``snarc_*`` fields from a SNARC-like input.
+
+    Accepts either a mapping ``{'surprise': ..., 'novelty': ..., ...}``
+    or an object with those attributes.  Values are clamped:
+      - surprise / novelty / arousal / conflict → [0, 1]
+      - reward → [-1, 1]
+
+    ``None`` → all zeros.
+    """
+    if snarc is None:
+        return {
+            "snarc_surprise": 0.0,
+            "snarc_novelty": 0.0,
+            "snarc_arousal": 0.0,
+            "snarc_reward": 0.0,
+            "snarc_conflict": 0.0,
+        }
+
+    def _get(key: str, default: float = 0.0) -> float:
+        try:
+            if isinstance(snarc, dict):
+                value = snarc.get(key, default)
+            else:
+                value = getattr(snarc, key, default)
+            if value is None:
+                return default
+            return float(value)
+        except Exception:
+            return default
+
+    try:
+        return {
+            "snarc_surprise": _clamp_unit(_get("surprise", 0.0)),
+            "snarc_novelty": _clamp_unit(_get("novelty", 0.0)),
+            "snarc_arousal": _clamp_unit(_get("arousal", 0.0)),
+            "snarc_reward": _clamp_range(_get("reward", 0.0), -1.0, 1.0),
+            "snarc_conflict": _clamp_unit(_get("conflict", 0.0)),
+        }
+    except Exception as e:  # noqa: BLE001
+        logger.warning("_extract_snarc_features raised: %s — falling back to defaults", e)
+        return _extract_snarc_features(None)
+
+
+def _extract_metabolic_features(metabolic: Optional[Any]) -> Dict[str, Any]:
+    """Extract ``metabolic_state`` / ``atp_level`` / ``atp_trend``.
+
+    Accepts a ``MetabolicController``-like object exposing:
+      - ``current_state`` (Enum-like; ``.value`` is the str) OR a string
+      - ``atp_current`` (0-100)
+      - ``atp_trend`` or ``get_atp_trend()`` returning one of
+        ``VALID_ATP_TRENDS``
+
+    ``None`` → sensible defaults (wake, 0 ATP, stable).
+    """
+    if metabolic is None:
+        return {
+            "metabolic_state": _DEFAULT_METABOLIC_STATE,
+            "atp_level": _DEFAULT_ATP_LEVEL,
+            "atp_trend": _DEFAULT_ATP_TREND,
+        }
+
+    try:
+        # current_state — either an Enum or a str.
+        raw_state = getattr(metabolic, "current_state", None)
+        if raw_state is None and isinstance(metabolic, dict):
+            raw_state = metabolic.get("current_state") or metabolic.get("state")
+        # Enum → .value, else coerce to str.
+        if hasattr(raw_state, "value"):
+            state_str = raw_state.value
+        else:
+            state_str = raw_state
+        if not isinstance(state_str, str) or state_str not in VALID_METABOLIC_STATES:
+            state_str = _DEFAULT_METABOLIC_STATE
+
+        # ATP level.
+        atp = None
+        if isinstance(metabolic, dict):
+            atp = metabolic.get("atp_current", metabolic.get("atp_level"))
+        else:
+            atp = getattr(metabolic, "atp_current", getattr(metabolic, "atp_level", None))
+        try:
+            atp_val = float(atp) if atp is not None else _DEFAULT_ATP_LEVEL
+        except (TypeError, ValueError):
+            atp_val = _DEFAULT_ATP_LEVEL
+        atp_val = _clamp_range(atp_val, 0.0, 100.0)
+
+        # ATP trend.  Prefer a method, then an attribute, then stable.
+        trend: Optional[str] = None
+        if hasattr(metabolic, "get_atp_trend") and callable(metabolic.get_atp_trend):
+            try:
+                trend = metabolic.get_atp_trend()
+            except Exception as e:
+                logger.warning("metabolic.get_atp_trend raised: %s", e)
+        if trend is None:
+            if isinstance(metabolic, dict):
+                trend = metabolic.get("atp_trend")
+            else:
+                trend = getattr(metabolic, "atp_trend", None)
+        if not isinstance(trend, str) or trend not in VALID_ATP_TRENDS:
+            trend = _DEFAULT_ATP_TREND
+
+        return {
+            "metabolic_state": state_str,
+            "atp_level": float(atp_val),
+            "atp_trend": trend,
+        }
+    except Exception as e:  # noqa: BLE001
+        logger.warning("_extract_metabolic_features raised: %s — falling back to defaults", e)
+        return _extract_metabolic_features(None)
+
+
+def _extract_episodic_features(
+    episodic: Optional[Any],
+    *,
+    cue: Optional[Any] = None,
+    k: int = 5,
+) -> Dict[str, Any]:
+    """Extract ``recall_*`` fields from an ``EpisodicIndex``-like object.
+
+    Calls ``episodic.recall(cue, k=k)`` if both the component and cue
+    are provided; parses the top-k results for:
+      - ``recall_count`` : number of results returned (0..k)
+      - ``recall_best_similarity`` : top-1 similarity, 0 if empty
+      - ``recall_best_outcome`` : reward from best-match episode, None
+        if the best match has no reward recorded
+
+    Episodic may not be available before Phase 3 integration.  ``None``
+    input OR missing ``cue`` → defaults (0, 0.0, None).
+    """
+    if episodic is None or cue is None:
+        return {
+            "recall_count": 0,
+            "recall_best_similarity": 0.0,
+            "recall_best_outcome": None,
+        }
+
+    try:
+        if not hasattr(episodic, "recall") or not callable(episodic.recall):
+            return _extract_episodic_features(None)
+
+        results = episodic.recall(cue, k=k)
+        if not results:
+            return {
+                "recall_count": 0,
+                "recall_best_similarity": 0.0,
+                "recall_best_outcome": None,
+            }
+
+        count = len(results)
+        # Best-match similarity and outcome.  Results are ordered;
+        # take the first.  Tolerate both RecallResult and raw dicts.
+        best = results[0]
+        similarity = getattr(best, "similarity", None)
+        if similarity is None and isinstance(best, dict):
+            similarity = best.get("similarity")
+        try:
+            similarity = _clamp_unit(float(similarity)) if similarity is not None else 0.0
+        except (TypeError, ValueError):
+            similarity = 0.0
+
+        # Outcome is the episode's reward, if any.
+        ep = getattr(best, "episode", None)
+        if ep is None and isinstance(best, dict):
+            ep = best.get("episode")
+        outcome: Optional[float] = None
+        if ep is not None:
+            reward = getattr(ep, "reward", None)
+            if reward is None and isinstance(ep, dict):
+                reward = ep.get("reward")
+            try:
+                if reward is not None:
+                    outcome = float(reward)
+            except (TypeError, ValueError):
+                outcome = None
+
+        return {
+            "recall_count": int(count),
+            "recall_best_similarity": float(similarity),
+            "recall_best_outcome": outcome,
+        }
+    except Exception as e:  # noqa: BLE001
+        logger.warning("_extract_episodic_features raised: %s — falling back to defaults", e)
+        return _extract_episodic_features(None)
+
+
+def _extract_cerebellum_features(
+    cerebellum: Optional[Any],
+    *,
+    state: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Extract ``habit_available`` / ``habit_confidence`` via cerebellum lookup.
+
+    ``cerebellum.lookup(state)`` returns a ranked list of
+    ``HabitMatch`` objects.  The highest-confidence match (sorted by
+    the cerebellum itself) supplies ``habit_confidence``.
+
+    ``None`` → no habit available, zero confidence.
+    """
+    if cerebellum is None or state is None:
+        return {
+            "habit_available": False,
+            "habit_confidence": 0.0,
+        }
+
+    try:
+        if not hasattr(cerebellum, "lookup") or not callable(cerebellum.lookup):
+            return _extract_cerebellum_features(None)
+
+        matches = cerebellum.lookup(state)
+        if not matches:
+            return {
+                "habit_available": False,
+                "habit_confidence": 0.0,
+            }
+
+        best = matches[0]
+        confidence = getattr(best, "confidence", None)
+        if confidence is None and isinstance(best, dict):
+            confidence = best.get("confidence")
+        try:
+            confidence = _clamp_unit(float(confidence)) if confidence is not None else 0.0
+        except (TypeError, ValueError):
+            confidence = 0.0
+
+        return {
+            "habit_available": True,
+            "habit_confidence": float(confidence),
+        }
+    except Exception as e:  # noqa: BLE001
+        logger.warning("_extract_cerebellum_features raised: %s — falling back to defaults", e)
+        return _extract_cerebellum_features(None)
+
+
+def _extract_rpe_features(
+    rpe: Optional[Any],
+    *,
+    state_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Extract ``prior_invoke`` / ``prior_habit`` / ``prior_noop`` from RPE.
+
+    Per PRD §2.6: the router reads priors via
+    ``rpe.get_action_priors(state_key)``, which returns a dict
+    ``{action_name: prior_value}``.  The PRD doesn't pin the exact
+    action vocabulary — only that 'invoke', 'habit', 'noop' are the
+    router's decision classes.  We query those three names and
+    normalize.
+
+    RPE is not available before Phase 4 (per sprint doc).  ``None``
+    input OR missing ``state_key`` → uniform distribution (1/3 each),
+    which is a deliberate "no information" signal.
+    """
+    if rpe is None or not state_key:
+        return {
+            "prior_invoke": _UNIFORM_PRIOR,
+            "prior_habit": _UNIFORM_PRIOR,
+            "prior_noop": _UNIFORM_PRIOR,
+        }
+
+    try:
+        if not hasattr(rpe, "get_action_priors") or not callable(rpe.get_action_priors):
+            return _extract_rpe_features(None)
+
+        priors = rpe.get_action_priors(state_key, ["invoke", "habit", "noop"])
+        if not isinstance(priors, dict):
+            return _extract_rpe_features(None)
+
+        def _one(name: str) -> float:
+            try:
+                return _clamp_unit(float(priors.get(name, _UNIFORM_PRIOR)))
+            except (TypeError, ValueError):
+                return _UNIFORM_PRIOR
+
+        return {
+            "prior_invoke": _one("invoke"),
+            "prior_habit": _one("habit"),
+            "prior_noop": _one("noop"),
+        }
+    except Exception as e:  # noqa: BLE001
+        logger.warning("_extract_rpe_features raised: %s — falling back to defaults", e)
+        return _extract_rpe_features(None)
+
+
+def _extract_metacog_features(metacog: Optional[Any]) -> Dict[str, Any]:
+    """Extract ``metacog_block_list`` — plugin names currently forbidden.
+
+    Per PRD §2.7: metacog can publish hard constraints (priority >=
+    0.9) forbidding the router from invoking specific plugins this
+    tick.  We expose them here as a bounded list of plugin names.
+
+    Accepts:
+      - A Metacog-like object with ``get_block_list()`` method
+      - A Metacog-like object with a ``block_list`` attribute
+      - A dict with a ``block_list`` key
+      - An iterable of plugin names directly
+
+    ``None`` → empty list.
+    """
+    if metacog is None:
+        return {"metacog_block_list": []}
+
+    try:
+        block_list: Iterable[Any]
+        if hasattr(metacog, "get_block_list") and callable(metacog.get_block_list):
+            block_list = metacog.get_block_list()
+        elif hasattr(metacog, "block_list"):
+            block_list = metacog.block_list
+        elif isinstance(metacog, dict):
+            block_list = metacog.get("block_list", [])
+        elif isinstance(metacog, (list, tuple, set)):
+            block_list = metacog
+        else:
+            block_list = []
+
+        # Coerce to a list of strings, filter non-strings, cap length.
+        cleaned: List[str] = []
+        for item in block_list or []:
+            if isinstance(item, str):
+                cleaned.append(item)
+            if len(cleaned) >= _MAX_METACOG_BLOCK_LIST:
+                break
+        return {"metacog_block_list": cleaned}
+    except Exception as e:  # noqa: BLE001
+        logger.warning("_extract_metacog_features raised: %s — falling back to defaults", e)
+        return {"metacog_block_list": []}
+
+
+def _extract_sensory_features(sensory: Optional[Any]) -> Dict[str, Any]:
+    """Extract ``sensory_modalities`` / ``sensory_novelty`` / ``sensory_urgency``.
+
+    Accepts:
+      - A dict with keys {``modalities``, ``novelty``, ``urgency``}
+      - An object with those attributes
+
+    ``modalities`` may be ``list[str]`` directly, or ``dict[str, Any]``
+    where the keys are modality names (values ignored — presence is
+    the signal).  We cap length defensively.
+
+    ``None`` → empty list, zero novelty, zero urgency.
+    """
+    if sensory is None:
+        return {
+            "sensory_modalities": [],
+            "sensory_novelty": 0.0,
+            "sensory_urgency": 0.0,
+        }
+
+    try:
+        def _get(key: str, default: Any = None) -> Any:
+            if isinstance(sensory, dict):
+                return sensory.get(key, default)
+            return getattr(sensory, key, default)
+
+        raw_modalities = _get("modalities", [])
+        modalities: List[str] = []
+        if isinstance(raw_modalities, dict):
+            for name in raw_modalities.keys():
+                if isinstance(name, str):
+                    modalities.append(name)
+                if len(modalities) >= _MAX_SENSORY_MODALITIES:
+                    break
+        elif isinstance(raw_modalities, (list, tuple, set)):
+            for name in raw_modalities:
+                if isinstance(name, str):
+                    modalities.append(name)
+                if len(modalities) >= _MAX_SENSORY_MODALITIES:
+                    break
+
+        novelty = _get("novelty", _DEFAULT_UNIT)
+        urgency = _get("urgency", _DEFAULT_UNIT)
+
+        try:
+            novelty_f = _clamp_unit(float(novelty)) if novelty is not None else _DEFAULT_UNIT
+        except (TypeError, ValueError):
+            novelty_f = _DEFAULT_UNIT
+        try:
+            urgency_f = _clamp_unit(float(urgency)) if urgency is not None else _DEFAULT_UNIT
+        except (TypeError, ValueError):
+            urgency_f = _DEFAULT_UNIT
+
+        return {
+            "sensory_modalities": modalities,
+            "sensory_novelty": novelty_f,
+            "sensory_urgency": urgency_f,
+        }
+    except Exception as e:  # noqa: BLE001
+        logger.warning("_extract_sensory_features raised: %s — falling back to defaults", e)
+        return _extract_sensory_features(None)
+
+
+def _extract_cartridge_features(cartridge: Optional[Any]) -> Dict[str, Any]:
+    """Extract Andy's routing-role cartridge recall stubs.
+
+    Per sprint doc (Track 2): "Cartridge_recall_* fields (PRD §3.1) —
+    stubbed to zero for Phase 0; real values arrive once Andy's
+    routing-role cartridge is wired."
+
+    This stub always returns the canonical "no recall" triple
+    regardless of input — which is correct for Phase 0.  The signature
+    still accepts ``cartridge`` so that when Andy's wire lands (next
+    track), we can populate this without changing call sites.
+
+    Fields:
+      - cartridge_recall_count : 0
+      - cartridge_recall_best_similarity : 0.0
+      - cartridge_recall_embedding : zeros of length CARTRIDGE_EMBEDDING_DIM
+    """
+    # Intentionally simple: Phase 0 never populates these from live data.
+    # The PluginRegistry/cartridge-integration track will replace this
+    # body with a real call to ``router_cartridge.search(...)``.
+    del cartridge  # explicitly unused at Phase 0
+    return {
+        "cartridge_recall_count": 0,
+        "cartridge_recall_best_similarity": 0.0,
+        "cartridge_recall_embedding": [0.0] * CARTRIDGE_EMBEDDING_DIM,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Top-level extractor
+# ──────────────────────────────────────────────────────────────────────
+
+def extract_router_input(
+    wm: Optional[Any] = None,
+    snarc: Optional[Any] = None,
+    metabolic: Optional[Any] = None,
+    episodic: Optional[Any] = None,
+    cerebellum: Optional[Any] = None,
+    rpe: Optional[Any] = None,
+    metacog: Optional[Any] = None,
+    plugin_registry: Optional[Any] = None,  # reserved — Phase 0 does not consume
+    sensory: Optional[Any] = None,
+    *,
+    tick: int,
+    goal_id: Optional[str] = None,
+    timestamp: Optional[float] = None,
+    episodic_cue: Optional[Any] = None,
+    cerebellum_state: Optional[Any] = None,
+    cartridge: Optional[Any] = None,
+) -> RouterInput:
+    """Build a normative ``RouterInput`` from live kernel state.
+
+    This is the pure-function contract the router will call at every
+    consciousness-loop tick.  Every optional component may be
+    ``None``; the output is always a valid ``RouterInput`` with the
+    same field shape regardless.
+
+    Args:
+        wm: WorkingMemory instance (reads ``.slots``, ``.capacity``,
+            ``.stable_key(goal_id)``).
+        snarc: Mapping or object with keys/attrs ``surprise``,
+            ``novelty``, ``arousal``, ``reward``, ``conflict``.
+        metabolic: MetabolicController-like with ``current_state``,
+            ``atp_current``, optional ``get_atp_trend()``.
+        episodic: EpisodicIndex-like with ``recall(cue, k=...)``.
+        cerebellum: Cerebellum-like with ``lookup(state)``.
+        rpe: RewardPredictionError-like with
+            ``get_action_priors(state_key, actions)``.
+        metacog: Metacog-like with ``get_block_list()`` or
+            ``.block_list``, or an iterable of plugin names.
+        plugin_registry: Reserved for Phase 1+ (cartridge wiring,
+            plugin-tier lookups).  Not consumed at Phase 0.
+        sensory: Mapping/object with ``modalities``, ``novelty``,
+            ``urgency``.
+        tick: Consciousness-loop cycle counter (required).
+        goal_id: Active goal ID from WM.
+        timestamp: Wall-clock time.  Defaults to ``time.time()`` if not
+            provided — the extractor is the right place to stamp this
+            since it's closest to "when we saw the kernel state".
+        episodic_cue: An EpisodicCue-like object passed through to
+            ``episodic.recall(...)``.  Without a cue, episodic recall
+            is a no-op (returns defaults).  Typical construction lives
+            in the integration layer (Track 5).
+        cerebellum_state: A StateSignature-like object passed to
+            ``cerebellum.lookup(...)``.  Without a state, cerebellum
+            lookup is a no-op.
+        cartridge: Andy's router-role cartridge (Phase 1+ wire).  Not
+            consumed at Phase 0 — ``_extract_cartridge_features``
+            always returns stubs.
+
+    Returns:
+        RouterInput with every field populated from the sub-extractors,
+        stamped with ``tick``, ``timestamp``, and ``goal_id``.
+
+    Raises:
+        ValueError, TypeError: only if ``RouterInput.__post_init__``
+            rejects the assembled payload.  By construction, the
+            sub-extractors produce in-range values — so this only
+            fires if the caller passed a negative ``tick``, a
+            non-numeric ``timestamp``, or similar caller-side bug.
+    """
+    if plugin_registry is not None:
+        # Reserved for future wiring; explicitly no-op at Phase 0.
+        # Declared here so Phase 1 can start consuming it without a
+        # signature change.  Logging at DEBUG to avoid log noise.
+        logger.debug("plugin_registry supplied but not consumed at Phase 0")
+
+    # Stamp context identity first — so if a sub-extractor has a bug
+    # and we still want to emit a record, the record at least has a
+    # tick/timestamp.
+    if timestamp is None:
+        timestamp = time.time()
+
+    # Run every sub-extractor.  These are all best-effort; the
+    # sub-extractors themselves handle their own failure isolation.
+    wm_fields = _extract_wm_features(wm, goal_id=goal_id)
+    snarc_fields = _extract_snarc_features(snarc)
+    metabolic_fields = _extract_metabolic_features(metabolic)
+    episodic_fields = _extract_episodic_features(episodic, cue=episodic_cue)
+    cerebellum_fields = _extract_cerebellum_features(cerebellum, state=cerebellum_state)
+    rpe_fields = _extract_rpe_features(rpe, state_key=wm_fields["wm_state_key"])
+    metacog_fields = _extract_metacog_features(metacog)
+    sensory_fields = _extract_sensory_features(sensory)
+    cartridge_fields = _extract_cartridge_features(cartridge)
+
+    # Assemble.  Dict order matches RouterInput field order for
+    # reader-friendly reading; RouterInput takes kwargs so the order
+    # is actually irrelevant, but humans read top-to-bottom.
+    return RouterInput(
+        tick=int(tick),
+        timestamp=float(timestamp),
+        goal_id=goal_id,
+        **wm_fields,
+        **sensory_fields,
+        **snarc_fields,
+        **metabolic_fields,
+        **episodic_fields,
+        **cerebellum_fields,
+        **rpe_fields,
+        **metacog_fields,
+        **cartridge_fields,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Helpers — range clamping (mirrors RouterInput's validators but here
+# we SILENTLY clamp rather than raise, because sub-extractors are the
+# last line of defense before RouterInput.__post_init__ would reject).
+# ──────────────────────────────────────────────────────────────────────
+
+def _clamp_unit(value: float) -> float:
+    """Clamp a float to [0, 1].  NaN → 0."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if v != v:  # NaN check without math.isnan to avoid an import
+        return 0.0
+    if v < 0.0:
+        return 0.0
+    if v > 1.0:
+        return 1.0
+    return v
+
+
+def _clamp_range(value: float, lo: float, hi: float) -> float:
+    """Clamp a float to [lo, hi].  NaN → midpoint."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return (lo + hi) / 2.0
+    if v != v:  # NaN
+        return (lo + hi) / 2.0
+    if v < lo:
+        return lo
+    if v > hi:
+        return hi
+    return v
+
+
+__all__ = [
+    "extract_router_input",
+    "_extract_wm_features",
+    "_extract_snarc_features",
+    "_extract_metabolic_features",
+    "_extract_episodic_features",
+    "_extract_cerebellum_features",
+    "_extract_rpe_features",
+    "_extract_metacog_features",
+    "_extract_sensory_features",
+    "_extract_cartridge_features",
+]

--- a/sage/cognition/router/tests/test_feature_extraction.py
+++ b/sage/cognition/router/tests/test_feature_extraction.py
@@ -1,0 +1,934 @@
+#!/usr/bin/env python3
+"""
+Unit tests for router Phase 0 Track 2 — feature extraction.
+
+Coverage (sprint-doc Track 2 acceptance criteria):
+
+  1. All-present — every component supplies data.
+  2. Sparse-present — WM + SNARC + metabolic only; others None.
+  3. All-stubbed — every component None.
+  4. Edge cases — empty WM, zero salience, missing goal_id.
+  5. Determinism — same inputs → same RouterInput.
+  6. Field correctness — each sub-extractor maps to the right
+     RouterInput fields per PRD §3.1.
+  7. Failure isolation — a sub-extractor whose component raises
+     must not propagate; it returns defaults.
+  8. Vector length invariant — RouterInput shape is fixed regardless
+     of which optional components are None.
+
+Run:
+    python3 -m pytest sage/cognition/router/tests/test_feature_extraction.py -v
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from sage.cognition.router import (
+    CARTRIDGE_EMBEDDING_DIM,
+    RouterInput,
+    VALID_ATP_TRENDS,
+    VALID_METABOLIC_STATES,
+)
+from sage.cognition.router.feature_extraction import (
+    _extract_cartridge_features,
+    _extract_cerebellum_features,
+    _extract_episodic_features,
+    _extract_metabolic_features,
+    _extract_metacog_features,
+    _extract_rpe_features,
+    _extract_sensory_features,
+    _extract_snarc_features,
+    _extract_wm_features,
+    extract_router_input,
+)
+
+# Import real WM to exercise the actual public API contract.
+from sage.cognition.working_memory import WorkingMemory
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Lightweight stubs — each mimics the contract documented in the PRD
+# for its component, without pulling in torch / numpy heavy deps.
+# ──────────────────────────────────────────────────────────────────────
+
+class _SNARCStub(dict):
+    """SNARC can be passed as a dict or an attr-bag.  Test both."""
+
+
+@dataclass
+class _MetabolicStub:
+    current_state: Any = "focus"
+    atp_current: float = 65.0
+    atp_trend: str = "stable"
+
+
+class _EpisodicStub:
+    def __init__(self, results: Optional[list] = None):
+        self._results = results or []
+        self.calls = 0
+
+    def recall(self, cue, k: int = 5):
+        self.calls += 1
+        return list(self._results)[:k]
+
+
+class _RecallStub:
+    def __init__(self, similarity: float, reward: Optional[float]):
+        self.similarity = similarity
+        # Mirror the real RecallResult shape: `.episode` with `.reward`
+        self.episode = SimpleNamespace(reward=reward)
+
+
+class _HabitMatchStub:
+    def __init__(self, confidence: float):
+        self.confidence = confidence
+
+
+class _CerebellumStub:
+    def __init__(self, matches: Optional[list] = None):
+        self._matches = matches or []
+        self.calls = 0
+
+    def lookup(self, state):
+        self.calls += 1
+        return list(self._matches)
+
+
+class _RPEStub:
+    def __init__(self, priors: Dict[str, float]):
+        self.priors = priors
+        self.calls = 0
+        self.last_state_key: Optional[str] = None
+        self.last_actions: Optional[list] = None
+
+    def get_action_priors(self, state_key: str, actions: List[str]) -> Dict[str, float]:
+        self.calls += 1
+        self.last_state_key = state_key
+        self.last_actions = list(actions)
+        return {a: self.priors.get(a, 0.0) for a in actions}
+
+
+class _MetacogStub:
+    def __init__(self, block_list: List[str]):
+        self.block_list = block_list
+
+
+class _MetacogCallableStub:
+    def __init__(self, block_list: List[str]):
+        self._block_list = block_list
+        self.calls = 0
+
+    def get_block_list(self) -> List[str]:
+        self.calls += 1
+        return list(self._block_list)
+
+
+class _RaisingStub:
+    """Any attr access raises.  Used for failure-isolation tests."""
+
+    def __getattr__(self, item):
+        raise RuntimeError(f"boom-{item}")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# WM sub-extractor
+# ──────────────────────────────────────────────────────────────────────
+
+def _make_wm() -> WorkingMemory:
+    """Real WM with a goal + plan step + hypothesis."""
+    wm = WorkingMemory(capacity=7)
+    wm.add_item("goal", {"game": "cd82"}, priority=0.9, goal_id="g1")
+    wm.add_item("plan_step", {"step": 1}, priority=0.7, goal_id="g1")
+    wm.add_item("hypothesis", {"claim": "A"}, priority=0.5, goal_id="g1")
+    return wm
+
+
+def test_wm_none_returns_defaults():
+    out = _extract_wm_features(None)
+    assert out["wm_state_key"] == "0" * 16
+    assert out["wm_slot_counts"] == {}
+    assert out["wm_goal_active"] is False
+    assert out["wm_age_ticks"] == 0
+    assert out["wm_pressure"] == 0.0
+
+
+def test_wm_populated_returns_live_features():
+    wm = _make_wm()
+    out = _extract_wm_features(wm, goal_id="g1")
+
+    # state_key is 16-char hex from WM
+    assert isinstance(out["wm_state_key"], str) and len(out["wm_state_key"]) == 16
+    assert out["wm_state_key"] == wm.stable_key("g1")
+
+    # slot counts filtered to goal_id
+    assert out["wm_slot_counts"]["goal"] == 1
+    assert out["wm_slot_counts"]["plan_step"] == 1
+    assert out["wm_slot_counts"]["hypothesis"] == 1
+
+    # goal active
+    assert out["wm_goal_active"] is True
+
+    # pressure = 3/7
+    assert abs(out["wm_pressure"] - 3 / 7) < 1e-9
+
+
+def test_wm_goal_filtering_ignores_other_goals():
+    wm = WorkingMemory(capacity=7)
+    wm.add_item("goal", {"g": "A"}, priority=0.9, goal_id="A")
+    wm.add_item("goal", {"g": "B"}, priority=0.9, goal_id="B")
+    out = _extract_wm_features(wm, goal_id="A")
+    # Only the A-goal should show up
+    assert out["wm_slot_counts"].get("goal", 0) == 1
+
+
+def test_wm_empty_returns_zero_pressure():
+    wm = WorkingMemory(capacity=7)
+    out = _extract_wm_features(wm)
+    assert out["wm_pressure"] == 0.0
+    assert out["wm_slot_counts"] == {}
+    assert out["wm_goal_active"] is False
+
+
+def test_wm_failure_isolation_returns_defaults():
+    out = _extract_wm_features(_RaisingStub())
+    # Should not raise; should return defaults.
+    assert out["wm_state_key"] == "0" * 16
+    assert out["wm_slot_counts"] == {}
+
+
+def test_wm_missing_goal_id_does_not_filter():
+    wm = WorkingMemory(capacity=7)
+    wm.add_item("goal", "A", priority=0.9, goal_id="A")
+    wm.add_item("goal", "B", priority=0.9, goal_id="B")
+    out = _extract_wm_features(wm, goal_id=None)
+    # Without filter, both goals count
+    assert out["wm_slot_counts"].get("goal", 0) == 2
+    assert out["wm_goal_active"] is True
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SNARC sub-extractor
+# ──────────────────────────────────────────────────────────────────────
+
+def test_snarc_none_returns_zeros():
+    out = _extract_snarc_features(None)
+    assert out["snarc_surprise"] == 0.0
+    assert out["snarc_novelty"] == 0.0
+    assert out["snarc_arousal"] == 0.0
+    assert out["snarc_reward"] == 0.0
+    assert out["snarc_conflict"] == 0.0
+
+
+def test_snarc_dict_input():
+    snarc = {"surprise": 0.3, "novelty": 0.4, "arousal": 0.5, "reward": -0.2, "conflict": 0.1}
+    out = _extract_snarc_features(snarc)
+    assert out["snarc_surprise"] == 0.3
+    assert out["snarc_reward"] == -0.2
+    assert out["snarc_conflict"] == 0.1
+
+
+def test_snarc_object_input():
+    snarc = SimpleNamespace(surprise=0.9, novelty=0.8, arousal=0.7, reward=0.6, conflict=0.5)
+    out = _extract_snarc_features(snarc)
+    assert out["snarc_surprise"] == 0.9
+    assert out["snarc_reward"] == 0.6
+
+
+def test_snarc_clamps_out_of_range():
+    # Above-1 should clamp to 1, below-0 should clamp to 0.
+    snarc = {"surprise": 1.5, "novelty": -0.3, "arousal": 2.0, "reward": -5.0, "conflict": 99.0}
+    out = _extract_snarc_features(snarc)
+    assert out["snarc_surprise"] == 1.0
+    assert out["snarc_novelty"] == 0.0
+    assert out["snarc_arousal"] == 1.0
+    assert out["snarc_reward"] == -1.0
+    assert out["snarc_conflict"] == 1.0
+
+
+def test_snarc_missing_keys_default_to_zero():
+    snarc = {"surprise": 0.5}  # only one key supplied
+    out = _extract_snarc_features(snarc)
+    assert out["snarc_surprise"] == 0.5
+    assert out["snarc_novelty"] == 0.0
+    assert out["snarc_arousal"] == 0.0
+    assert out["snarc_reward"] == 0.0
+    assert out["snarc_conflict"] == 0.0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Metabolic sub-extractor
+# ──────────────────────────────────────────────────────────────────────
+
+def test_metabolic_none_returns_defaults():
+    out = _extract_metabolic_features(None)
+    assert out["metabolic_state"] == "wake"
+    assert out["atp_level"] == 0.0
+    assert out["atp_trend"] == "stable"
+
+
+def test_metabolic_object_input():
+    stub = _MetabolicStub(current_state="focus", atp_current=65.0, atp_trend="rising")
+    out = _extract_metabolic_features(stub)
+    assert out["metabolic_state"] == "focus"
+    assert out["atp_level"] == 65.0
+    assert out["atp_trend"] == "rising"
+
+
+def test_metabolic_enum_like_state():
+    enum_like = SimpleNamespace(value="dream")
+    stub = _MetabolicStub(current_state=enum_like, atp_current=20.0, atp_trend="falling")
+    out = _extract_metabolic_features(stub)
+    assert out["metabolic_state"] == "dream"
+    assert out["atp_trend"] == "falling"
+
+
+def test_metabolic_invalid_state_falls_back():
+    stub = _MetabolicStub(current_state="not_a_real_state")
+    out = _extract_metabolic_features(stub)
+    assert out["metabolic_state"] == "wake"
+
+
+def test_metabolic_invalid_atp_trend_falls_back():
+    stub = _MetabolicStub(atp_trend="sideways")
+    out = _extract_metabolic_features(stub)
+    assert out["atp_trend"] == "stable"
+
+
+def test_metabolic_atp_clamped():
+    stub = _MetabolicStub(atp_current=150.0)
+    out = _extract_metabolic_features(stub)
+    assert out["atp_level"] == 100.0
+    stub = _MetabolicStub(atp_current=-10.0)
+    out = _extract_metabolic_features(stub)
+    assert out["atp_level"] == 0.0
+
+
+def test_metabolic_all_valid_states():
+    # Smoke test: all canonical states serialize as-is.
+    for s in VALID_METABOLIC_STATES:
+        stub = _MetabolicStub(current_state=s)
+        out = _extract_metabolic_features(stub)
+        assert out["metabolic_state"] == s
+
+
+def test_metabolic_all_valid_trends():
+    for t in VALID_ATP_TRENDS:
+        stub = _MetabolicStub(atp_trend=t)
+        out = _extract_metabolic_features(stub)
+        assert out["atp_trend"] == t
+
+
+def test_metabolic_dict_input():
+    out = _extract_metabolic_features(
+        {"current_state": "rest", "atp_current": 30.0, "atp_trend": "falling"}
+    )
+    assert out["metabolic_state"] == "rest"
+    assert out["atp_level"] == 30.0
+    assert out["atp_trend"] == "falling"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Episodic sub-extractor
+# ──────────────────────────────────────────────────────────────────────
+
+def test_episodic_none_returns_defaults():
+    out = _extract_episodic_features(None)
+    assert out["recall_count"] == 0
+    assert out["recall_best_similarity"] == 0.0
+    assert out["recall_best_outcome"] is None
+
+
+def test_episodic_missing_cue_returns_defaults():
+    # Component present but no cue → treated as "cannot query"
+    stub = _EpisodicStub(results=[_RecallStub(0.9, 0.5)])
+    out = _extract_episodic_features(stub, cue=None)
+    assert out["recall_count"] == 0
+    assert stub.calls == 0
+
+
+def test_episodic_with_results():
+    results = [_RecallStub(0.9, 0.3), _RecallStub(0.8, 0.1), _RecallStub(0.7, None)]
+    stub = _EpisodicStub(results=results)
+    out = _extract_episodic_features(stub, cue=object(), k=3)
+    assert out["recall_count"] == 3
+    assert out["recall_best_similarity"] == 0.9
+    assert out["recall_best_outcome"] == 0.3
+    assert stub.calls == 1
+
+
+def test_episodic_empty_results():
+    stub = _EpisodicStub(results=[])
+    out = _extract_episodic_features(stub, cue=object())
+    assert out["recall_count"] == 0
+    assert out["recall_best_similarity"] == 0.0
+    assert out["recall_best_outcome"] is None
+
+
+def test_episodic_best_has_no_reward():
+    results = [_RecallStub(0.9, None)]
+    stub = _EpisodicStub(results=results)
+    out = _extract_episodic_features(stub, cue=object())
+    assert out["recall_count"] == 1
+    assert out["recall_best_similarity"] == 0.9
+    assert out["recall_best_outcome"] is None
+
+
+def test_episodic_failure_isolation():
+    class _Boom:
+        def recall(self, cue, k=5):
+            raise RuntimeError("boom")
+    out = _extract_episodic_features(_Boom(), cue=object())
+    assert out["recall_count"] == 0
+    assert out["recall_best_similarity"] == 0.0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Cerebellum sub-extractor
+# ──────────────────────────────────────────────────────────────────────
+
+def test_cerebellum_none_returns_defaults():
+    out = _extract_cerebellum_features(None)
+    assert out["habit_available"] is False
+    assert out["habit_confidence"] == 0.0
+
+
+def test_cerebellum_missing_state_returns_defaults():
+    # Component present but no state → cannot query.
+    stub = _CerebellumStub(matches=[_HabitMatchStub(0.9)])
+    out = _extract_cerebellum_features(stub, state=None)
+    assert out["habit_available"] is False
+    assert stub.calls == 0
+
+
+def test_cerebellum_match_returns_available():
+    matches = [_HabitMatchStub(0.85), _HabitMatchStub(0.75)]
+    stub = _CerebellumStub(matches=matches)
+    out = _extract_cerebellum_features(stub, state=object())
+    assert out["habit_available"] is True
+    assert out["habit_confidence"] == 0.85
+
+
+def test_cerebellum_empty_match_list():
+    stub = _CerebellumStub(matches=[])
+    out = _extract_cerebellum_features(stub, state=object())
+    assert out["habit_available"] is False
+    assert out["habit_confidence"] == 0.0
+
+
+def test_cerebellum_clamps_confidence():
+    matches = [_HabitMatchStub(1.5)]
+    stub = _CerebellumStub(matches=matches)
+    out = _extract_cerebellum_features(stub, state=object())
+    assert out["habit_confidence"] == 1.0
+
+
+def test_cerebellum_failure_isolation():
+    class _Boom:
+        def lookup(self, s):
+            raise RuntimeError("boom")
+    out = _extract_cerebellum_features(_Boom(), state=object())
+    assert out["habit_available"] is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# RPE sub-extractor
+# ──────────────────────────────────────────────────────────────────────
+
+def test_rpe_none_returns_uniform_prior():
+    out = _extract_rpe_features(None, state_key="state")
+    # Uniform over 3 classes → 1/3 each
+    for k in ("prior_invoke", "prior_habit", "prior_noop"):
+        assert abs(out[k] - 1 / 3) < 1e-9
+
+
+def test_rpe_missing_state_key_returns_uniform():
+    stub = _RPEStub({"invoke": 0.6, "habit": 0.3, "noop": 0.1})
+    out = _extract_rpe_features(stub, state_key=None)
+    for k in ("prior_invoke", "prior_habit", "prior_noop"):
+        assert abs(out[k] - 1 / 3) < 1e-9
+    assert stub.calls == 0
+
+
+def test_rpe_reads_priors():
+    stub = _RPEStub({"invoke": 0.5, "habit": 0.3, "noop": 0.2})
+    out = _extract_rpe_features(stub, state_key="sk-1")
+    assert out["prior_invoke"] == 0.5
+    assert out["prior_habit"] == 0.3
+    assert out["prior_noop"] == 0.2
+    assert stub.calls == 1
+    assert stub.last_state_key == "sk-1"
+    assert stub.last_actions == ["invoke", "habit", "noop"]
+
+
+def test_rpe_priors_clamped_to_unit():
+    stub = _RPEStub({"invoke": 1.5, "habit": -0.3, "noop": 0.4})
+    out = _extract_rpe_features(stub, state_key="sk-1")
+    assert out["prior_invoke"] == 1.0
+    assert out["prior_habit"] == 0.0
+    assert out["prior_noop"] == 0.4
+
+
+def test_rpe_failure_isolation():
+    class _Boom:
+        def get_action_priors(self, sk, actions):
+            raise RuntimeError("boom")
+    out = _extract_rpe_features(_Boom(), state_key="sk")
+    # Falls back to uniform
+    for k in ("prior_invoke", "prior_habit", "prior_noop"):
+        assert abs(out[k] - 1 / 3) < 1e-9
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Metacog sub-extractor
+# ──────────────────────────────────────────────────────────────────────
+
+def test_metacog_none_returns_empty():
+    out = _extract_metacog_features(None)
+    assert out["metacog_block_list"] == []
+
+
+def test_metacog_attr_list():
+    stub = _MetacogStub(["vision_plugin", "audio_plugin"])
+    out = _extract_metacog_features(stub)
+    assert out["metacog_block_list"] == ["vision_plugin", "audio_plugin"]
+
+
+def test_metacog_callable_get_block_list():
+    stub = _MetacogCallableStub(["llm_plugin"])
+    out = _extract_metacog_features(stub)
+    assert out["metacog_block_list"] == ["llm_plugin"]
+    assert stub.calls == 1
+
+
+def test_metacog_dict_input():
+    out = _extract_metacog_features({"block_list": ["a", "b"]})
+    assert out["metacog_block_list"] == ["a", "b"]
+
+
+def test_metacog_list_input():
+    out = _extract_metacog_features(["a", "b", "c"])
+    assert out["metacog_block_list"] == ["a", "b", "c"]
+
+
+def test_metacog_filters_non_strings():
+    # Non-strings are dropped
+    out = _extract_metacog_features([1, "a", None, "b", 2.5])
+    assert out["metacog_block_list"] == ["a", "b"]
+
+
+def test_metacog_failure_isolation():
+    class _Boom:
+        @property
+        def block_list(self):
+            raise RuntimeError("boom")
+    out = _extract_metacog_features(_Boom())
+    assert out["metacog_block_list"] == []
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Sensory sub-extractor
+# ──────────────────────────────────────────────────────────────────────
+
+def test_sensory_none_returns_defaults():
+    out = _extract_sensory_features(None)
+    assert out["sensory_modalities"] == []
+    assert out["sensory_novelty"] == 0.0
+    assert out["sensory_urgency"] == 0.0
+
+
+def test_sensory_dict_list_modalities():
+    sensory = {"modalities": ["vision", "time"], "novelty": 0.4, "urgency": 0.2}
+    out = _extract_sensory_features(sensory)
+    assert out["sensory_modalities"] == ["vision", "time"]
+    assert out["sensory_novelty"] == 0.4
+    assert out["sensory_urgency"] == 0.2
+
+
+def test_sensory_dict_dict_modalities():
+    # Sometimes modality dicts carry metadata; we only take the keys
+    sensory = {"modalities": {"vision": {"foo": 1}, "time": {}}, "novelty": 0.5, "urgency": 0.5}
+    out = _extract_sensory_features(sensory)
+    assert set(out["sensory_modalities"]) == {"vision", "time"}
+
+
+def test_sensory_object_input():
+    sensory = SimpleNamespace(modalities=["message"], novelty=0.1, urgency=0.9)
+    out = _extract_sensory_features(sensory)
+    assert out["sensory_modalities"] == ["message"]
+    assert out["sensory_novelty"] == 0.1
+    assert out["sensory_urgency"] == 0.9
+
+
+def test_sensory_clamps_and_filters():
+    sensory = {
+        "modalities": ["vision", 42, None, "time"],
+        "novelty": 1.5,
+        "urgency": -0.3,
+    }
+    out = _extract_sensory_features(sensory)
+    assert out["sensory_modalities"] == ["vision", "time"]
+    assert out["sensory_novelty"] == 1.0
+    assert out["sensory_urgency"] == 0.0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Cartridge sub-extractor (Phase 0 stub)
+# ──────────────────────────────────────────────────────────────────────
+
+def test_cartridge_none_returns_stub():
+    out = _extract_cartridge_features(None)
+    assert out["cartridge_recall_count"] == 0
+    assert out["cartridge_recall_best_similarity"] == 0.0
+    assert out["cartridge_recall_embedding"] == [0.0] * CARTRIDGE_EMBEDDING_DIM
+    assert len(out["cartridge_recall_embedding"]) == CARTRIDGE_EMBEDDING_DIM
+
+
+def test_cartridge_present_still_returns_stub_at_phase_0():
+    # Phase 0: we never consume a real cartridge.  Guaranteed stub.
+    stub = SimpleNamespace(search=lambda *a, **k: [])
+    out = _extract_cartridge_features(stub)
+    assert out["cartridge_recall_count"] == 0
+    assert out["cartridge_recall_best_similarity"] == 0.0
+    assert out["cartridge_recall_embedding"] == [0.0] * CARTRIDGE_EMBEDDING_DIM
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Top-level extract_router_input
+# ──────────────────────────────────────────────────────────────────────
+
+def _all_present_kit(goal_id: str = "g1"):
+    """Build a full component kit for 'all-present' tests.
+
+    Returns a dict: {wm, snarc, metabolic, episodic, cerebellum, rpe,
+                     metacog, sensory, episodic_cue, cerebellum_state}.
+    """
+    wm = _make_wm()
+    snarc = {"surprise": 0.3, "novelty": 0.4, "arousal": 0.5, "reward": -0.2, "conflict": 0.1}
+    metabolic = _MetabolicStub(current_state="focus", atp_current=65.0, atp_trend="stable")
+    episodic = _EpisodicStub(results=[_RecallStub(0.85, 0.2), _RecallStub(0.75, None)])
+    cerebellum = _CerebellumStub(matches=[_HabitMatchStub(0.88)])
+    rpe = _RPEStub({"invoke": 0.5, "habit": 0.3, "noop": 0.2})
+    metacog = _MetacogStub(["perseverating_plugin"])
+    sensory = {"modalities": ["vision", "time"], "novelty": 0.1, "urgency": 0.2}
+    return dict(
+        wm=wm,
+        snarc=snarc,
+        metabolic=metabolic,
+        episodic=episodic,
+        cerebellum=cerebellum,
+        rpe=rpe,
+        metacog=metacog,
+        sensory=sensory,
+        episodic_cue=object(),  # placeholder; episodic stub ignores content
+        cerebellum_state=object(),
+    )
+
+
+def test_all_present_extraction_produces_valid_routerinput():
+    kit = _all_present_kit()
+    ri = extract_router_input(tick=42, goal_id="g1", timestamp=1700000000.0, **kit)
+    assert isinstance(ri, RouterInput)
+    assert ri.tick == 42
+    assert ri.timestamp == 1700000000.0
+    assert ri.goal_id == "g1"
+    # Fields populated from sub-extractors
+    assert ri.metabolic_state == "focus"
+    assert ri.atp_level == 65.0
+    assert ri.atp_trend == "stable"
+    assert ri.snarc_surprise == 0.3
+    assert ri.snarc_reward == -0.2
+    assert ri.recall_count == 2
+    assert ri.recall_best_similarity == 0.85
+    assert ri.recall_best_outcome == 0.2
+    assert ri.habit_available is True
+    assert ri.habit_confidence == 0.88
+    assert ri.prior_invoke == 0.5
+    assert ri.prior_habit == 0.3
+    assert ri.prior_noop == 0.2
+    assert ri.metacog_block_list == ["perseverating_plugin"]
+    assert ri.sensory_modalities == ["vision", "time"]
+    assert ri.wm_goal_active is True
+    # Cartridge is always stubbed at Phase 0
+    assert ri.cartridge_recall_count == 0
+    assert ri.cartridge_recall_best_similarity == 0.0
+    assert len(ri.cartridge_recall_embedding) == CARTRIDGE_EMBEDDING_DIM
+
+
+def test_sparse_present_wm_snarc_metabolic_only():
+    """Sprint-doc Track 2 acceptance: sparse-present — WM + SNARC +
+    metabolic; other components None."""
+    ri = extract_router_input(
+        wm=_make_wm(),
+        snarc={"surprise": 0.5, "novelty": 0.5, "arousal": 0.5, "reward": 0.0, "conflict": 0.0},
+        metabolic=_MetabolicStub(current_state="wake", atp_current=40.0),
+        episodic=None,
+        cerebellum=None,
+        rpe=None,
+        metacog=None,
+        sensory=None,
+        tick=5,
+        goal_id="g1",
+    )
+    # WM populated
+    assert ri.wm_goal_active is True
+    # SNARC populated
+    assert ri.snarc_surprise == 0.5
+    # Metabolic populated
+    assert ri.metabolic_state == "wake"
+    # Missing components use defaults
+    assert ri.recall_count == 0
+    assert ri.recall_best_outcome is None
+    assert ri.habit_available is False
+    # Priors: uniform
+    assert abs(ri.prior_invoke - 1 / 3) < 1e-9
+    # Metacog and sensory empty
+    assert ri.metacog_block_list == []
+    assert ri.sensory_modalities == []
+    # Cartridge stub
+    assert len(ri.cartridge_recall_embedding) == CARTRIDGE_EMBEDDING_DIM
+
+
+def test_all_stubbed_every_component_none():
+    """Sprint-doc Track 2 acceptance: all-stubbed — every component
+    None."""
+    ri = extract_router_input(tick=1)
+    assert isinstance(ri, RouterInput)
+    assert ri.tick == 1
+    assert ri.goal_id is None
+    assert ri.wm_state_key == "0" * 16
+    assert ri.wm_slot_counts == {}
+    assert ri.wm_goal_active is False
+    assert ri.wm_age_ticks == 0
+    assert ri.wm_pressure == 0.0
+    assert ri.sensory_modalities == []
+    assert ri.sensory_novelty == 0.0
+    assert ri.sensory_urgency == 0.0
+    assert ri.snarc_surprise == 0.0
+    assert ri.snarc_novelty == 0.0
+    assert ri.snarc_arousal == 0.0
+    assert ri.snarc_reward == 0.0
+    assert ri.snarc_conflict == 0.0
+    assert ri.metabolic_state == "wake"
+    assert ri.atp_level == 0.0
+    assert ri.atp_trend == "stable"
+    assert ri.recall_count == 0
+    assert ri.recall_best_similarity == 0.0
+    assert ri.recall_best_outcome is None
+    assert ri.habit_available is False
+    assert ri.habit_confidence == 0.0
+    assert abs(ri.prior_invoke - 1 / 3) < 1e-9
+    assert abs(ri.prior_habit - 1 / 3) < 1e-9
+    assert abs(ri.prior_noop - 1 / 3) < 1e-9
+    assert ri.metacog_block_list == []
+    assert ri.cartridge_recall_count == 0
+    assert ri.cartridge_recall_best_similarity == 0.0
+    assert len(ri.cartridge_recall_embedding) == CARTRIDGE_EMBEDDING_DIM
+    # All zeros
+    assert all(v == 0.0 for v in ri.cartridge_recall_embedding)
+
+
+def test_edge_case_empty_wm_zero_salience_no_goal():
+    """Edge case: empty WM, zero SNARC, no goal_id (sprint-doc Track 2)."""
+    wm = WorkingMemory(capacity=7)  # empty
+    snarc = {"surprise": 0.0, "novelty": 0.0, "arousal": 0.0, "reward": 0.0, "conflict": 0.0}
+    ri = extract_router_input(
+        wm=wm,
+        snarc=snarc,
+        metabolic=_MetabolicStub(current_state="rest", atp_current=10.0, atp_trend="falling"),
+        tick=0,
+        goal_id=None,
+    )
+    assert ri.wm_goal_active is False
+    assert ri.wm_pressure == 0.0
+    assert ri.wm_slot_counts == {}
+    assert ri.snarc_arousal == 0.0
+    # state_key is deterministic even for empty WM
+    assert isinstance(ri.wm_state_key, str)
+    assert len(ri.wm_state_key) == 16
+    assert ri.goal_id is None
+
+
+def test_determinism_same_inputs_same_output():
+    """Sprint-doc Track 2 acceptance: determinism — same inputs →
+    same RouterInput."""
+    kit = _all_present_kit()
+    ri1 = extract_router_input(tick=7, goal_id="g1", timestamp=1700000000.0, **kit)
+    ri2 = extract_router_input(tick=7, goal_id="g1", timestamp=1700000000.0, **kit)
+    # Same inputs → identical serializations.
+    assert ri1.to_dict() == ri2.to_dict()
+
+
+def test_feature_vector_length_fixed_regardless_of_none_components():
+    """Sprint-doc Track 2 acceptance: feature vector length is fixed
+    regardless of which optional components are None.
+
+    We verify this by round-tripping to dict and confirming the key
+    set is identical across every combination.
+    """
+    combos = [
+        # All None
+        dict(tick=1),
+        # WM only
+        dict(tick=1, wm=_make_wm()),
+        # SNARC + metabolic
+        dict(tick=1, snarc={"surprise": 0.5}, metabolic=_MetabolicStub()),
+        # Everything
+        dict(tick=1, **_all_present_kit()),
+    ]
+    key_sets = []
+    embedding_lengths = []
+    for c in combos:
+        ri = extract_router_input(**c)
+        d = ri.to_dict()
+        key_sets.append(frozenset(d.keys()))
+        embedding_lengths.append(len(ri.cartridge_recall_embedding))
+
+    # All combos produce the same RouterInput key-set (fixed shape)
+    assert len(set(key_sets)) == 1, f"key sets differ: {key_sets}"
+
+    # Cartridge embedding always 768
+    assert all(length == CARTRIDGE_EMBEDDING_DIM for length in embedding_lengths)
+
+
+def test_timestamp_defaults_to_now():
+    t0 = time.time()
+    ri = extract_router_input(tick=1)
+    t1 = time.time()
+    assert t0 - 1.0 <= ri.timestamp <= t1 + 1.0
+
+
+def test_goal_id_optional_and_forwarded():
+    ri = extract_router_input(tick=1, goal_id=None)
+    assert ri.goal_id is None
+    ri = extract_router_input(tick=1, goal_id="g-xyz")
+    assert ri.goal_id == "g-xyz"
+
+
+def test_negative_tick_rejected_by_routerinput():
+    # Boundary contract: the extractor passes its tick through to
+    # RouterInput.__post_init__, which raises on negative values.
+    with pytest.raises(ValueError):
+        extract_router_input(tick=-1)
+
+
+def test_rpe_uses_wm_state_key_as_state_key():
+    """The RPE sub-extractor should be called with the state key
+    derived from WM — not from the caller.  This is the binding that
+    guarantees serving-time features match training-time features
+    (PRD §4.7.G: no training-serving skew)."""
+    wm = _make_wm()
+    rpe = _RPEStub({"invoke": 0.5, "habit": 0.3, "noop": 0.2})
+    ri = extract_router_input(
+        wm=wm,
+        rpe=rpe,
+        tick=1,
+        goal_id="g1",
+    )
+    assert rpe.last_state_key == wm.stable_key("g1")
+    assert ri.wm_state_key == wm.stable_key("g1")
+
+
+def test_cartridge_kwarg_passes_without_effect():
+    # ``cartridge`` is plumbed through so a future track can wire it;
+    # at Phase 0 it must not change output.
+    fixed_ts = 1700000000.0
+    ri_none = extract_router_input(tick=1, timestamp=fixed_ts)
+    ri_passed = extract_router_input(
+        tick=1, timestamp=fixed_ts, cartridge=SimpleNamespace(search=lambda *a, **k: [])
+    )
+    assert ri_none.to_dict() == ri_passed.to_dict()
+
+
+def test_plugin_registry_kwarg_noop_at_phase_0():
+    # ``plugin_registry`` is reserved; must not change output.
+    fixed_ts = 1700000000.0
+    ri_none = extract_router_input(tick=1, timestamp=fixed_ts)
+    ri_passed = extract_router_input(
+        tick=1, timestamp=fixed_ts, plugin_registry=SimpleNamespace(names=lambda: ["p1"])
+    )
+    assert ri_none.to_dict() == ri_passed.to_dict()
+
+
+def test_full_json_roundtrip():
+    """Extracted RouterInput round-trips through to_dict/from_dict."""
+    kit = _all_present_kit()
+    ri = extract_router_input(tick=99, goal_id="g1", timestamp=1234567.0, **kit)
+    d = ri.to_dict()
+    ri2 = RouterInput.from_dict(d)
+    assert ri.to_dict() == ri2.to_dict()
+
+
+def test_extractor_does_not_mutate_inputs():
+    """Sub-extractors are pure — running extraction twice must not
+    change the underlying components."""
+    kit = _all_present_kit()
+    wm = kit["wm"]
+    # Snapshot key WM state
+    slots_before = {sid: slot.content_type for sid, slot in wm.slots.items()}
+    total_adds_before = wm.total_adds
+    total_accesses_before = wm.total_accesses
+
+    # Extract twice
+    extract_router_input(tick=1, goal_id="g1", **kit)
+    extract_router_input(tick=2, goal_id="g1", **kit)
+
+    # WM slot map unchanged
+    slots_after = {sid: slot.content_type for sid, slot in wm.slots.items()}
+    assert slots_before == slots_after
+    # No new adds
+    assert wm.total_adds == total_adds_before
+    # No read-side accesses (we don't go through wm.get_item)
+    assert wm.total_accesses == total_accesses_before
+
+
+def test_extractor_recovers_from_broken_component():
+    """If a single component raises, the extractor must still return
+    a valid RouterInput with defaults for that component."""
+    # Broken episodic.
+    class _BadEpisodic:
+        def recall(self, cue, k=5):
+            raise RuntimeError("episodic-boom")
+
+    ri = extract_router_input(
+        wm=_make_wm(),
+        snarc={"surprise": 0.5},
+        metabolic=_MetabolicStub(),
+        episodic=_BadEpisodic(),
+        episodic_cue=object(),
+        cerebellum=_CerebellumStub(matches=[_HabitMatchStub(0.8)]),
+        cerebellum_state=object(),
+        tick=1,
+        goal_id="g1",
+    )
+    # Episodic defaulted
+    assert ri.recall_count == 0
+    assert ri.recall_best_similarity == 0.0
+    # Cerebellum still works
+    assert ri.habit_available is True
+    assert ri.habit_confidence == 0.8
+
+
+def test_missing_cue_and_state_means_optional_components_inert():
+    """Providing episodic + cerebellum but no cue/state means they
+    are inert — the extractor reads defaults rather than calling them."""
+    episodic = _EpisodicStub(results=[_RecallStub(0.9, 0.5)])
+    cerebellum = _CerebellumStub(matches=[_HabitMatchStub(0.9)])
+    ri = extract_router_input(
+        wm=_make_wm(),
+        episodic=episodic,
+        cerebellum=cerebellum,
+        tick=1,
+        goal_id="g1",
+        episodic_cue=None,
+        cerebellum_state=None,
+    )
+    assert ri.recall_count == 0
+    assert ri.habit_available is False
+    assert episodic.calls == 0
+    assert cerebellum.calls == 0


### PR DESCRIPTION
## Track
Phase 0, Track 2 — feature extraction (per `shared-context/arc-agi-3/phase2/brain-arch/router-sprint-1-phase-0.md`)

## What this ships

- `sage/cognition/router/feature_extraction.py`
  - `extract_router_input(wm, snarc, metabolic, episodic, cerebellum, rpe, metacog, plugin_registry, sensory, *, tick, goal_id, timestamp, episodic_cue, cerebellum_state, cartridge) -> RouterInput`
  - 9 pure per-component sub-extractors, each accepts `None` and returns defaults:
    - `_extract_wm_features` — reads `wm.stable_key(goal_id)`, `wm.slots`, `wm.capacity`
    - `_extract_snarc_features` — accepts dict or attr-bag; clamps [0,1] / [-1,1]
    - `_extract_metabolic_features` — enum or str state; `atp_current`; `get_atp_trend()` or `atp_trend`
    - `_extract_episodic_features` — `episodic.recall(cue, k)`; parses top-k similarity + reward
    - `_extract_cerebellum_features` — `cerebellum.lookup(state)`; reads best-match confidence
    - `_extract_rpe_features` — `rpe.get_action_priors(wm_state_key, ['invoke','habit','noop'])`; uniform prior when absent
    - `_extract_metacog_features` — callable, attr, dict, or iterable; filters non-strings
    - `_extract_sensory_features` — modalities may be list or dict; clamps novelty/urgency
    - `_extract_cartridge_features` — Phase 0 stub (zeros, length 768)
- `sage/cognition/router/tests/test_feature_extraction.py` — 67 tests

## What this does NOT ship (deferred to other tracks)

- Consciousness-loop integration at step 5 (Track 5)
- Real episodic cue / cerebellum state construction from kernel state (Track 5)
- Andy's routing-role cartridge wiring (coordinated separately — `shared-context/arc-agi-3/fleet-learning/waving-cat/router-cartridge-invitation.md`)
- Plugin registry consumption (kwarg reserved, unused at Phase 0)
- Programmatic baseline dispatcher (Track 3)

## Tests added

67 unit tests covering sprint-doc acceptance criteria:
- **Sub-extractor correctness** (per component): None path, populated path, clamping, enum-or-str handling, dict-or-attr handling, failure isolation
- **Top-level acceptance scenarios**: all-present, sparse-present (WM + SNARC + metabolic only), all-stubbed, edge cases (empty WM, zero salience, missing goal_id)
- **Determinism**: same inputs → identical `RouterInput.to_dict()`
- **Vector length invariance**: `to_dict()` key set identical across all component-presence combinations; embedding always 768-long
- **Purity**: repeated extraction does not mutate the WM (no new adds, no access-count bump)
- **Failure isolation**: a broken component does not propagate; extractor returns defaults for that component only
- **Training-serving binding**: RPE is called with the WM-derived state_key (PRD §4.7.G)
- **JSON round-trip**: extracted RouterInput round-trips through `to_dict`/`from_dict`

## Test results

```
$ python3 -m pytest sage/cognition/router/tests/test_feature_extraction.py -v
... 67 passed, 1 warning in 3.94s

$ python3 -m pytest sage/cognition/router/ -v
... 132 passed, 1 warning in 8.78s
```

Combined router suite: 132/132 pass (65 prior from Tracks 1 + 4 + 67 new).

## Acceptance criteria from sprint doc

- [x] Extraction is deterministic for fixed inputs
- [x] Feature vector length is fixed regardless of which optional components are None
- [x] Tests cover the missing-component matrix (all-present / sparse / all-stubbed)
- [x] Mock-friendly — every sub-extractor accepts None
- [x] Combined router test suite remains green
- [x] No torch dependency
- [x] All output JSON-serializable (RouterInput enforces)
- [x] Failure isolation — broken component returns defaults rather than raising

## Reviewer notes

### Which PRD §2 components consume which RouterInput fields

| Sub-extractor | Component (PRD §) | RouterInput fields |
|---|---|---|
| WM | §2.1 WorkingMemory (v0.2) | `wm_state_key`, `wm_slot_counts`, `wm_goal_active`, `wm_age_ticks`, `wm_pressure` |
| SNARC | §2.2 SNARC | `snarc_surprise`, `snarc_novelty`, `snarc_arousal`, `snarc_reward`, `snarc_conflict` |
| Metabolic | §2.3 MetabolicController | `metabolic_state`, `atp_level`, `atp_trend` |
| Episodic | §2.4 EpisodicIndex (Thor) | `recall_count`, `recall_best_similarity`, `recall_best_outcome` |
| Cerebellum | §2.5 Cerebellum (McNugget) | `habit_available`, `habit_confidence` |
| RPE | §2.6 RewardPredictionError (Legion) | `prior_invoke`, `prior_habit`, `prior_noop` |
| Metacog | §2.7 Metacog (Nomad) | `metacog_block_list` |
| Plugin registry | §2.8 | (reserved — kwarg unused at Phase 0) |
| Cartridge | §2.9 Andy's routing-role cartridge | `cartridge_recall_count`, `cartridge_recall_best_similarity`, `cartridge_recall_embedding` |
| Sensory | §2.10 consciousness-loop step 5 input | `sensory_modalities`, `sensory_novelty`, `sensory_urgency` |

### Defaults chosen for component-None paths

- **WM None**: `wm_state_key = '0' * 16`. Chose a canonical sentinel rather than an empty string so "missing WM" records are distinguishable from real ones. Slot counts empty, `wm_goal_active=False`, `wm_pressure=0.0`, `wm_age_ticks=0`.
- **SNARC None**: all zeros. Low-salience is the correct "no information" encoding for SNARC.
- **Metabolic None**: `metabolic_state='wake'` (the PRD default), `atp_level=0.0`, `atp_trend='stable'`. Low ATP is conservative — downstream gating in step 6 will read this as "don't invoke expensive tiers."
- **Episodic None**: `recall_count=0`, `recall_best_similarity=0.0`, `recall_best_outcome=None`. Episodic may be absent before Phase 3 integration.
- **Cerebellum None**: `habit_available=False`, `habit_confidence=0.0`. Safe default — router chooses from invoke/noop.
- **RPE None**: uniform prior `1/3` across invoke/habit/noop. Deliberate "no information" encoding; sums to 1.0 so downstream consumers see a valid distribution. RPE is not expected before Phase 4.
- **Metacog None**: empty block list.
- **Sensory None**: empty modalities, zero novelty/urgency.

### Stubbed pending other tracks

- **Cartridge** — always returns zeros (count=0, similarity=0.0, 768-dim zero vector) regardless of whether a cartridge object is passed. Per sprint-doc Track 2: "Cartridge_recall_* fields stubbed to zero for Phase 0; real values arrive once Andy's routing-role cartridge is wired." The kwarg is plumbed through so a later track can drop in a real call without a signature change.
- **Plugin registry** — kwarg is accepted but never read. Reserved for Phase 1+ when it wires into cartridge search context and plugin-tier lookups.

### Design notes

- **Fixed feature-vector shape is mandatory** (sprint-doc Track 2 acceptance): every combination of None/populated components produces the same `RouterInput.to_dict()` key set, verified in `test_feature_vector_length_fixed_regardless_of_none_components`. The cartridge embedding is always exactly 768 floats (`CARTRIDGE_EMBEDDING_DIM` from Track 1). If this contract breaks, the router model trained on old data is invalidated.
- **RPE state_key binds to WM state_key** (PRD §4.7.G guards against training-serving skew). The top-level extractor computes `wm_state_key` first, then passes it to RPE — so serving-time features always come from the same SNARC-state-keyed path training-time features did.
- **Failure isolation is defense-in-depth**: each sub-extractor catches its own exceptions and returns defaults (logged at WARNING). The top-level extractor does not add a second try/except around sub-extractor calls — sub-extractors are responsible for their own safety. This matches the Track 5 integration-layer philosophy: "pipeline failures must NEVER break the consciousness loop."
- **Purity is tested, not just documented**: `test_extractor_does_not_mutate_inputs` runs the extractor twice against a real `WorkingMemory` and asserts `total_adds` / `total_accesses` / slot map are unchanged. Sub-extractors never call `wm.get_item` (which bumps access counts) — only `wm.slots` / `wm.capacity` / `wm.stable_key` which are read-only.

## Dependencies

- Track 1 (schemas) — MERGED, consumed via `from sage.cognition.router import RouterInput, CARTRIDGE_EMBEDDING_DIM`
- Track 4 (dataset writer/reader) — MERGED, not consumed here (Track 5 wires both together)

🤖 Generated with [Claude Code](https://claude.com/claude-code)