### PR TITLE
[router] Phase 0 Track 6: outcome backfill via sidecar partitions

### DIFF
--- a/sage/cognition/router/__init__.py
+++ b/sage/cognition/router/__init__.py
@@ -36,6 +36,14 @@ from sage.cognition.router.shadow import (
     SHADOW_ENV_VAR,
     is_shadow_enabled,
 )
+from sage.cognition.router.outcome import (
+    OutcomeTracker,
+    OUTCOME_SCHEMA_VERSION,
+    TRAJECTORY_TICKS,
+    STATUS_COMPLETE,
+    STATUS_INCOMPLETE,
+    STATUS_FAILED,
+)
 
 __all__ = [
     # Dataclasses
@@ -49,6 +57,13 @@ __all__ = [
     "RouterShadowHook",
     "SHADOW_ENV_VAR",
     "is_shadow_enabled",
+    # Outcome tracker (Track 6)
+    "OutcomeTracker",
+    "OUTCOME_SCHEMA_VERSION",
+    "TRAJECTORY_TICKS",
+    "STATUS_COMPLETE",
+    "STATUS_INCOMPLETE",
+    "STATUS_FAILED",
     # Constants
     "ROUTER_SCHEMA_VERSION",
     "CARTRIDGE_EMBEDDING_DIM",

--- a/sage/cognition/router/data/__init__.py
+++ b/sage/cognition/router/data/__init__.py
@@ -41,6 +41,7 @@ from sage.cognition.router.data.writer import (
 from sage.cognition.router.data.reader import (
     RouterDatasetReader,
     SUPPORTED_SCHEMA_VERSIONS,
+    OUTCOME_FILE_PREFIX,
 )
 from sage.cognition.router.data.pruner import (
     RouterDatasetPruner,
@@ -60,6 +61,7 @@ __all__ = [
     "salience_score",
     "SCHEMA_VERSION",
     "SUPPORTED_SCHEMA_VERSIONS",
+    "OUTCOME_FILE_PREFIX",
     "RouterDatasetPruner",
     "PruneStats",
     "AGE_BRACKETS",

--- a/sage/cognition/router/data/reader.py
+++ b/sage/cognition/router/data/reader.py
@@ -9,6 +9,10 @@ Responsibilities:
   * Read across partitions via glob patterns (machine + date range).
   * Handle partial / corrupt trailing lines without crashing — reads are
     best-effort; diagnostic info goes to a logger, not an exception.
+  * Auto-merge Track 6 outcome sidecar partitions by ``record_id`` at
+    read time. Main partitions remain append-only; outcomes live in
+    parallel ``outcome_{date}.jsonl[.gz]`` files. Forensic readers that
+    want pre-backfill state can opt out via ``merge_outcomes=False``.
 
 Schema-version-awareness: the reader doesn't *migrate* old records to
 new shapes (migrations are out of scope for Phase 0, per sprint doc).
@@ -31,6 +35,12 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 # version OUTSIDE this set still yield; we just emit a warn so the
 # operator can add the version to the registry when upstream evolves.
 SUPPORTED_SCHEMA_VERSIONS: set = {"0.1.0"}
+
+
+# Track 6 outcome sidecar: filename prefix and glob patterns. The reader
+# auto-merges ``outcome_{date}.jsonl[.gz]`` into main-partition records
+# when ``merge_outcomes=True`` (default). See module docstring.
+OUTCOME_FILE_PREFIX: str = "outcome_"
 
 
 # Default fill-ins for fields a v0.1.0 consumer might expect. Empty for
@@ -60,6 +70,13 @@ class RouterDatasetReader:
 
     def __init__(self, base_dir: Union[str, Path]):
         self.base_dir = Path(base_dir)
+
+    # ── outcome sidecar helpers ───────────────────────────────────
+
+    @staticmethod
+    def _is_outcome_file(path: Path) -> bool:
+        """True if ``path`` is an outcome sidecar partition."""
+        return path.name.startswith(OUTCOME_FILE_PREFIX)
 
     # ── single-file iteration ─────────────────────────────────────
 
@@ -118,6 +135,7 @@ class RouterDatasetReader:
         self,
         machine: str = "*",
         date_range: Optional[Tuple[Union[str, date], Union[str, date]]] = None,
+        merge_outcomes: bool = True,
     ) -> Iterator[Dict[str, Any]]:
         """Iterate records across multiple partition files.
 
@@ -128,19 +146,63 @@ class RouterDatasetReader:
         date_range:
             Optional (start, end) inclusive, each as ``YYYY-MM-DD`` string
             or ``datetime.date``. None → no date filter.
+        merge_outcomes:
+            When True (default), records are merged with Track 6 outcome
+            sidecar entries by ``record_id`` before being yielded. Set
+            False for forensic replays that want the exact on-disk
+            main-partition state (no post-hoc outcomes).
 
         Yields records in file-order (deterministic: sorted by path).
         """
+        outcome_index: Dict[str, Dict[str, Any]] = {}
+        if merge_outcomes:
+            # Prefetch all outcome sidecars once for this query. Memory
+            # footprint is bounded by the sampled partition size; the
+            # outcome dict per record is small (one trajectory of 5
+            # samples + a few scalars). This is the simpler correct
+            # approach — if fleet-scale merges show pressure later, we
+            # can switch to a per-partition date-aligned stream join.
+            outcome_index = self._build_outcome_index(machine, date_range)
+
         for partition_path in self._resolve_partitions(machine, date_range):
-            yield from self.read_file(partition_path)
+            for record in self.read_file(partition_path):
+                if merge_outcomes:
+                    record = self._apply_outcome(record, outcome_index)
+                yield record
 
     def list_partitions(
         self,
         machine: str = "*",
         date_range: Optional[Tuple[Union[str, date], Union[str, date]]] = None,
     ) -> List[Path]:
-        """Return all partition paths matching the filter, sorted."""
+        """Return all (main) partition paths matching the filter, sorted.
+
+        Outcome sidecar partitions are excluded. Use
+        ``list_outcome_partitions`` to enumerate those separately.
+        """
         return sorted(self._resolve_partitions(machine, date_range))
+
+    def list_outcome_partitions(
+        self,
+        machine: str = "*",
+        date_range: Optional[Tuple[Union[str, date], Union[str, date]]] = None,
+    ) -> List[Path]:
+        """Return all outcome sidecar partition paths matching the filter."""
+        return sorted(self._resolve_outcome_partitions(machine, date_range))
+
+    def read_outcomes(
+        self,
+        machine: str = "*",
+        date_range: Optional[Tuple[Union[str, date], Union[str, date]]] = None,
+    ) -> Iterator[Dict[str, Any]]:
+        """Iterate raw outcome sidecar records (record_id + outcome dict).
+
+        Useful for analytics / debugging. The normal training replay
+        path should use ``read_partition(merge_outcomes=True)`` so the
+        outcome arrives attached to its parent record.
+        """
+        for path in self._resolve_outcome_partitions(machine, date_range):
+            yield from self.read_file(path)
 
     # ── internals ─────────────────────────────────────────────────
 
@@ -149,7 +211,33 @@ class RouterDatasetReader:
         machine: str,
         date_range: Optional[Tuple[Union[str, date], Union[str, date]]],
     ) -> List[Path]:
-        """Glob + date filter. Returns sorted list (stable iteration)."""
+        """Glob + date filter. Returns sorted list (stable iteration).
+
+        Outcome sidecar partitions (prefix ``outcome_``) are EXCLUDED.
+        """
+        return self._resolve_partitions_filtered(
+            machine, date_range, outcome_only=False,
+        )
+
+    def _resolve_outcome_partitions(
+        self,
+        machine: str,
+        date_range: Optional[Tuple[Union[str, date], Union[str, date]]],
+    ) -> List[Path]:
+        """Same filter as ``_resolve_partitions`` but only outcome files."""
+        return self._resolve_partitions_filtered(
+            machine, date_range, outcome_only=True,
+        )
+
+    def _resolve_partitions_filtered(
+        self,
+        machine: str,
+        date_range: Optional[Tuple[Union[str, date], Union[str, date]]],
+        outcome_only: bool,
+    ) -> List[Path]:
+        """Shared glob + date filter. ``outcome_only`` toggles which
+        partition family is returned.
+        """
         if not self.base_dir.exists():
             return []
 
@@ -158,6 +246,12 @@ class RouterDatasetReader:
         candidates: List[Path] = []
         for pat in patterns:
             candidates.extend(self.base_dir.glob(pat))
+
+        # Split main from outcome sidecars.
+        candidates = [
+            p for p in candidates
+            if self._is_outcome_file(p) == outcome_only
+        ]
 
         if date_range is None:
             return sorted(candidates)
@@ -172,6 +266,9 @@ class RouterDatasetReader:
                 if stem.endswith(suffix):
                     stem = stem[: -len(suffix)]
                     break
+            # Strip outcome_ prefix if present (for outcome partitions).
+            if stem.startswith(OUTCOME_FILE_PREFIX):
+                stem = stem[len(OUTCOME_FILE_PREFIX):]
             try:
                 d = datetime.strptime(stem, "%Y-%m-%d").date()
             except ValueError:
@@ -180,6 +277,56 @@ class RouterDatasetReader:
             return start_d <= d <= end_d
 
         return sorted([p for p in candidates if in_range(p)])
+
+    def _build_outcome_index(
+        self,
+        machine: str,
+        date_range: Optional[Tuple[Union[str, date], Union[str, date]]],
+    ) -> Dict[str, Dict[str, Any]]:
+        """Load all outcome sidecar entries in the query range into a dict.
+
+        Keyed by ``record_id``. On conflict (same record_id appears in
+        multiple sidecars, e.g. a buggy retry) the LATER-emitted wins
+        (by ``emitted_at``). Missing ``emitted_at`` sorts as 0, so a
+        properly-timestamped later emission always overrides.
+        """
+        index: Dict[str, Dict[str, Any]] = {}
+        timestamps: Dict[str, float] = {}
+        for path in self._resolve_outcome_partitions(machine, date_range):
+            for entry in self.read_file(path):
+                rid = entry.get("record_id")
+                if not rid:
+                    continue
+                ts = float(entry.get("emitted_at", 0.0) or 0.0)
+                if rid in index and timestamps.get(rid, 0.0) >= ts:
+                    continue
+                index[rid] = entry
+                timestamps[rid] = ts
+        return index
+
+    def _apply_outcome(
+        self,
+        record: Dict[str, Any],
+        outcome_index: Dict[str, Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Merge a sidecar outcome entry onto a record if present.
+
+        Non-destructive: a copy is returned only when a merge is needed,
+        otherwise the original dict is passed through. The ``outcome``
+        field on the record wins if it is already populated and
+        non-None — we never overwrite an existing outcome.
+        """
+        rid = record.get("record_id")
+        if not rid:
+            return record
+        if record.get("outcome") is not None:
+            return record
+        sidecar = outcome_index.get(rid)
+        if sidecar is None:
+            return record
+        merged = dict(record)
+        merged["outcome"] = sidecar.get("outcome")
+        return merged
 
     def _hydrate(self, record: Dict[str, Any]) -> Dict[str, Any]:
         """Fill defaults + log schema version mismatches."""

--- a/sage/cognition/router/outcome.py
+++ b/sage/cognition/router/outcome.py
@@ -1,0 +1,963 @@
+#!/usr/bin/env python3
+"""
+Outcome tracking — Phase 0 Track 6.
+===================================
+
+``OutcomeTracker`` backfills every written ``RouterRecord`` with an
+observed outcome: the 5-tick post-decision SNARC trajectory, a scalar
+``snarc_resolution_score`` per PRD §4.7.E, an optional RPE signal, and
+a ``level_up_observed`` flag (game-specific; optional for Phase 0).
+
+Why this exists
+---------------
+
+Track 5's ``RouterShadowHook`` writes records to the main dataset
+partition as soon as a decision is made. At write time, the outcome
+cannot be known — it lives in the *next* 5 ticks. The Track 6 tracker
+watches subsequent ticks, accumulates per-record SNARC trajectories,
+and emits a standalone outcome record to a **sidecar** partition keyed
+by ``record_id``. The reader merges the main partition with the sidecar
+at load time (see ``sage.cognition.router.data.reader``).
+
+Sidecar vs rewrite — design choice
+----------------------------------
+
+We deliberately do NOT rewrite the main partition to add outcomes.
+Reasons:
+
+1. **Append-only discipline of the writer**. ``RouterDatasetWriter``
+   keeps a gzip handle open across flushes. Rewriting the partition
+   means coordinating with a live writer — race-prone, expensive.
+2. **Atomicity**. Rewriting a gzipped JSONL file means decoding,
+   editing, recompressing, atomic-renaming. One bug drops the whole
+   day's data. Sidecars never touch the main file.
+3. **Reproducibility**. Main partition is immutable once a day ends.
+   Forensic reads ("what did we know at decision time?") are trivially
+   available. "What was the outcome?" is a join, not a mutation.
+4. **Failure isolation**. A broken outcome pipeline can NEVER corrupt
+   the primary dataset. Disable the tracker, delete the sidecars, re-
+   ingest cleanly. This is the same discipline PRD §5.5 asks of the
+   writer itself.
+5. **Pruning independence**. Track 9 prunes main partitions by SNARC
+   quintile. Outcomes for dropped records become orphans in sidecars,
+   but the reader's merge is a left-outer join — orphan outcomes never
+   surface without a matching record. A later pruner pass can sweep
+   orphan outcome files by age.
+
+Sidecar filename convention
+---------------------------
+
+    {base_dir}/{machine}/outcome_{YYYY-MM-DD}.jsonl[.gz]
+
+Same daily rollover as main partitions. Uses ``RouterDatasetWriter``
+under the hood with a ``machine`` subpath that embeds "outcome_" into
+the filename — see ``_OutcomeWriter`` below.
+
+Edge cases handled
+------------------
+
+* **Tick gap > window**. If we buffer a record at tick N and the next
+  observation arrives at tick N+10 (window is 5), the outcome is
+  emitted immediately on flush with ``status='incomplete'`` and
+  whatever partial trajectory accumulated.
+* **Kernel restart mid-buffer**. The in-memory buffer is persisted to
+  ``{base_dir}/{machine}/outcome_buffer.json`` on every ``flush()``
+  and on ``close()``. ``load_buffer()`` restores it. Resumption is
+  best-effort — if the tick counter has advanced, stale records are
+  flushed with ``status='incomplete'``.
+* **Plugin failure mid-dispatch**. Callers can pass ``failure=True``
+  to ``observe_tick`` (for the decision tick's own record) or later;
+  we record ``status='failed'`` with whatever trajectory exists.
+* **Ordering**. Observations must be monotonic in ``tick``. Out-of-
+  order observations are logged and ignored. This matches the
+  consciousness loop's single-threaded tick semantics.
+* **No-op**. A decision whose observations never arrive flushes at
+  ``close()`` with ``status='incomplete'`` so we always have a record
+  on disk for every recorded decision.
+
+Failure isolation
+-----------------
+
+Every method swallows exceptions. The tracker never propagates an
+error into the consciousness loop. Disk failures, serialization
+failures, and buffer-restore failures all log at WARNING and continue.
+
+No torch dependency. Pure stdlib.
+
+Spec:
+  - PRD §4.7.E (SNARC trajectory as outcome signal)
+  - PRD §5 (record shape, sidecar governance)
+  - Sprint doc Track 6 (router-sprint-1-phase-0.md)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+
+from sage.cognition.router.data.writer import RouterDatasetWriter
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Schema + constants
+# ──────────────────────────────────────────────────────────────────────
+
+# Outcome schema version. Distinct from the record-level
+# ``ROUTER_SCHEMA_VERSION`` — outcome shape evolves independently.
+# Consumers MUST key off this rather than the record schema.
+OUTCOME_SCHEMA_VERSION: str = "v0.1.0"
+
+# PRD §4.7.E says "5-tick post-decision SNARC trajectory". We collect
+# ticks t+1 .. t+TRAJECTORY_TICKS inclusive — i.e. 5 samples after the
+# decision tick. The decision-tick SNARC itself is the baseline (t0).
+# Changing this is NOT a free knob — any change MUST bump
+# ``OUTCOME_SCHEMA_VERSION`` and propagate to the reader's merge logic.
+TRAJECTORY_TICKS: int = 5
+
+# SNARC dimensions we track for resolution scoring. Subset of the
+# SNARC vector PRD §3.1 declares on RouterInput: arousal/conflict/
+# surprise are the "dominant features" PRD §4.7.E flags. Reward and
+# novelty are recorded too (for trajectory completeness) but not
+# counted toward ``snarc_resolution_score``.
+RESOLUTION_DIMS: Tuple[str, ...] = ("arousal", "conflict", "surprise")
+ALL_SNARC_DIMS: Tuple[str, ...] = (
+    "arousal", "conflict", "surprise", "reward", "novelty",
+)
+
+# Status values for the outcome record.
+STATUS_COMPLETE: str = "complete"      # full window observed
+STATUS_INCOMPLETE: str = "incomplete"  # tick gap / flush before window closed
+STATUS_FAILED: str = "failed"          # plugin failure reported during window
+
+# Subdirectory + filename prefix for sidecar partitions. The underlying
+# writer lays out ``{base_dir}/{machine}/`` — we encode "outcome_" into
+# the prefix by using a writer-machine-name trick (see _OutcomeWriter).
+OUTCOME_FILE_PREFIX: str = "outcome_"
+
+# Buffer-persistence filename. Lives alongside main partitions per
+# machine — simpler than a separate directory.
+BUFFER_FILENAME: str = "outcome_buffer.json"
+
+_log = logging.getLogger(__name__)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Data shapes
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _PendingOutcome:
+    """An outcome record still accumulating its SNARC trajectory.
+
+    Intentionally minimal — the buffer is hot at fleet scale (one per
+    kept decision per machine per tick). Anything that isn't needed to
+    materialize the final outcome stays off this dataclass.
+
+    Fields
+    ------
+    record_id:
+        ``RouterRecord.record_id`` — primary key of the sidecar write.
+    tick_at_decision:
+        Loop tick when the decision was made. Trajectory samples must
+        have ``tick > tick_at_decision`` and are counted in order.
+    snarc_at_decision:
+        Dict of SNARC values at t0. Used to identify the dominant
+        dimension for ``snarc_resolution_score`` per PRD §4.7.E.
+    trajectory:
+        List of (tick, {snarc_dim: float}) tuples, in observation order.
+        Truncated to ``TRAJECTORY_TICKS`` samples at most.
+    rpe_signal:
+        Optional scalar RPE observed in the window. Phase 4+ wiring.
+    level_up_observed:
+        Optional bool; game-specific flag set via ``observe_tick``.
+    failure:
+        Optional bool; set True when a plugin failure is reported.
+    decision_timestamp:
+        Wall-clock seconds at decision — for staleness checks on
+        resume. Not part of the emitted outcome.
+    """
+
+    record_id: str
+    tick_at_decision: int
+    snarc_at_decision: Dict[str, float]
+    trajectory: List[Tuple[int, Dict[str, float]]] = field(default_factory=list)
+    rpe_signal: Optional[float] = None
+    level_up_observed: Optional[bool] = None
+    failure: bool = False
+    decision_timestamp: float = field(default_factory=time.time)
+
+    def to_json(self) -> Dict[str, Any]:
+        """Serialize for buffer persistence. NOT the outcome schema."""
+        return {
+            "record_id": self.record_id,
+            "tick_at_decision": self.tick_at_decision,
+            "snarc_at_decision": dict(self.snarc_at_decision),
+            "trajectory": [(int(t), dict(s)) for t, s in self.trajectory],
+            "rpe_signal": self.rpe_signal,
+            "level_up_observed": self.level_up_observed,
+            "failure": bool(self.failure),
+            "decision_timestamp": float(self.decision_timestamp),
+        }
+
+    @classmethod
+    def from_json(cls, data: Dict[str, Any]) -> "_PendingOutcome":
+        traj = [
+            (int(t), {str(k): float(v) for k, v in s.items()})
+            for t, s in data.get("trajectory", [])
+        ]
+        return cls(
+            record_id=str(data["record_id"]),
+            tick_at_decision=int(data["tick_at_decision"]),
+            snarc_at_decision={str(k): float(v) for k, v in
+                               data.get("snarc_at_decision", {}).items()},
+            trajectory=traj,
+            rpe_signal=data.get("rpe_signal"),
+            level_up_observed=data.get("level_up_observed"),
+            failure=bool(data.get("failure", False)),
+            decision_timestamp=float(data.get("decision_timestamp", time.time())),
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Sidecar writer wrapper
+# ──────────────────────────────────────────────────────────────────────
+
+
+class _OutcomeWriter:
+    """Thin shim that funnels outcome records to an ``outcome_{date}``
+    sidecar partition using ``RouterDatasetWriter`` machinery.
+
+    The underlying writer expects ``{base_dir}/{machine}/{date}.jsonl``.
+    We achieve the ``outcome_`` filename prefix by passing a
+    ``machine`` directory that points at the real machine subpath but
+    passing a custom ``clock`` that prefixes the date. That is too
+    clever. Simpler: we just write the JSONL ourselves, using the same
+    atomic append+flush+gzip discipline, but keyed on the filename
+    convention we need.
+
+    This class is intentionally small — Track 4 already did the work of
+    proving JSONL append-with-rollover correct. We copy the pattern
+    rather than reusing the class to keep failure isolation tight: an
+    outcome writer failure must not take the main writer down with it.
+    """
+
+    def __init__(
+        self,
+        base_dir: Union[str, Path],
+        machine: str,
+        compress: bool = True,
+        buffer_size: int = 64,
+        clock: Optional[Any] = None,
+    ) -> None:
+        if not machine or "/" in machine or "\\" in machine:
+            raise ValueError(f"machine must be a simple name, got {machine!r}")
+        # Delegate to a RouterDatasetWriter that thinks it's writing to
+        # machine subdir ``{machine}`` but with partition names prefixed
+        # by "outcome_". We can't change the writer's filename format
+        # without invasive surgery, so we override via subclassing.
+        self._inner = _PrefixedDatasetWriter(
+            base_dir=base_dir,
+            machine=machine,
+            compress=compress,
+            buffer_size=buffer_size,
+            clock=clock,
+            filename_prefix=OUTCOME_FILE_PREFIX,
+        )
+
+    def append(self, outcome_record: Dict[str, Any]) -> bool:
+        """Queue one outcome dict. Never raises."""
+        try:
+            return bool(self._inner.append(outcome_record))
+        except Exception as e:  # noqa: BLE001
+            _log.warning("outcome sidecar append failed: %s", e)
+            return False
+
+    def flush(self) -> None:
+        try:
+            self._inner.flush()
+        except Exception as e:  # noqa: BLE001
+            _log.warning("outcome sidecar flush failed: %s", e)
+
+    def close(self) -> None:
+        try:
+            self._inner.close()
+        except Exception as e:  # noqa: BLE001
+            _log.warning("outcome sidecar close failed: %s", e)
+
+    def current_path(self) -> Optional[Path]:
+        return self._inner.current_path()
+
+    def get_stats(self) -> Dict[str, Any]:
+        return self._inner.get_stats()
+
+
+class _PrefixedDatasetWriter(RouterDatasetWriter):
+    """RouterDatasetWriter that prepends a filename prefix to partitions.
+
+    Same partition layout — ``{base_dir}/{machine}/{prefix}{date}.jsonl[.gz]``.
+    Used by ``_OutcomeWriter`` to emit ``outcome_YYYY-MM-DD.jsonl[.gz]``
+    alongside the main partitions without needing a separate subdir.
+    """
+
+    def __init__(self, *args: Any, filename_prefix: str = "", **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._filename_prefix = filename_prefix
+
+    def _ensure_partition(self) -> None:  # type: ignore[override]
+        today = self._clock().strftime("%Y-%m-%d")
+        ext = ".jsonl.gz" if self.compress else ".jsonl"
+        fname = f"{self._filename_prefix}{today}{ext}"
+        partition = self.base_dir / self.machine / fname
+
+        if self._current_path == partition and self._current_handle is not None:
+            return
+
+        # Close previous handle.
+        if self._current_handle is not None:
+            try:
+                self._current_handle.close()
+            except Exception as e:  # pragma: no cover
+                _log.exception("Error closing previous outcome partition: %s", e)
+            self._current_handle = None
+            self._current_path = None
+
+        try:
+            partition.parent.mkdir(parents=True, exist_ok=True)
+            if self.compress:
+                import gzip as _gzip
+                handle: Any = _gzip.open(str(partition), "at", encoding="utf-8")
+            else:
+                handle = open(partition, "a", encoding="utf-8")
+            self._current_handle = handle
+            self._current_path = partition
+        except Exception as e:
+            _log.exception("Failed to open outcome partition %s: %s", partition, e)
+            self._current_handle = None
+            self._current_path = None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# OutcomeTracker
+# ──────────────────────────────────────────────────────────────────────
+
+
+class OutcomeTracker:
+    """Backfill ``RouterRecord`` outcomes via SNARC-trajectory observation.
+
+    Lifecycle
+    ---------
+
+    1. ``RouterShadowHook`` writes a record to the main partition and
+       calls ``tracker.register_decision(record_id, tick, snarc_at_decision)``
+       to buffer a pending outcome.
+    2. On each subsequent tick, the consciousness loop calls
+       ``tracker.observe_tick(tick, snarc, rpe_signal=..., level_up=...)``.
+       Every pending record whose tick window includes the current tick
+       gets one more trajectory sample.
+    3. When a pending record's window closes (i.e. ``TRAJECTORY_TICKS``
+       samples collected, OR the next observation's tick exceeds
+       ``tick_at_decision + TRAJECTORY_TICKS``), its outcome is emitted
+       to the sidecar writer and the pending entry is discarded.
+    4. ``tracker.flush()`` emits any remaining pending outcomes with
+       ``status='incomplete'``. ``tracker.close()`` calls ``flush()``
+       and closes the writer handle.
+
+    Buffer persistence
+    ------------------
+
+    On every ``flush()`` / ``close()``, the pending buffer is
+    serialized to ``{base_dir}/{machine}/outcome_buffer.json``. On
+    construction, ``load_buffer()`` reads it back if it exists. A
+    crashed kernel loses AT MOST one ``flush_interval`` of buffered
+    pending outcomes; those records' outcomes will be absent from the
+    sidecar (the reader surfaces them with ``outcome=None``).
+
+    Parameters
+    ----------
+    base_dir:
+        Root of the router dataset layout (same as the writer's).
+    machine:
+        Machine name — matches the writer's machine subdir.
+    compress:
+        Gzip sidecar partitions. Default True, matches writer default.
+    buffer_size:
+        Sidecar writer flush threshold (records). Default 64.
+    max_pending:
+        Soft cap on the in-memory pending buffer. When exceeded, the
+        oldest pending entry is evicted + flushed with
+        ``status='incomplete'``. Guards against an unbounded buffer
+        if ``observe_tick`` stops being called for any reason.
+    clock:
+        Optional callable returning current UTC datetime. Forwarded
+        to the sidecar writer for deterministic test partitions.
+
+    Notes
+    -----
+    * The tracker is single-threaded by design. The consciousness loop
+      runs it from the loop thread; no locking. If a future architecture
+      calls ``observe_tick`` from multiple threads, wrap with a lock.
+    * Out-of-order ticks are rejected (logged, ignored). The
+      consciousness loop is monotonic in tick; an out-of-order tick
+      indicates either a reset (handle by re-instantiating the tracker)
+      or a bug.
+    """
+
+    # Maximum pending entries before the oldest is force-evicted.
+    DEFAULT_MAX_PENDING: int = 4096
+
+    def __init__(
+        self,
+        base_dir: Union[str, Path],
+        machine: str,
+        compress: bool = True,
+        buffer_size: int = 64,
+        max_pending: int = DEFAULT_MAX_PENDING,
+        clock: Optional[Any] = None,
+    ) -> None:
+        if max_pending < 1:
+            raise ValueError(f"max_pending must be >= 1, got {max_pending}")
+        self.base_dir = Path(base_dir)
+        self.machine = machine
+        self.max_pending = max_pending
+
+        # OrderedDict preserves insertion order — ``popitem(last=False)``
+        # evicts the oldest entry when the cap is hit.
+        self._pending: "OrderedDict[str, _PendingOutcome]" = OrderedDict()
+
+        self._writer = _OutcomeWriter(
+            base_dir=base_dir,
+            machine=machine,
+            compress=compress,
+            buffer_size=buffer_size,
+            clock=clock,
+        )
+        # Path to the persisted buffer.
+        self._buffer_path = self.base_dir / machine / BUFFER_FILENAME
+
+        # Observability counters.
+        self.decisions_registered: int = 0
+        self.outcomes_emitted_complete: int = 0
+        self.outcomes_emitted_incomplete: int = 0
+        self.outcomes_emitted_failed: int = 0
+        self.ticks_observed: int = 0
+        self.out_of_order_observations: int = 0
+        self.evictions: int = 0
+        self.errors: int = 0
+        self._last_observed_tick: Optional[int] = None
+        self._closed: bool = False
+
+        # Best-effort restore — any failure logs + continues with an
+        # empty buffer.
+        try:
+            self._load_buffer()
+        except Exception as e:  # noqa: BLE001
+            _log.warning("outcome buffer restore failed: %s", e)
+
+    # ── context manager ──────────────────────────────────────────────
+
+    def __enter__(self) -> "OutcomeTracker":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    # ── public API ───────────────────────────────────────────────────
+
+    def register_decision(
+        self,
+        record_id: str,
+        tick_at_decision: int,
+        snarc_at_decision: Dict[str, float],
+    ) -> bool:
+        """Begin tracking a decision's post-decision SNARC trajectory.
+
+        Returns True if registered. Returns False if the tracker is
+        closed or the record_id is already pending (we DO NOT overwrite
+        — an existing pending outcome must close first).
+
+        Never raises.
+        """
+        try:
+            if self._closed:
+                _log.warning("OutcomeTracker.register_decision after close; ignored")
+                return False
+            if not isinstance(record_id, str) or not record_id:
+                _log.warning("register_decision: bad record_id %r", record_id)
+                return False
+            if record_id in self._pending:
+                _log.warning("register_decision: %s already pending", record_id)
+                return False
+            snarc_clean = _coerce_snarc(snarc_at_decision)
+            pending = _PendingOutcome(
+                record_id=record_id,
+                tick_at_decision=int(tick_at_decision),
+                snarc_at_decision=snarc_clean,
+            )
+            self._pending[record_id] = pending
+            self.decisions_registered += 1
+
+            # Enforce cap — oldest evicted + flushed as incomplete.
+            while len(self._pending) > self.max_pending:
+                _, oldest = self._pending.popitem(last=False)
+                self.evictions += 1
+                self._emit_outcome(oldest, status=STATUS_INCOMPLETE,
+                                   resolved_at_tick=oldest.tick_at_decision)
+            return True
+        except Exception as e:  # noqa: BLE001
+            _log.warning("register_decision failed: %s", e)
+            self.errors += 1
+            return False
+
+    def observe_tick(
+        self,
+        tick: int,
+        snarc: Dict[str, float],
+        rpe_signal: Optional[float] = None,
+        level_up: Optional[bool] = None,
+        failed_record_ids: Optional[Iterable[str]] = None,
+    ) -> int:
+        """Feed one post-decision tick's SNARC (and optional signals).
+
+        Parameters
+        ----------
+        tick:
+            Current consciousness-loop tick. Must be monotonically
+            non-decreasing across calls — out-of-order ticks are
+            ignored.
+        snarc:
+            Dict of SNARC scalar values (arousal/conflict/surprise/
+            reward/novelty). Missing dims default to 0.0.
+        rpe_signal:
+            Optional scalar RPE observed this tick. Applied to ALL
+            currently-pending outcomes whose decision tick < tick.
+            Phase 4+ wiring.
+        level_up:
+            Optional bool; game-specific. Applied to all currently-
+            pending outcomes. ``None`` leaves the field untouched so a
+            later True observation wins.
+        failed_record_ids:
+            Optional iterable of record_ids whose dispatch failed this
+            tick. Those records' outcomes will emit with
+            ``status='failed'`` regardless of trajectory completeness.
+
+        Returns
+        -------
+        int
+            Number of outcomes emitted (window-closed or failed) on
+            this tick.
+
+        Never raises. Errors are counted + logged.
+        """
+        emitted = 0
+        try:
+            if self._closed:
+                _log.warning("observe_tick after close; ignored")
+                return 0
+            # Monotonic tick check — allow ties (same tick, multiple
+            # calls for different signals) but not regression.
+            if (self._last_observed_tick is not None
+                    and tick < self._last_observed_tick):
+                _log.warning(
+                    "observe_tick: out-of-order tick %d (last was %d); ignored",
+                    tick, self._last_observed_tick,
+                )
+                self.out_of_order_observations += 1
+                return 0
+            self._last_observed_tick = int(tick)
+            self.ticks_observed += 1
+
+            snarc_clean = _coerce_snarc(snarc)
+            failed = set(failed_record_ids) if failed_record_ids else set()
+
+            # We iterate a snapshot of the keys; emission mutates
+            # ``self._pending``.
+            for record_id in list(self._pending.keys()):
+                pending = self._pending.get(record_id)
+                if pending is None:  # emitted by another branch this loop
+                    continue
+
+                # Plugin failure? Emit as failed right now.
+                if record_id in failed:
+                    pending.failure = True
+                    self._pending.pop(record_id, None)
+                    self._emit_outcome(pending, status=STATUS_FAILED,
+                                       resolved_at_tick=int(tick))
+                    emitted += 1
+                    continue
+
+                # Decision-tick sample doesn't count — trajectory is
+                # STRICTLY post-decision (PRD §4.7.E).
+                if tick <= pending.tick_at_decision:
+                    continue
+
+                # Gap too large? Flush with the samples we have.
+                window_end = pending.tick_at_decision + TRAJECTORY_TICKS
+                if tick > window_end:
+                    # No new sample for this record — the window closed
+                    # silently on an earlier tick that simply never
+                    # arrived. Emit the (possibly partial) trajectory.
+                    self._pending.pop(record_id, None)
+                    status = (STATUS_COMPLETE
+                              if len(pending.trajectory) >= TRAJECTORY_TICKS
+                              else STATUS_INCOMPLETE)
+                    self._emit_outcome(pending, status=status,
+                                       resolved_at_tick=window_end)
+                    emitted += 1
+                    continue
+
+                # Append this tick's SNARC to the trajectory. Cap at
+                # TRAJECTORY_TICKS samples (defensive; shouldn't
+                # trigger given the window_end check above).
+                if len(pending.trajectory) < TRAJECTORY_TICKS:
+                    pending.trajectory.append((int(tick), dict(snarc_clean)))
+                # Record optional signals (last-write-wins for scalars,
+                # OR-accumulate for level_up bool).
+                if rpe_signal is not None:
+                    try:
+                        pending.rpe_signal = float(rpe_signal)
+                    except (TypeError, ValueError):
+                        pass
+                if level_up is not None:
+                    pending.level_up_observed = bool(
+                        pending.level_up_observed or level_up
+                    )
+
+                # Window fully observed — emit now.
+                if len(pending.trajectory) >= TRAJECTORY_TICKS:
+                    self._pending.pop(record_id, None)
+                    self._emit_outcome(pending, status=STATUS_COMPLETE,
+                                       resolved_at_tick=int(tick))
+                    emitted += 1
+
+            return emitted
+        except Exception as e:  # noqa: BLE001
+            _log.warning("observe_tick failed: %s", e)
+            self.errors += 1
+            return emitted
+
+    def flush(self) -> int:
+        """Emit all remaining pending outcomes with ``incomplete`` status.
+
+        Also persists the (now-empty) buffer to disk and flushes the
+        sidecar writer. Returns the count of outcomes emitted.
+
+        Never raises.
+        """
+        count = 0
+        try:
+            for record_id in list(self._pending.keys()):
+                pending = self._pending.pop(record_id, None)
+                if pending is None:
+                    continue
+                status = (STATUS_COMPLETE
+                          if len(pending.trajectory) >= TRAJECTORY_TICKS
+                          else STATUS_INCOMPLETE)
+                resolved = (pending.tick_at_decision
+                            + len(pending.trajectory))
+                self._emit_outcome(pending, status=status,
+                                   resolved_at_tick=resolved)
+                count += 1
+            self._writer.flush()
+            # Persist empty buffer (truncates stale state from a prior
+            # run). Best-effort.
+            self._persist_buffer()
+        except Exception as e:  # noqa: BLE001
+            _log.warning("flush failed: %s", e)
+            self.errors += 1
+        return count
+
+    def persist(self) -> None:
+        """Persist the current pending buffer WITHOUT flushing outcomes.
+
+        Useful for graceful shutdown paths that want to preserve
+        pending state for the next kernel start. ``flush()`` and
+        ``close()`` both persist afterwards — this is a separate
+        method for callers that want to snapshot without draining.
+        """
+        try:
+            self._persist_buffer()
+        except Exception as e:  # noqa: BLE001
+            _log.warning("persist failed: %s", e)
+            self.errors += 1
+
+    def close(self) -> None:
+        """Flush pending, close the sidecar writer. Idempotent."""
+        if self._closed:
+            return
+        try:
+            self.flush()
+        finally:
+            try:
+                self._writer.close()
+            except Exception as e:  # noqa: BLE001
+                _log.warning("outcome writer close failed: %s", e)
+            self._closed = True
+
+    # ── introspection ────────────────────────────────────────────────
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Snapshot of tracker counters for observability."""
+        return {
+            "decisions_registered": self.decisions_registered,
+            "outcomes_emitted_complete": self.outcomes_emitted_complete,
+            "outcomes_emitted_incomplete": self.outcomes_emitted_incomplete,
+            "outcomes_emitted_failed": self.outcomes_emitted_failed,
+            "ticks_observed": self.ticks_observed,
+            "out_of_order_observations": self.out_of_order_observations,
+            "evictions": self.evictions,
+            "errors": self.errors,
+            "pending": len(self._pending),
+            "last_observed_tick": self._last_observed_tick,
+            "machine": self.machine,
+        }
+
+    def pending_record_ids(self) -> List[str]:
+        """Return record_ids still waiting for more observations."""
+        return list(self._pending.keys())
+
+    # ── internals ────────────────────────────────────────────────────
+
+    def _emit_outcome(
+        self,
+        pending: _PendingOutcome,
+        status: str,
+        resolved_at_tick: int,
+    ) -> None:
+        """Build and write the final outcome dict for one pending entry.
+
+        The outcome dict shape matches Track 6 deliverable:
+
+            {
+                "record_id": ...,                 # primary key for merge
+                "outcome": {
+                    "snarc_trajectory": [...],    # list of dicts
+                    "snarc_resolution_score": ..., # PRD §4.7.E
+                    "rpe_signal": ...,
+                    "level_up_observed": ...,
+                    "resolved_at_tick": ...,
+                    "tick_at_decision": ...,
+                    "status": "complete"|"incomplete"|"failed",
+                    "outcome_schema_version": "v0.1.0",
+                },
+                "machine": ...,
+                "emitted_at": ...,
+            }
+
+        Never raises.
+        """
+        try:
+            trajectory_dicts = [
+                {"tick": int(t), **_project_snarc(s)}
+                for t, s in pending.trajectory
+            ]
+            score = _snarc_resolution_score(
+                snarc_at_decision=pending.snarc_at_decision,
+                trajectory=pending.trajectory,
+            )
+            outcome_dict: Dict[str, Any] = {
+                "snarc_trajectory": trajectory_dicts,
+                "snarc_resolution_score": score,
+                "rpe_signal": pending.rpe_signal,
+                "level_up_observed": pending.level_up_observed,
+                "resolved_at_tick": int(resolved_at_tick),
+                "tick_at_decision": int(pending.tick_at_decision),
+                "status": status,
+                "outcome_schema_version": OUTCOME_SCHEMA_VERSION,
+            }
+            # If a failure was reported but the status wasn't set to
+            # failed, reflect it in the payload so downstream readers
+            # can still see it.
+            if pending.failure and status != STATUS_FAILED:
+                outcome_dict["plugin_failure_observed"] = True
+
+            sidecar_record = {
+                "record_id": pending.record_id,
+                "outcome": outcome_dict,
+                "machine": self.machine,
+                "emitted_at": time.time(),
+                "schema_version": OUTCOME_SCHEMA_VERSION,
+            }
+            ok = self._writer.append(sidecar_record)
+            if not ok:
+                self.errors += 1
+                return
+
+            if status == STATUS_COMPLETE:
+                self.outcomes_emitted_complete += 1
+            elif status == STATUS_FAILED:
+                self.outcomes_emitted_failed += 1
+            else:
+                self.outcomes_emitted_incomplete += 1
+        except Exception as e:  # noqa: BLE001
+            _log.warning("emit_outcome for %s failed: %s",
+                         getattr(pending, "record_id", "?"), e)
+            self.errors += 1
+
+    def _persist_buffer(self) -> None:
+        """Write the current pending buffer to disk atomically.
+
+        Uses the standard write-tmp-rename pattern. Any failure is
+        logged + swallowed (the buffer is lost on next restart, which
+        is the already-documented degradation path).
+        """
+        try:
+            self._buffer_path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "outcome_schema_version": OUTCOME_SCHEMA_VERSION,
+                "machine": self.machine,
+                "persisted_at": time.time(),
+                "pending": [p.to_json() for p in self._pending.values()],
+                "last_observed_tick": self._last_observed_tick,
+            }
+            tmp_path = self._buffer_path.with_suffix(
+                self._buffer_path.suffix + ".tmp"
+            )
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                json.dump(payload, f, separators=(",", ":"), default=str)
+                f.flush()
+                try:
+                    os.fsync(f.fileno())
+                except (OSError, AttributeError):
+                    # fsync unsupported on some FS (e.g. WSL mount) —
+                    # the atomic rename is still the critical step.
+                    pass
+            os.replace(tmp_path, self._buffer_path)
+        except Exception as e:  # noqa: BLE001
+            _log.warning("persist_buffer failed: %s", e)
+            self.errors += 1
+
+    def _load_buffer(self) -> None:
+        """Restore the pending buffer from disk, if one exists.
+
+        Best-effort. Stale entries (whose ``tick_at_decision`` is older
+        than ``last_observed_tick`` by more than the trajectory window)
+        are flushed immediately as ``incomplete`` so they don't clog
+        the buffer after a long downtime.
+        """
+        if not self._buffer_path.exists():
+            return
+        try:
+            with open(self._buffer_path, "r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except Exception as e:  # noqa: BLE001
+            _log.warning("load_buffer: unreadable %s: %s", self._buffer_path, e)
+            return
+
+        last_tick = payload.get("last_observed_tick")
+        try:
+            last_tick_int = int(last_tick) if last_tick is not None else None
+        except (TypeError, ValueError):
+            last_tick_int = None
+        self._last_observed_tick = last_tick_int
+
+        pending_entries = payload.get("pending", [])
+        for entry in pending_entries:
+            try:
+                pending = _PendingOutcome.from_json(entry)
+            except Exception as e:  # noqa: BLE001
+                _log.warning("load_buffer: bad pending entry: %s", e)
+                continue
+
+            # If the last observed tick has already moved past this
+            # pending's window, emit incomplete now.
+            if (last_tick_int is not None
+                    and last_tick_int > pending.tick_at_decision + TRAJECTORY_TICKS):
+                self._emit_outcome(
+                    pending,
+                    status=STATUS_INCOMPLETE,
+                    resolved_at_tick=pending.tick_at_decision
+                    + len(pending.trajectory),
+                )
+                continue
+
+            self._pending[pending.record_id] = pending
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Module-level helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _coerce_snarc(snarc: Any) -> Dict[str, float]:
+    """Project whatever the caller passed into the canonical SNARC dict.
+
+    Missing dims → 0.0. Non-numeric values → 0.0 with a debug log.
+    Always returns a dict with ALL keys in ``ALL_SNARC_DIMS`` present.
+    """
+    out: Dict[str, float] = {dim: 0.0 for dim in ALL_SNARC_DIMS}
+    if not isinstance(snarc, dict):
+        return out
+    for k in ALL_SNARC_DIMS:
+        v = snarc.get(k, 0.0)
+        try:
+            out[k] = float(v) if v is not None else 0.0
+        except (TypeError, ValueError):
+            out[k] = 0.0
+    return out
+
+
+def _project_snarc(snarc: Dict[str, float]) -> Dict[str, float]:
+    """Return the SNARC dict projected to ALL_SNARC_DIMS with floats."""
+    return {k: float(snarc.get(k, 0.0) or 0.0) for k in ALL_SNARC_DIMS}
+
+
+def _snarc_resolution_score(
+    snarc_at_decision: Dict[str, float],
+    trajectory: List[Tuple[int, Dict[str, float]]],
+) -> Optional[float]:
+    """Compute the PRD §4.7.E resolution score.
+
+    Score = Δ (dominant SNARC dim) = snarc_at_decision[dom] - snarc_final[dom]
+
+    Where ``dom`` is the argmax of ``snarc_at_decision`` restricted to
+    ``RESOLUTION_DIMS`` (arousal/conflict/surprise) — the "dominant
+    features" PRD §4.7.E names. Positive score = dimension was reduced
+    after the decision (good). Negative = amplified.
+
+    Returns ``None`` when:
+      * the trajectory is empty (no post-decision SNARC observed), or
+      * all decision-time SNARC values in ``RESOLUTION_DIMS`` are zero
+        (no dominant feature — score is ill-defined).
+    """
+    if not trajectory:
+        return None
+
+    # Identify dominant dimension at decision time.
+    best_dim: Optional[str] = None
+    best_val: float = -1.0
+    for dim in RESOLUTION_DIMS:
+        v = float(snarc_at_decision.get(dim, 0.0) or 0.0)
+        if v > best_val:
+            best_val = v
+            best_dim = dim
+    if best_dim is None or best_val <= 0.0:
+        return None
+
+    # Use the LAST observed trajectory sample as the post-decision
+    # value. "Resolution" is the delta at the end of the window, not
+    # a per-step average — PRD §4.7.E language is "reduces arousal/
+    # conflict/surprise" which we interpret as end-of-window delta.
+    final_tick, final_snarc = trajectory[-1]
+    final_val = float(final_snarc.get(best_dim, 0.0) or 0.0)
+    return best_val - final_val
+
+
+__all__ = [
+    "OutcomeTracker",
+    "OUTCOME_SCHEMA_VERSION",
+    "TRAJECTORY_TICKS",
+    "RESOLUTION_DIMS",
+    "ALL_SNARC_DIMS",
+    "STATUS_COMPLETE",
+    "STATUS_INCOMPLETE",
+    "STATUS_FAILED",
+    "OUTCOME_FILE_PREFIX",
+    "BUFFER_FILENAME",
+]

--- a/sage/cognition/router/tests/test_outcome.py
+++ b/sage/cognition/router/tests/test_outcome.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+"""
+Unit tests for OutcomeTracker — Phase 0 Track 6.
+================================================
+
+Covers the Track 6 deliverable matrix:
+
+ 1. Basic happy path: decision at tick N, SNARC at N+1..N+5 → complete
+    outcome with correct trajectory length and resolution score.
+ 2. Tick gap > TRAJECTORY_TICKS → status='incomplete' with partial
+    trajectory.
+ 3. Kernel restart: buffer persisted to disk, reloaded into a fresh
+    tracker, backfill resumes.
+ 4. SNARC resolution score matches PRD §4.7.E formula (Δ dominant dim).
+ 5. Multiple concurrent decisions with overlapping windows.
+ 6. No-op: decision recorded but NO observations → flush emits
+    'incomplete' with empty trajectory.
+ 7. Sidecar reader auto-merges outcomes onto main records.
+ 8. ``merge_outcomes=False`` yields main records untouched.
+ 9. Plugin failure mid-window marks status='failed' on that tick.
+10. Out-of-order tick observations ignored + counted.
+11. Max-pending cap evicts oldest as incomplete.
+12. Atomic writes: tmp files cleaned up after persist.
+13. Zero-salience SNARC at decision → resolution_score = None.
+14. Duplicate register_decision rejected.
+15. Outcome schema version stamped on every sidecar entry.
+
+All tests are torch-free and use ``tmp_path`` for filesystem isolation.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from sage.cognition.router.outcome import (
+    OUTCOME_SCHEMA_VERSION,
+    STATUS_COMPLETE,
+    STATUS_FAILED,
+    STATUS_INCOMPLETE,
+    TRAJECTORY_TICKS,
+    OutcomeTracker,
+    _snarc_resolution_score,
+)
+from sage.cognition.router.data import (
+    RouterDatasetReader,
+    RouterDatasetWriter,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Helpers / fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _fixed_clock(year: int = 2026, month: int = 4, day: int = 17):
+    """Deterministic UTC clock for partition-naming assertions."""
+    frozen = datetime(year, month, day, 12, 0, 0, tzinfo=timezone.utc)
+    return lambda: frozen
+
+
+def _snarc(**kwargs: float) -> Dict[str, float]:
+    """Canonical SNARC dict with zero defaults."""
+    out = {"arousal": 0.0, "conflict": 0.0, "surprise": 0.0,
+           "reward": 0.0, "novelty": 0.0}
+    out.update(kwargs)
+    return out
+
+
+def _read_outcome_lines(base_dir: Path, machine: str) -> list:
+    """Read every sidecar entry back — uncompressed or gzipped."""
+    records = []
+    for path in sorted((base_dir / machine).glob("outcome_*.jsonl*")):
+        if path.suffix == ".gz":
+            with gzip.open(path, "rt", encoding="utf-8") as f:
+                for line in f:
+                    if line.strip():
+                        records.append(json.loads(line))
+        else:
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    if line.strip():
+                        records.append(json.loads(line))
+    return records
+
+
+@pytest.fixture
+def tracker_factory(tmp_path):
+    """Produce tracker instances wired to a fresh tmp_path."""
+    def _make(compress: bool = False, buffer_size: int = 1,
+             max_pending: int = 4096, machine: str = "testmachine",
+             clock=None) -> OutcomeTracker:
+        return OutcomeTracker(
+            base_dir=tmp_path,
+            machine=machine,
+            compress=compress,
+            buffer_size=buffer_size,
+            max_pending=max_pending,
+            clock=clock or _fixed_clock(),
+        )
+    return _make
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 1. Happy path — full 5-tick window
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_basic_full_window_outcome(tracker_factory, tmp_path):
+    tracker = tracker_factory()
+
+    # Decision at tick 100 with dominant arousal=0.9.
+    tracker.register_decision(
+        record_id="rec-1",
+        tick_at_decision=100,
+        snarc_at_decision=_snarc(arousal=0.9, conflict=0.2),
+    )
+
+    # Feed 5 post-decision ticks; arousal decays linearly.
+    for i, a in enumerate([0.8, 0.6, 0.4, 0.2, 0.1], start=1):
+        tracker.observe_tick(tick=100 + i, snarc=_snarc(arousal=a))
+
+    tracker.close()
+
+    outcomes = _read_outcome_lines(tmp_path, "testmachine")
+    assert len(outcomes) == 1
+    entry = outcomes[0]
+    assert entry["record_id"] == "rec-1"
+    oc = entry["outcome"]
+    assert oc["status"] == STATUS_COMPLETE
+    assert oc["outcome_schema_version"] == OUTCOME_SCHEMA_VERSION
+    assert len(oc["snarc_trajectory"]) == TRAJECTORY_TICKS
+    assert oc["tick_at_decision"] == 100
+    assert oc["resolved_at_tick"] == 105
+    # Resolution score = arousal_at_decision (0.9) - final_arousal (0.1) = 0.8
+    assert oc["snarc_resolution_score"] == pytest.approx(0.8)
+
+    stats = tracker.get_stats()
+    assert stats["outcomes_emitted_complete"] == 1
+    assert stats["outcomes_emitted_incomplete"] == 0
+    assert stats["pending"] == 0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 2. Tick gap > window → incomplete
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_tick_gap_flushes_incomplete(tracker_factory, tmp_path):
+    tracker = tracker_factory()
+    tracker.register_decision("rec-gap", 50, _snarc(arousal=0.7))
+
+    # Feed one valid tick, then a massive gap.
+    tracker.observe_tick(tick=51, snarc=_snarc(arousal=0.65))
+    tracker.observe_tick(tick=100, snarc=_snarc(arousal=0.5))
+
+    tracker.close()
+
+    outcomes = _read_outcome_lines(tmp_path, "testmachine")
+    assert len(outcomes) == 1
+    oc = outcomes[0]["outcome"]
+    assert oc["status"] == STATUS_INCOMPLETE
+    assert len(oc["snarc_trajectory"]) == 1  # only tick 51 captured
+    assert oc["resolved_at_tick"] == 55  # window end (50 + 5)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 3. Kernel restart — buffer persistence
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_kernel_restart_resumes_buffer(tracker_factory, tmp_path):
+    t1 = tracker_factory()
+    t1.register_decision("rec-R", 10, _snarc(arousal=0.8))
+    t1.observe_tick(11, _snarc(arousal=0.75))
+    t1.observe_tick(12, _snarc(arousal=0.7))
+    t1.persist()  # snapshot without flushing
+
+    # Simulate kernel restart — DO NOT close t1 (that would flush).
+    # Abandon t1 and construct a fresh tracker reading the same buffer.
+    t2 = OutcomeTracker(
+        base_dir=tmp_path,
+        machine="testmachine",
+        compress=False,
+        buffer_size=1,
+        clock=_fixed_clock(),
+    )
+    pending = t2.pending_record_ids()
+    assert "rec-R" in pending
+
+    # Complete the trajectory on t2.
+    t2.observe_tick(13, _snarc(arousal=0.6))
+    t2.observe_tick(14, _snarc(arousal=0.5))
+    t2.observe_tick(15, _snarc(arousal=0.4))
+    t2.close()
+
+    outcomes = _read_outcome_lines(tmp_path, "testmachine")
+    assert len(outcomes) == 1
+    oc = outcomes[0]["outcome"]
+    assert oc["status"] == STATUS_COMPLETE
+    assert len(oc["snarc_trajectory"]) == TRAJECTORY_TICKS
+
+
+def test_kernel_restart_stale_buffer_flushes_incomplete(tracker_factory, tmp_path):
+    """Buffer entries older than last_observed_tick by > window are
+    force-flushed as incomplete on load."""
+    t1 = tracker_factory()
+    t1.register_decision("rec-stale", 10, _snarc(arousal=0.8))
+    # Pretend many ticks passed — set last_observed_tick forward via
+    # an observation that doesn't touch our pending (wrong record_id).
+    t1.observe_tick(100, _snarc(arousal=0.1))  # this flushes rec-stale
+    t1.persist()
+
+    # rec-stale was flushed on the gap check, not stored. Now register a
+    # stale record, persist, and force last_observed_tick on reload.
+    t1.register_decision("rec-stale2", 10, _snarc(arousal=0.8))
+    # Don't observe — just persist with last_observed_tick stuck at 100.
+    t1.persist()
+    t1._writer.close()  # don't flush pending outcomes yet
+
+    t2 = OutcomeTracker(
+        base_dir=tmp_path,
+        machine="testmachine",
+        compress=False,
+        buffer_size=1,
+        clock=_fixed_clock(),
+    )
+    # rec-stale2 should have been emitted incomplete on load (100 > 10+5).
+    assert "rec-stale2" not in t2.pending_record_ids()
+    t2.close()
+
+    outcomes = _read_outcome_lines(tmp_path, "testmachine")
+    rec_ids = [o["record_id"] for o in outcomes]
+    assert "rec-stale2" in rec_ids
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 4. SNARC resolution score — PRD §4.7.E
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_resolution_score_picks_dominant_dim():
+    # conflict is dominant at decision (0.9).
+    snarc0 = _snarc(arousal=0.3, conflict=0.9, surprise=0.2)
+    # Final trajectory sample: conflict reduced to 0.2, arousal risen.
+    traj = [
+        (1, _snarc(arousal=0.5, conflict=0.7, surprise=0.2)),
+        (2, _snarc(arousal=0.6, conflict=0.5, surprise=0.2)),
+        (3, _snarc(arousal=0.7, conflict=0.3, surprise=0.2)),
+        (4, _snarc(arousal=0.8, conflict=0.25, surprise=0.2)),
+        (5, _snarc(arousal=0.9, conflict=0.2, surprise=0.2)),
+    ]
+    score = _snarc_resolution_score(snarc0, traj)
+    # Dominant is conflict (0.9). Final conflict = 0.2. Δ = 0.7.
+    assert score == pytest.approx(0.7)
+
+
+def test_resolution_score_none_when_all_zero():
+    # Reward doesn't count as "dominant" — only arousal/conflict/surprise.
+    snarc0 = _snarc(reward=0.9, novelty=0.8)
+    traj = [(1, _snarc(reward=0.1))]
+    assert _snarc_resolution_score(snarc0, traj) is None
+
+
+def test_resolution_score_none_when_trajectory_empty():
+    snarc0 = _snarc(arousal=0.9)
+    assert _snarc_resolution_score(snarc0, []) is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 5. Overlapping concurrent decisions
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_concurrent_decisions_overlapping_windows(tracker_factory, tmp_path):
+    tracker = tracker_factory()
+    # Three decisions spanning overlapping windows. Each gets observations
+    # at EVERY subsequent tick so all three should complete cleanly.
+    tracker.register_decision("a", 100, _snarc(arousal=0.8))
+    tracker.register_decision("b", 102, _snarc(conflict=0.9))
+    tracker.register_decision("c", 104, _snarc(surprise=0.7))
+    # Ticks 101..109 — every decision gets up to 5 post-decision samples.
+    for tick, snarc_vals in [
+        (101, {"arousal": 0.7}),
+        (102, {"arousal": 0.65, "conflict": 0.85}),
+        (103, {"arousal": 0.6, "conflict": 0.8}),
+        (104, {"arousal": 0.5, "conflict": 0.7}),
+        (105, {"arousal": 0.4, "conflict": 0.6, "surprise": 0.6}),
+        (106, {"arousal": 0.3, "conflict": 0.5, "surprise": 0.5}),
+        (107, {"arousal": 0.2, "conflict": 0.4, "surprise": 0.4}),
+        (108, {"conflict": 0.3, "surprise": 0.3}),
+        (109, {"surprise": 0.2}),
+    ]:
+        tracker.observe_tick(tick, _snarc(**snarc_vals))
+    tracker.close()
+
+    outcomes = _read_outcome_lines(tmp_path, "testmachine")
+    by_id = {o["record_id"]: o["outcome"] for o in outcomes}
+    assert set(by_id.keys()) == {"a", "b", "c"}
+    # Each gets exactly the 5 post-decision ticks in its window.
+    for rid in ("a", "b", "c"):
+        assert by_id[rid]["status"] == STATUS_COMPLETE, (
+            f"{rid} not complete: {by_id[rid]}"
+        )
+        assert len(by_id[rid]["snarc_trajectory"]) == TRAJECTORY_TICKS
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 6. No observations → incomplete on flush
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_noop_decision_flushed_incomplete(tracker_factory, tmp_path):
+    tracker = tracker_factory()
+    tracker.register_decision("lonely", 999, _snarc(arousal=0.5))
+    tracker.close()  # flushes
+
+    outcomes = _read_outcome_lines(tmp_path, "testmachine")
+    assert len(outcomes) == 1
+    oc = outcomes[0]["outcome"]
+    assert oc["status"] == STATUS_INCOMPLETE
+    assert oc["snarc_trajectory"] == []
+    # Resolution score undefined without trajectory.
+    assert oc["snarc_resolution_score"] is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 7 + 8. Reader merges outcomes / opt-out
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_reader_merges_outcomes_by_record_id(tmp_path):
+    """End-to-end: writer drops records, tracker emits outcomes, reader
+    merges them at load time.
+    """
+    machine = "integ"
+    clock = _fixed_clock(2026, 4, 17)
+    writer = RouterDatasetWriter(
+        base_dir=tmp_path, machine=machine,
+        compress=False, buffer_size=1, clock=clock,
+    )
+    # Seed two main-partition records with outcome=None.
+    for rid, tick, arousal in [("r1", 10, 0.8), ("r2", 20, 0.5)]:
+        writer.append({
+            "record_id": rid,
+            "schema_version": "0.1.0",
+            "timestamp": 1700000000.0,
+            "machine": machine,
+            "router_input": {"tick": tick},
+            "router_output": {"action": "noop"},
+            "outcome": None,
+        })
+    writer.close()
+
+    # Tracker emits an outcome only for r1 — r2 stays without outcome.
+    tracker = OutcomeTracker(
+        base_dir=tmp_path, machine=machine,
+        compress=False, buffer_size=1, clock=clock,
+    )
+    tracker.register_decision("r1", 10, _snarc(arousal=0.8))
+    for i, a in enumerate([0.7, 0.6, 0.5, 0.4, 0.3], start=1):
+        tracker.observe_tick(10 + i, _snarc(arousal=a))
+    tracker.close()
+
+    reader = RouterDatasetReader(base_dir=tmp_path)
+    merged = {r["record_id"]: r for r in reader.read_partition(machine=machine)}
+    assert merged["r1"]["outcome"] is not None
+    assert merged["r1"]["outcome"]["status"] == STATUS_COMPLETE
+    assert merged["r2"]["outcome"] is None
+
+
+def test_reader_opt_out_preserves_main_state(tmp_path):
+    machine = "integ2"
+    clock = _fixed_clock(2026, 4, 17)
+    writer = RouterDatasetWriter(
+        base_dir=tmp_path, machine=machine,
+        compress=False, buffer_size=1, clock=clock,
+    )
+    writer.append({
+        "record_id": "r1",
+        "schema_version": "0.1.0",
+        "timestamp": 1700000000.0,
+        "machine": machine,
+        "outcome": None,
+    })
+    writer.close()
+
+    tracker = OutcomeTracker(
+        base_dir=tmp_path, machine=machine,
+        compress=False, buffer_size=1, clock=clock,
+    )
+    tracker.register_decision("r1", 0, _snarc(arousal=0.9))
+    for i, a in enumerate([0.1] * 5, start=1):
+        tracker.observe_tick(i, _snarc(arousal=a))
+    tracker.close()
+
+    reader = RouterDatasetReader(base_dir=tmp_path)
+    forensic = list(reader.read_partition(machine=machine, merge_outcomes=False))
+    assert len(forensic) == 1
+    assert forensic[0]["outcome"] is None  # no merge
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 9. Plugin failure mid-window
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_plugin_failure_emits_failed_status(tracker_factory, tmp_path):
+    tracker = tracker_factory()
+    tracker.register_decision("boom", 5, _snarc(arousal=0.8))
+    tracker.observe_tick(6, _snarc(arousal=0.7))
+    tracker.observe_tick(7, _snarc(arousal=0.6), failed_record_ids=["boom"])
+    tracker.close()
+
+    outcomes = _read_outcome_lines(tmp_path, "testmachine")
+    assert len(outcomes) == 1
+    oc = outcomes[0]["outcome"]
+    assert oc["status"] == STATUS_FAILED
+    # Trajectory captured one sample (tick 6); tick-7 failure doesn't
+    # extend trajectory.
+    assert len(oc["snarc_trajectory"]) == 1
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 10. Out-of-order ticks
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_out_of_order_ticks_ignored(tracker_factory):
+    tracker = tracker_factory()
+    tracker.register_decision("x", 10, _snarc(arousal=0.8))
+    tracker.observe_tick(11, _snarc(arousal=0.7))
+    # Regression — should be ignored.
+    tracker.observe_tick(5, _snarc(arousal=0.9))
+    assert tracker.get_stats()["out_of_order_observations"] == 1
+    # Pending still has x, and trajectory only has the tick-11 sample.
+    tracker.close()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 11. Max-pending eviction
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_max_pending_evicts_oldest(tracker_factory, tmp_path):
+    tracker = tracker_factory(max_pending=2)
+    tracker.register_decision("a", 1, _snarc(arousal=0.5))
+    tracker.register_decision("b", 2, _snarc(arousal=0.5))
+    tracker.register_decision("c", 3, _snarc(arousal=0.5))  # evicts a
+    stats = tracker.get_stats()
+    assert stats["evictions"] == 1
+    assert "a" not in tracker.pending_record_ids()
+    tracker.close()
+
+    outcomes = _read_outcome_lines(tmp_path, "testmachine")
+    ids_by_status = {o["record_id"]: o["outcome"]["status"] for o in outcomes}
+    assert ids_by_status.get("a") == STATUS_INCOMPLETE
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 12. Atomic writes — no leftover .tmp after persist
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_persist_buffer_cleans_up_tmp(tracker_factory, tmp_path):
+    tracker = tracker_factory()
+    tracker.register_decision("a", 1, _snarc(arousal=0.5))
+    tracker.persist()
+    leftover = list((tmp_path / "testmachine").glob("*.tmp"))
+    assert leftover == []
+    # Buffer file itself exists and is valid JSON.
+    buf = (tmp_path / "testmachine" / "outcome_buffer.json")
+    assert buf.exists()
+    with open(buf) as f:
+        data = json.load(f)
+    assert data["outcome_schema_version"] == OUTCOME_SCHEMA_VERSION
+    assert len(data["pending"]) == 1
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 13. Duplicate register_decision
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_duplicate_register_returns_false(tracker_factory):
+    tracker = tracker_factory()
+    assert tracker.register_decision("dup", 1, _snarc(arousal=0.5)) is True
+    assert tracker.register_decision("dup", 2, _snarc(arousal=0.7)) is False
+    tracker.close()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 14. Schema version stamped on every sidecar entry
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_outcome_schema_version_stamped(tracker_factory, tmp_path):
+    tracker = tracker_factory()
+    tracker.register_decision("v", 1, _snarc(arousal=0.5))
+    for i in range(1, 6):
+        tracker.observe_tick(1 + i, _snarc(arousal=0.5 - i * 0.05))
+    tracker.close()
+    outcomes = _read_outcome_lines(tmp_path, "testmachine")
+    assert all(
+        o["outcome"]["outcome_schema_version"] == OUTCOME_SCHEMA_VERSION
+        for o in outcomes
+    )
+    assert all(
+        o["schema_version"] == OUTCOME_SCHEMA_VERSION
+        for o in outcomes
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 15. Optional signals propagate through
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_rpe_and_level_up_signals_recorded(tracker_factory, tmp_path):
+    tracker = tracker_factory()
+    tracker.register_decision("s", 0, _snarc(arousal=0.9))
+    tracker.observe_tick(1, _snarc(arousal=0.7), rpe_signal=0.3)
+    tracker.observe_tick(2, _snarc(arousal=0.5), level_up=True)
+    tracker.observe_tick(3, _snarc(arousal=0.4))
+    tracker.observe_tick(4, _snarc(arousal=0.3))
+    tracker.observe_tick(5, _snarc(arousal=0.2), rpe_signal=0.8)
+    tracker.close()
+    outcomes = _read_outcome_lines(tmp_path, "testmachine")
+    assert len(outcomes) == 1
+    oc = outcomes[0]["outcome"]
+    # rpe is last-write-wins; level_up is OR-accumulate.
+    assert oc["rpe_signal"] == pytest.approx(0.8)
+    assert oc["level_up_observed"] is True
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 16. Decision-tick SNARC sample itself doesn't count
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_decision_tick_sample_excluded(tracker_factory):
+    tracker = tracker_factory()
+    tracker.register_decision("z", 10, _snarc(arousal=0.9))
+    # tick == tick_at_decision — must be ignored.
+    tracker.observe_tick(10, _snarc(arousal=0.9))
+    assert len(tracker._pending["z"].trajectory) == 0
+    tracker.observe_tick(11, _snarc(arousal=0.7))
+    assert len(tracker._pending["z"].trajectory) == 1
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 17. Gzip sidecar round-trip through reader
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_gzip_sidecar_readable_by_reader(tmp_path):
+    machine = "gz"
+    clock = _fixed_clock(2026, 4, 17)
+    writer = RouterDatasetWriter(
+        base_dir=tmp_path, machine=machine,
+        compress=True, buffer_size=1, clock=clock,
+    )
+    writer.append({
+        "record_id": "g1",
+        "schema_version": "0.1.0",
+        "timestamp": 1700000000.0,
+        "machine": machine,
+        "outcome": None,
+    })
+    writer.close()
+    tracker = OutcomeTracker(
+        base_dir=tmp_path, machine=machine,
+        compress=True, buffer_size=1, clock=clock,
+    )
+    tracker.register_decision("g1", 0, _snarc(arousal=0.9))
+    for i, a in enumerate([0.8, 0.7, 0.6, 0.5, 0.4], start=1):
+        tracker.observe_tick(i, _snarc(arousal=a))
+    tracker.close()
+
+    # Confirm gzip outcome file was written.
+    gzs = list((tmp_path / machine).glob("outcome_*.jsonl.gz"))
+    assert len(gzs) == 1
+
+    reader = RouterDatasetReader(base_dir=tmp_path)
+    merged = list(reader.read_partition(machine=machine))
+    assert len(merged) == 1
+    assert merged[0]["outcome"]["status"] == STATUS_COMPLETE


### PR DESCRIPTION
## Track
Phase 0, Track 6 — Outcome tracking (per `shared-context/arc-agi-3/phase2/brain-arch/router-sprint-1-phase-0.md`)

## What this ships
- `sage/cognition/router/outcome.py` — `OutcomeTracker` class
  - `register_decision(record_id, tick, snarc_at_decision)` — buffer a pending outcome after Track 5 writes its record
  - `observe_tick(tick, snarc, rpe_signal=None, level_up=None, failed_record_ids=None)` — feed post-decision ticks
  - `flush()` / `close()` — drain pending with `incomplete` status
  - `persist()` — snapshot buffer to `outcome_buffer.json` without flushing
- `_OutcomeWriter` + `_PrefixedDatasetWriter` — reuse Track 4's writer machinery with filename prefix override to emit `outcome_{YYYY-MM-DD}.jsonl[.gz]`
- `_snarc_resolution_score` — PRD §4.7.E formula: Δ(dominant SNARC dim) from t0 to end-of-window, scoped to arousal/conflict/surprise
- Reader update: `RouterDatasetReader.read_partition(merge_outcomes=True)` auto-merges sidecars by `record_id`; main partitions touched only to read. New `list_outcome_partitions` / `read_outcomes` for forensic use.
- 20 unit tests covering the Track 6 deliverable matrix

## What this does NOT ship (deferred to other tracks)
- Wiring `OutcomeTracker` into the consciousness loop (belongs with Track 5 follow-up; this PR only provides the mechanism)
- Cron/timer scheduling for pruning orphan outcome partitions (Track 9-adjacent)
- Real RPE source (Phase 4+); the tracker accepts the signal but nothing feeds it yet

## Sidecar vs rewrite — rationale
Recommended in the sprint doc and adopted here. Rationale recorded in `outcome.py` module docstring:
1. **No race with live writer** — main partition gzip handle stays open; rewrite-while-append is race-prone.
2. **Atomicity cheap** — sidecar appends are the same append-only discipline Track 4 proved correct.
3. **Immutable main partitions** — forensic "what did we know at decision time?" is a free operation via `merge_outcomes=False`.
4. **Failure isolation** — a broken outcome pipeline cannot corrupt the primary dataset.
5. **Pruning independence** — orphans become invisible via the reader's left-outer-join semantics.

## Reader merge strategy
Auto-merge by default with explicit opt-out (`merge_outcomes=False`). Justification:
- Training pipelines always want outcomes attached.
- Forensic replays ("what did the router see before we knew the outcome?") are the rare case and get the explicit flag.
- Merge is a left-outer join: records without a sidecar entry surface with `outcome=None`, unchanged.
- Conflict resolution: if the same `record_id` appears in multiple sidecars, latest `emitted_at` wins (handles buggy retries / duplicate emissions).

## Edge cases explicitly covered
- **Tick gap > window** → `status='incomplete'` with partial trajectory, `resolved_at_tick` pinned to window end.
- **Kernel restart mid-buffer** → `outcome_buffer.json` written atomically via tmp+os.replace; reloaded on construction; stale entries (last_observed_tick > decision+5) auto-flushed on load.
- **Plugin failure** → caller passes `failed_record_ids` to `observe_tick`; matching records emit with `status='failed'`.
- **Out-of-order ticks** → logged, ignored, counted (`out_of_order_observations`).
- **No-op decisions** → `close()` flushes remaining pending as `incomplete` with empty trajectory.
- **Buffer overflow** → `max_pending` (default 4096) caps in-memory buffer; oldest evicted + emitted incomplete.
- **Zero-salience decision** → `snarc_resolution_score = None` (no dominant dim).

## Tick-window length
5 ticks per PRD §4.7.E — **no deviation**. Exposed as `TRAJECTORY_TICKS` module constant; changing it requires an `OUTCOME_SCHEMA_VERSION` bump (documented in the constant's comment).

## Schema version
`OUTCOME_SCHEMA_VERSION = "v0.1.0"` stamped on every sidecar entry (both at the record level and inside the `outcome` dict). Reader merge keys off it in future versions.

## Tests added (20)
- `test_basic_full_window_outcome` — happy path, 5 ticks → complete, correct resolution score
- `test_tick_gap_flushes_incomplete` — gap > window
- `test_kernel_restart_resumes_buffer` — persist → new tracker → complete
- `test_kernel_restart_stale_buffer_flushes_incomplete` — stale entries purged on load
- `test_resolution_score_picks_dominant_dim` — PRD §4.7.E formula verification
- `test_resolution_score_none_when_all_zero`
- `test_resolution_score_none_when_trajectory_empty`
- `test_concurrent_decisions_overlapping_windows` — three records, interleaved
- `test_noop_decision_flushed_incomplete` — no observations ever arrive
- `test_reader_merges_outcomes_by_record_id` — end-to-end with writer + reader
- `test_reader_opt_out_preserves_main_state` — `merge_outcomes=False`
- `test_plugin_failure_emits_failed_status`
- `test_out_of_order_ticks_ignored`
- `test_max_pending_evicts_oldest`
- `test_persist_buffer_cleans_up_tmp` — atomic writes, no `.tmp` leftovers
- `test_duplicate_register_returns_false`
- `test_outcome_schema_version_stamped`
- `test_rpe_and_level_up_signals_recorded`
- `test_decision_tick_sample_excluded` — trajectory is strictly post-decision
- `test_gzip_sidecar_readable_by_reader` — compression round-trip

## Test results
```
sage/cognition/router/tests/test_outcome.py .................... [100%]
======================== 20 passed, 1 warning in 1.19s =========================

Full router suite:
======================= 242 passed, 1 warning in 10.02s ========================
```

## Acceptance criteria from sprint doc
- [x] Backfill written records with outcome data once observed: SNARC trajectory over next 5 ticks, RPE signal if available
- [x] Outcome buffer keyed by record_id; flushes to disk every N ticks or on tick gap >5
- [x] Handles edge cases: kernel restart mid-buffer, plugin failure mid-dispatch, ATP exhaustion before outcome resolves (plugin-failure path handles the ATP case — the record marks failed and moves on)
- [x] Unit tests with synthetic tick streams (20 covering the matrix)
- [x] Sidecar approach chosen per sprint guidance

## Dependencies
- Track 1 (merged): `RouterRecord` + `with_outcome()`
- Track 4 (merged): `RouterDatasetWriter` / `RouterDatasetReader` — we subclass the writer and extend the reader
- Track 5 (merged): `RouterShadowHook` writes the initial record; Track 6 runs after and backfills

## Reviewer notes
- The `_PrefixedDatasetWriter` subclass overrides `_ensure_partition` only; all other writer discipline (rollover, gzip, failure isolation) is inherited. Kept minimal on purpose.
- Resolution score uses **end-of-window delta**, not mean reduction over the window. PRD §4.7.E says "rewards decisions that reduce arousal/conflict/surprise" — end-of-window is the simplest correct interpretation and easy to swap to an integral later without a schema bump (stored as a scalar either way).
- Reader merge is O(sidecar-records) in memory per query. For fleet-scale replays, consider streaming-join later; deliberately kept simple at Phase 0.
- `OutcomeTracker` is single-threaded by design (consciousness loop thread). If future architecture needs multi-thread, wrap with a lock.
- No wire-up into `SAGEConsciousness` yet — that's a follow-up integration PR to keep this one Track-6-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)