### PR TITLE
[router] Phase 0 Track 7: per-machine deployment scripts + runbook

### DIFF
--- a/sage/core/sage_consciousness.py
+++ b/sage/core/sage_consciousness.py
@@ -1429,9 +1429,17 @@ class SAGEConsciousness:
                 RouterDatasetPruner,
             )
 
-            # Resolve dataset root. Config override wins; then
-            # instance_dir subfolder; finally a safe tmp path.
+            # Resolve dataset root. Precedence:
+            #   1. config['router_shadow_dir']  (explicit code-level override)
+            #   2. $SAGE_ROUTER_DATA_DIR        (operator / systemd env)
+            #   3. {instance_dir}/router_shadow (default per-instance)
+            #   4. /tmp/sage-router-shadow      (last-resort safe path)
+            # Env var wins over defaults so per-machine installers
+            # (Track 7) can point the fleet at a shared dataset root
+            # without a code change.
             base_dir = self.config.get('router_shadow_dir')
+            if not base_dir:
+                base_dir = os.environ.get('SAGE_ROUTER_DATA_DIR', '').strip() or None
             if not base_dir:
                 instance_dir = self.config.get('instance_dir', '')
                 if instance_dir:

--- a/scripts/router_pipeline_disk_monitor.sh
+++ b/scripts/router_pipeline_disk_monitor.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# router_pipeline_disk_monitor.sh — Periodic disk-usage check for the router
+# shadow dataset (Phase 0 Track 7).
+#
+# Threshold rationale (per sprint doc + Track 4 sizing):
+#   The sprint doc cites 100 MB/day as the original alert threshold. Track 4
+#   landed with gzip on by default — real partitions on synthetic data
+#   compress ~70× (and noticeably less on real records, but still a large
+#   factor). Under gzip, "normal" traffic should sit comfortably under
+#   10 MB/day/machine.
+#
+#   This monitor ships two thresholds:
+#     WARN  = 50 MB/day   (notable but not alarming under gzip)
+#     ALERT = 200 MB/day  (hard — something is wrong: gzip off? loop stuck?)
+#
+#   Both are overridable via flags or env vars so fleet-wide monitoring can
+#   tune per machine.
+#
+# Usage
+#   scripts/router_pipeline_disk_monitor.sh
+#   scripts/router_pipeline_disk_monitor.sh --json
+#   scripts/router_pipeline_disk_monitor.sh --warn-mb 50 --alert-mb 200
+#   scripts/router_pipeline_disk_monitor.sh --data-dir /var/sage/router
+#
+# Cron example (every 15 min, JSON to a log file):
+#   */15 * * * * /path/to/router_pipeline_disk_monitor.sh --json \
+#                >> /var/log/router-disk-monitor.log 2>&1
+#
+# Exit codes
+#   0 OK or WARN
+#   2 ALERT threshold exceeded
+#   3 configuration/dataset not found
+#   4 usage error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAGE_DIR="${SAGE_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+WARN_MB="${SAGE_ROUTER_WARN_MB:-50}"
+ALERT_MB="${SAGE_ROUTER_ALERT_MB:-200}"
+JSON_OUT=0
+DATA_DIR_OVERRIDE=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --json) JSON_OUT=1 ;;
+        --warn-mb) shift; WARN_MB="${1:-50}" ;;
+        --warn-mb=*) WARN_MB="${1#*=}" ;;
+        --alert-mb) shift; ALERT_MB="${1:-200}" ;;
+        --alert-mb=*) ALERT_MB="${1#*=}" ;;
+        --data-dir) shift; DATA_DIR_OVERRIDE="${1:-}" ;;
+        --data-dir=*) DATA_DIR_OVERRIDE="${1#*=}" ;;
+        -h|--help) sed -n '2,35p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 4 ;;
+    esac
+    shift
+done
+
+log() {
+    if [ "$JSON_OUT" -eq 0 ]; then
+        echo "[router-disk] $*"
+    fi
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# Machine detection
+# ──────────────────────────────────────────────────────────────────────
+
+detect_machine() {
+    if [ -n "${SAGE_MACHINE:-}" ]; then
+        echo "$SAGE_MACHINE" | tr '[:upper:]' '[:lower:]'; return
+    fi
+    local host; host="$(hostname 2>/dev/null | tr '[:upper:]' '[:lower:]')"
+    case "$host" in
+        *thor*) echo "thor" ;;
+        *cbp*) echo "cbp" ;;
+        *legion*) echo "legion" ;;
+        *nomad*|*desktop-9e6hcao*) echo "nomad" ;;
+        *mcnugget*) echo "mcnugget" ;;
+        ubuntu) [ -d "/home/sprout" ] && echo "sprout" || echo "unknown" ;;
+        *) echo "$host" ;;
+    esac
+}
+
+MACHINE="$(detect_machine)"
+UNIT="sage-daemon-${MACHINE}"
+
+# ──────────────────────────────────────────────────────────────────────
+# Locate DATA_DIR (same resolution as verify script, minus interactive noise)
+# ──────────────────────────────────────────────────────────────────────
+
+if [ -n "$DATA_DIR_OVERRIDE" ]; then
+    DATA_DIR="$DATA_DIR_OVERRIDE"
+elif [ -n "${SAGE_ROUTER_DATA_DIR:-}" ]; then
+    DATA_DIR="$SAGE_ROUTER_DATA_DIR"
+else
+    SYSTEM_DROPIN="/etc/systemd/system/${UNIT}.service.d/router-shadow.conf"
+    USER_DROPIN="${HOME}/.config/systemd/user/${UNIT}.service.d/router-shadow.conf"
+    PROFILE_ENV="${SAGE_DIR}/sage/gateway/router-shadow.env"
+
+    DATA_DIR=""
+    for c in "$SYSTEM_DROPIN" "$USER_DROPIN" "$PROFILE_ENV"; do
+        if [ -f "$c" ]; then
+            DATA_DIR="$(grep -E '(Environment=)?(export )?SAGE_ROUTER_DATA_DIR=' "$c" \
+                        | sed -E 's/.*SAGE_ROUTER_DATA_DIR=//; s/^"//; s/"$//' | head -n1)"
+            [ -n "$DATA_DIR" ] && break
+        fi
+    done
+fi
+
+if [ -z "$DATA_DIR" ]; then
+    log "ERROR: cannot resolve SAGE_ROUTER_DATA_DIR for machine=${MACHINE}"
+    exit 3
+fi
+
+MACHINE_DIR="${DATA_DIR}/${MACHINE}"
+
+# ──────────────────────────────────────────────────────────────────────
+# Measure today's partition
+# ──────────────────────────────────────────────────────────────────────
+
+TODAY="$(date -u +%Y-%m-%d)"
+PARTITIONS=()
+if [ -d "$MACHINE_DIR" ]; then
+    while IFS= read -r p; do
+        [ -n "$p" ] && PARTITIONS+=("$p")
+    done < <(find "$MACHINE_DIR" -maxdepth 1 -type f -name "${TODAY}.jsonl*" 2>/dev/null)
+fi
+
+TODAY_BYTES=0
+for p in "${PARTITIONS[@]}"; do
+    sz="$(stat -c '%s' "$p" 2>/dev/null || echo 0)"
+    TODAY_BYTES=$((TODAY_BYTES + sz))
+done
+
+# Grand total (all partitions for this machine, not just today)
+TOTAL_BYTES=0
+if [ -d "$MACHINE_DIR" ]; then
+    TOTAL_BYTES="$(find "$MACHINE_DIR" -maxdepth 1 -type f \
+                    \( -name '*.jsonl' -o -name '*.jsonl.gz' \) \
+                    -printf '%s\n' 2>/dev/null | awk '{s+=$1} END {print s+0}')"
+fi
+
+TODAY_MB=$(( TODAY_BYTES / 1024 / 1024 ))
+TOTAL_MB=$(( TOTAL_BYTES / 1024 / 1024 ))
+
+# Any gzip active today?
+GZIP_ACTIVE="unknown"
+for p in "${PARTITIONS[@]}"; do
+    case "$p" in
+        *.jsonl.gz) GZIP_ACTIVE="yes"; break ;;
+        *.jsonl)    GZIP_ACTIVE="no" ;;
+    esac
+done
+
+# ──────────────────────────────────────────────────────────────────────
+# Determine severity
+# ──────────────────────────────────────────────────────────────────────
+
+LEVEL="OK"
+EXIT=0
+if [ "$TODAY_MB" -ge "$ALERT_MB" ]; then
+    LEVEL="ALERT"
+    EXIT=2
+elif [ "$TODAY_MB" -ge "$WARN_MB" ]; then
+    LEVEL="WARN"
+    EXIT=0
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# Report
+# ──────────────────────────────────────────────────────────────────────
+
+if [ "$JSON_OUT" -eq 1 ]; then
+    # Compact single-line JSON — suitable for log aggregation.
+    printf '{"timestamp":"%s","machine":"%s","data_dir":"%s","today":"%s","today_mb":%d,"total_mb":%d,"warn_mb":%d,"alert_mb":%d,"level":"%s","gzip_active":"%s","partition_count":%d}\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        "$MACHINE" \
+        "$DATA_DIR" \
+        "$TODAY" \
+        "$TODAY_MB" \
+        "$TOTAL_MB" \
+        "$WARN_MB" \
+        "$ALERT_MB" \
+        "$LEVEL" \
+        "$GZIP_ACTIVE" \
+        "${#PARTITIONS[@]}"
+else
+    log "machine: $MACHINE"
+    log "data dir: $DATA_DIR"
+    log "today's partition ($TODAY): ${TODAY_MB} MB across ${#PARTITIONS[@]} file(s)"
+    log "all-time on this machine: ${TOTAL_MB} MB"
+    log "gzip active: $GZIP_ACTIVE"
+    log "thresholds: warn=${WARN_MB}MB alert=${ALERT_MB}MB"
+    log "LEVEL=${LEVEL}"
+fi
+
+exit "$EXIT"

--- a/scripts/router_pipeline_install.sh
+++ b/scripts/router_pipeline_install.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# router_pipeline_install.sh — Phase 0 Track 7 installer for the router shadow pipeline.
+#
+# What this does
+#   Writes a per-machine drop-in that tells the SAGE daemon to enable the
+#   router shadow hook (SAGE_ROUTER_SHADOW=1) and routes captured records to
+#   SAGE_ROUTER_DATA_DIR. The installer targets the SAGE daemon's environment
+#   only — it NEVER touches system-wide /etc/environment or the user profile.
+#
+# What this does NOT do
+#   * Does not start/stop the daemon. Operators restart it themselves after
+#     install so they can cross-check timing with dashboards/runbooks.
+#   * Does not write any dataset rows. Capture only happens once the daemon
+#     is restarted with the env loaded.
+#   * Does not alter router code. Wiring for SAGE_ROUTER_DATA_DIR lives in
+#     sage/core/sage_consciousness.py (Track 5 + Track 7 patch).
+#
+# Idempotency model
+#   Configuration is persisted to a *drop-in file*, not appended to existing
+#   shell RC files. Re-running the installer rewrites the drop-in from scratch.
+#   The presence-or-absence of lines inside the drop-in is the only source of
+#   truth. There is nothing to deduplicate because there is nothing appended.
+#
+# Locations by install mode
+#   systemd (Linux, service exists)   → /etc/systemd/system/sage-daemon-${machine}.service.d/router-shadow.conf
+#   user-systemd (Linux, no sudo)     → ~/.config/systemd/user/sage-daemon-${machine}.service.d/router-shadow.conf
+#   profile drop-in (macOS / WSL)     → $SAGE_DIR/sage/gateway/router-shadow.env
+#                                        (sourced by operators' launch wrapper)
+#
+# Usage
+#   scripts/router_pipeline_install.sh                 # install for this machine
+#   scripts/router_pipeline_install.sh --dry-run       # print what WOULD happen
+#   scripts/router_pipeline_install.sh --uninstall     # remove the drop-in
+#   scripts/router_pipeline_install.sh --data-dir PATH # override dataset root
+#
+# Environment overrides (read once, echoed in --dry-run output)
+#   SAGE_MACHINE         explicit machine name (overrides hostname detection)
+#   SAGE_ROUTER_DATA_DIR absolute dataset root (default per PRD §5:
+#                        $HOME/ai-workspace/private-context/training-data/router)
+#   SAGE_DIR             SAGE checkout root (default: repo inferred from script)
+#
+# Exit codes
+#   0  success (or dry-run succeeded)
+#   1  prereq failure (python/sage not importable, dataset dir not writable)
+#   2  usage error
+#   3  target daemon config not locatable
+
+set -euo pipefail
+
+# ──────────────────────────────────────────────────────────────────────
+# Path resolution + arg parsing
+# ──────────────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAGE_DIR="${SAGE_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+DRY_RUN=0
+UNINSTALL=0
+DATA_DIR_OVERRIDE=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1 ;;
+        --uninstall) UNINSTALL=1 ;;
+        --data-dir) shift; DATA_DIR_OVERRIDE="${1:-}" ;;
+        --data-dir=*) DATA_DIR_OVERRIDE="${1#*=}" ;;
+        -h|--help)
+            sed -n '2,40p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "[install] unknown arg: $1" >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+log() { echo "[router-install] $*"; }
+
+run() {
+    # Echo under dry-run, otherwise execute.
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "[dry-run] $*"
+    else
+        eval "$@"
+    fi
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# Machine detection (matches sage/gateway/machine_config.py)
+# ──────────────────────────────────────────────────────────────────────
+
+detect_machine() {
+    if [ -n "${SAGE_MACHINE:-}" ]; then
+        echo "$SAGE_MACHINE" | tr '[:upper:]' '[:lower:]'
+        return
+    fi
+    local host
+    host="$(hostname 2>/dev/null | tr '[:upper:]' '[:lower:]')"
+    case "$host" in
+        *thor*) echo "thor" ;;
+        *cbp*) echo "cbp" ;;
+        *legion*) echo "legion" ;;
+        *nomad*|*desktop-9e6hcao*) echo "nomad" ;;
+        *mcnugget*) echo "mcnugget" ;;
+        ubuntu)
+            # Sprout's default hostname on Jetson Orin Nano.
+            if [ -d "/home/sprout" ]; then
+                echo "sprout"
+            else
+                echo "unknown"
+            fi
+            ;;
+        *) echo "$host" ;;
+    esac
+}
+
+MACHINE="$(detect_machine)"
+
+# ──────────────────────────────────────────────────────────────────────
+# Dataset dir + prereqs
+# ──────────────────────────────────────────────────────────────────────
+
+default_data_dir() {
+    # Per PRD §5: records go to private-context/training-data/router/{machine}.
+    # SAGE_ROUTER_DATA_DIR should point at the *root*; the writer builds the
+    # per-machine subdir. We prefer $HOME-relative paths so systemd units can
+    # resolve them under the daemon's User=.
+    local candidates=(
+        "${HOME}/ai-workspace/private-context/training-data/router"
+        "${HOME}/ai-agents/private-context/training-data/router"
+        "/mnt/c/exe/projects/ai-agents/private-context/training-data/router"
+    )
+    for c in "${candidates[@]}"; do
+        # Use the first candidate whose grandparent exists — that tells us
+        # we're on the fleet-topology that matches.
+        local grandparent
+        grandparent="$(dirname "$(dirname "$c")")"
+        if [ -d "$grandparent" ]; then
+            echo "$c"
+            return
+        fi
+    done
+    # Last resort: first candidate (operator will create via runbook).
+    echo "${candidates[0]}"
+}
+
+if [ -n "$DATA_DIR_OVERRIDE" ]; then
+    DATA_DIR="$DATA_DIR_OVERRIDE"
+elif [ -n "${SAGE_ROUTER_DATA_DIR:-}" ]; then
+    DATA_DIR="$SAGE_ROUTER_DATA_DIR"
+else
+    DATA_DIR="$(default_data_dir)"
+fi
+
+check_prereqs() {
+    # Python 3.10+
+    if ! command -v python3 >/dev/null 2>&1; then
+        log "ERROR: python3 not found in PATH" >&2
+        return 1
+    fi
+    local pyver
+    pyver="$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
+    local major minor
+    major="${pyver%.*}"; minor="${pyver#*.}"
+    if [ "$major" -lt 3 ] || { [ "$major" -eq 3 ] && [ "$minor" -lt 10 ]; }; then
+        log "ERROR: python $pyver found; need 3.10+" >&2
+        return 1
+    fi
+
+    # Importable sage package — look in SAGE_DIR first.
+    if ! PYTHONPATH="$SAGE_DIR" python3 -c "import sage" >/dev/null 2>&1; then
+        log "ERROR: 'sage' package not importable from SAGE_DIR=$SAGE_DIR" >&2
+        return 1
+    fi
+
+    # Dataset dir: must be creatable. We don't actually create it here unless
+    # installing for real; in dry-run mode we only check that the parent
+    # exists + is writable so an operator can pre-flight the install.
+    local parent
+    parent="$(dirname "$DATA_DIR")"
+    if [ -d "$parent" ]; then
+        if [ ! -w "$parent" ]; then
+            log "ERROR: dataset parent $parent not writable by $(whoami)" >&2
+            return 1
+        fi
+    else
+        log "WARN: dataset parent $parent does not exist; runbook step required" >&2
+        # Non-fatal: operators following the runbook create it explicitly.
+    fi
+    return 0
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# Target detection: how does THIS machine start the SAGE daemon?
+# ──────────────────────────────────────────────────────────────────────
+
+SYSTEMD_SYSTEM_UNIT="sage-daemon-${MACHINE}"
+SYSTEMD_SYSTEM_DROPIN_DIR="/etc/systemd/system/${SYSTEMD_SYSTEM_UNIT}.service.d"
+SYSTEMD_USER_DROPIN_DIR="${HOME}/.config/systemd/user/${SYSTEMD_SYSTEM_UNIT}.service.d"
+PROFILE_ENV_FILE="${SAGE_DIR}/sage/gateway/router-shadow.env"
+
+DROPIN_FILENAME="router-shadow.conf"
+
+detect_target() {
+    # systemd unit file exists system-wide → system drop-in.
+    if systemctl list-unit-files "${SYSTEMD_SYSTEM_UNIT}.service" 2>/dev/null | grep -q "^${SYSTEMD_SYSTEM_UNIT}.service"; then
+        echo "systemd-system"
+        return
+    fi
+    # systemd user unit present?
+    if systemctl --user list-unit-files "${SYSTEMD_SYSTEM_UNIT}.service" 2>/dev/null | grep -q "^${SYSTEMD_SYSTEM_UNIT}.service"; then
+        echo "systemd-user"
+        return
+    fi
+    # No systemd → fallback env file sourced by ensure_daemon.sh.
+    echo "profile-env"
+}
+
+TARGET="$(detect_target)"
+
+# ──────────────────────────────────────────────────────────────────────
+# Drop-in content
+# ──────────────────────────────────────────────────────────────────────
+
+systemd_dropin_body() {
+    # Minimal drop-in: ONLY the router-shadow env.
+    cat <<EOF
+# Installed by scripts/router_pipeline_install.sh — Phase 0 Track 7.
+# Remove with: scripts/router_pipeline_install.sh --uninstall
+# Detected machine: ${MACHINE}
+[Service]
+Environment=SAGE_ROUTER_SHADOW=1
+Environment=SAGE_ROUTER_DATA_DIR=${DATA_DIR}
+EOF
+}
+
+profile_env_body() {
+    cat <<EOF
+# Installed by scripts/router_pipeline_install.sh — Phase 0 Track 7.
+# Sourced by sage/scripts/ensure_daemon.sh and raising wrappers.
+# Remove with: scripts/router_pipeline_install.sh --uninstall
+export SAGE_ROUTER_SHADOW=1
+export SAGE_ROUTER_DATA_DIR=${DATA_DIR}
+EOF
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# Install / uninstall drivers
+# ──────────────────────────────────────────────────────────────────────
+
+install_systemd_system() {
+    log "target: systemd system unit (${SYSTEMD_SYSTEM_UNIT}.service)"
+    run "sudo mkdir -p \"$SYSTEMD_SYSTEM_DROPIN_DIR\""
+    local body
+    body="$(systemd_dropin_body)"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "[dry-run] would write ${SYSTEMD_SYSTEM_DROPIN_DIR}/${DROPIN_FILENAME}:"
+        echo "$body" | sed 's/^/[dry-run]   /'
+    else
+        echo "$body" | sudo tee "${SYSTEMD_SYSTEM_DROPIN_DIR}/${DROPIN_FILENAME}" >/dev/null
+        sudo systemctl daemon-reload
+        log "installed. Restart with: sudo systemctl restart ${SYSTEMD_SYSTEM_UNIT}"
+    fi
+}
+
+install_systemd_user() {
+    log "target: systemd user unit (${SYSTEMD_SYSTEM_UNIT}.service, user scope)"
+    run "mkdir -p \"$SYSTEMD_USER_DROPIN_DIR\""
+    local body
+    body="$(systemd_dropin_body)"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "[dry-run] would write ${SYSTEMD_USER_DROPIN_DIR}/${DROPIN_FILENAME}:"
+        echo "$body" | sed 's/^/[dry-run]   /'
+    else
+        echo "$body" > "${SYSTEMD_USER_DROPIN_DIR}/${DROPIN_FILENAME}"
+        systemctl --user daemon-reload
+        log "installed. Restart with: systemctl --user restart ${SYSTEMD_SYSTEM_UNIT}"
+    fi
+}
+
+install_profile_env() {
+    log "target: profile env file (${PROFILE_ENV_FILE})"
+    run "mkdir -p \"$(dirname "$PROFILE_ENV_FILE")\""
+    local body
+    body="$(profile_env_body)"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "[dry-run] would write ${PROFILE_ENV_FILE}:"
+        echo "$body" | sed 's/^/[dry-run]   /'
+    else
+        echo "$body" > "$PROFILE_ENV_FILE"
+        chmod 0644 "$PROFILE_ENV_FILE"
+        log "installed. Daemon launchers should source this file before exec."
+        log "  e.g.  set -a; . ${PROFILE_ENV_FILE}; set +a; python3 -m sage.gateway"
+    fi
+}
+
+uninstall_systemd_system() {
+    local path="${SYSTEMD_SYSTEM_DROPIN_DIR}/${DROPIN_FILENAME}"
+    if [ -f "$path" ]; then
+        run "sudo rm -f \"$path\""
+        run "sudo rmdir --ignore-fail-on-non-empty \"$SYSTEMD_SYSTEM_DROPIN_DIR\" 2>/dev/null || true"
+        run "sudo systemctl daemon-reload"
+        log "removed ${path}"
+    else
+        log "nothing to remove at ${path}"
+    fi
+}
+
+uninstall_systemd_user() {
+    local path="${SYSTEMD_USER_DROPIN_DIR}/${DROPIN_FILENAME}"
+    if [ -f "$path" ]; then
+        run "rm -f \"$path\""
+        run "rmdir --ignore-fail-on-non-empty \"$SYSTEMD_USER_DROPIN_DIR\" 2>/dev/null || true"
+        run "systemctl --user daemon-reload"
+        log "removed ${path}"
+    else
+        log "nothing to remove at ${path}"
+    fi
+}
+
+uninstall_profile_env() {
+    if [ -f "$PROFILE_ENV_FILE" ]; then
+        run "rm -f \"$PROFILE_ENV_FILE\""
+        log "removed ${PROFILE_ENV_FILE}"
+    else
+        log "nothing to remove at ${PROFILE_ENV_FILE}"
+    fi
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# Main
+# ──────────────────────────────────────────────────────────────────────
+
+log "SAGE_DIR=${SAGE_DIR}"
+log "machine=${MACHINE}"
+log "dataset dir=${DATA_DIR}"
+log "target=${TARGET}"
+log "mode=$([ "$UNINSTALL" -eq 1 ] && echo uninstall || echo install)$([ "$DRY_RUN" -eq 1 ] && echo " (dry-run)" || echo "")"
+
+if [ "$UNINSTALL" -eq 1 ]; then
+    case "$TARGET" in
+        systemd-system) uninstall_systemd_system ;;
+        systemd-user)   uninstall_systemd_user ;;
+        profile-env)    uninstall_profile_env ;;
+        *) log "ERROR: unknown target $TARGET" >&2; exit 3 ;;
+    esac
+    exit 0
+fi
+
+# Install path — run prereqs first.
+if ! check_prereqs; then
+    exit 1
+fi
+
+case "$TARGET" in
+    systemd-system) install_systemd_system ;;
+    systemd-user)   install_systemd_user ;;
+    profile-env)    install_profile_env ;;
+    *) log "ERROR: unknown target $TARGET" >&2; exit 3 ;;
+esac
+
+log "done. Verify after daemon restart with: scripts/router_pipeline_verify.sh"

--- a/scripts/router_pipeline_verify.sh
+++ b/scripts/router_pipeline_verify.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# router_pipeline_verify.sh — Post-install verification for the router shadow pipeline.
+#
+# What it checks
+#   1. The installer's drop-in exists and carries SAGE_ROUTER_SHADOW=1.
+#   2. The dataset directory exists and is writable.
+#   3. (If the daemon is running) at least one record is written within
+#      ${SAGE_ROUTER_VERIFY_WAIT} seconds (default 60).
+#   4. Reports records/hour rate, last-write timestamp, partition bytes.
+#
+# What it deliberately does not do
+#   * Start/stop the daemon. Installers / runbook steps do that.
+#   * Interpret record contents. This is purely an ingestion-rate check.
+#
+# Usage
+#   scripts/router_pipeline_verify.sh
+#   scripts/router_pipeline_verify.sh --wait 120
+#   SAGE_MACHINE=sprout scripts/router_pipeline_verify.sh
+#   SAGE_ROUTER_DATA_DIR=/tmp/router scripts/router_pipeline_verify.sh
+#
+# Exit codes
+#   0 all checks pass
+#   1 configuration not found (drop-in missing)
+#   2 dataset directory problem (missing / unwritable)
+#   3 no records written in verify window
+#   4 usage error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAGE_DIR="${SAGE_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+WAIT_SECONDS="${SAGE_ROUTER_VERIFY_WAIT:-60}"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --wait) shift; WAIT_SECONDS="${1:-60}" ;;
+        --wait=*) WAIT_SECONDS="${1#*=}" ;;
+        -h|--help)
+            sed -n '2,30p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 4 ;;
+    esac
+    shift
+done
+
+log() { echo "[router-verify] $*"; }
+
+# ──────────────────────────────────────────────────────────────────────
+# Same detection as installer — must agree.
+# ──────────────────────────────────────────────────────────────────────
+
+detect_machine() {
+    if [ -n "${SAGE_MACHINE:-}" ]; then
+        echo "$SAGE_MACHINE" | tr '[:upper:]' '[:lower:]'; return
+    fi
+    local host; host="$(hostname 2>/dev/null | tr '[:upper:]' '[:lower:]')"
+    case "$host" in
+        *thor*) echo "thor" ;;
+        *cbp*) echo "cbp" ;;
+        *legion*) echo "legion" ;;
+        *nomad*|*desktop-9e6hcao*) echo "nomad" ;;
+        *mcnugget*) echo "mcnugget" ;;
+        ubuntu) [ -d "/home/sprout" ] && echo "sprout" || echo "unknown" ;;
+        *) echo "$host" ;;
+    esac
+}
+
+MACHINE="$(detect_machine)"
+UNIT="sage-daemon-${MACHINE}"
+SYSTEM_DROPIN="/etc/systemd/system/${UNIT}.service.d/router-shadow.conf"
+USER_DROPIN="${HOME}/.config/systemd/user/${UNIT}.service.d/router-shadow.conf"
+PROFILE_ENV="${SAGE_DIR}/sage/gateway/router-shadow.env"
+
+# ──────────────────────────────────────────────────────────────────────
+# Step 1: locate the config drop-in + extract SAGE_ROUTER_DATA_DIR
+# ──────────────────────────────────────────────────────────────────────
+
+DROPIN_PATH=""
+for candidate in "$SYSTEM_DROPIN" "$USER_DROPIN" "$PROFILE_ENV"; do
+    if [ -f "$candidate" ]; then
+        DROPIN_PATH="$candidate"; break
+    fi
+done
+
+if [ -z "$DROPIN_PATH" ]; then
+    log "ERROR: no router-shadow drop-in found for machine=${MACHINE}"
+    log "  checked: $SYSTEM_DROPIN"
+    log "  checked: $USER_DROPIN"
+    log "  checked: $PROFILE_ENV"
+    exit 1
+fi
+log "drop-in: $DROPIN_PATH"
+
+if ! grep -q "SAGE_ROUTER_SHADOW=1" "$DROPIN_PATH"; then
+    log "ERROR: drop-in does not set SAGE_ROUTER_SHADOW=1"
+    exit 1
+fi
+log "SAGE_ROUTER_SHADOW=1 present"
+
+# Extract data dir from drop-in (handles both systemd Environment= and shell export).
+DATA_DIR="$(grep -E '(Environment=)?(export )?SAGE_ROUTER_DATA_DIR=' "$DROPIN_PATH" \
+            | sed -E 's/.*SAGE_ROUTER_DATA_DIR=//; s/^"//; s/"$//' | head -n1)"
+
+# Allow env override (lets operators verify a non-standard location).
+DATA_DIR="${SAGE_ROUTER_DATA_DIR:-$DATA_DIR}"
+
+if [ -z "$DATA_DIR" ]; then
+    log "ERROR: could not determine SAGE_ROUTER_DATA_DIR"
+    exit 1
+fi
+log "dataset dir: $DATA_DIR"
+
+# ──────────────────────────────────────────────────────────────────────
+# Step 2: check dataset dir
+# ──────────────────────────────────────────────────────────────────────
+
+if [ ! -d "$DATA_DIR" ]; then
+    log "WARN: dataset dir does not exist yet; will appear on first write"
+fi
+
+MACHINE_DIR="${DATA_DIR}/${MACHINE}"
+if [ ! -d "$MACHINE_DIR" ]; then
+    log "WARN: per-machine dir ${MACHINE_DIR} does not exist yet"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# Step 3: poll for a record written inside the verify window
+# ──────────────────────────────────────────────────────────────────────
+
+find_latest_partition() {
+    if [ ! -d "$MACHINE_DIR" ]; then echo ""; return; fi
+    # Most-recently-modified .jsonl or .jsonl.gz
+    local f
+    f=$(find "$MACHINE_DIR" -maxdepth 1 -type f \
+           \( -name '*.jsonl' -o -name '*.jsonl.gz' \) \
+           -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -n1 | awk '{print $2}')
+    echo "$f"
+}
+
+partition_bytes() {
+    local f="$1"
+    [ -f "$f" ] && stat -c '%s' "$f" 2>/dev/null || echo "0"
+}
+
+partition_mtime_epoch() {
+    local f="$1"
+    [ -f "$f" ] && stat -c '%Y' "$f" 2>/dev/null || echo "0"
+}
+
+log "polling for records (window=${WAIT_SECONDS}s)..."
+
+START_EPOCH="$(date +%s)"
+INITIAL_BYTES=0
+INITIAL_PARTITION="$(find_latest_partition || true)"
+if [ -n "$INITIAL_PARTITION" ]; then
+    INITIAL_BYTES="$(partition_bytes "$INITIAL_PARTITION")"
+    log "  initial partition: $(basename "$INITIAL_PARTITION") (${INITIAL_BYTES} bytes)"
+fi
+
+WAITED=0
+INTERVAL=2
+DETECTED_WRITE=0
+while [ "$WAITED" -lt "$WAIT_SECONDS" ]; do
+    P="$(find_latest_partition || true)"
+    if [ -n "$P" ]; then
+        B="$(partition_bytes "$P")"
+        M="$(partition_mtime_epoch "$P")"
+        if [ "$P" != "$INITIAL_PARTITION" ] || [ "$B" -gt "$INITIAL_BYTES" ] || [ "$M" -gt "$START_EPOCH" ]; then
+            DETECTED_WRITE=1
+            break
+        fi
+    fi
+    sleep "$INTERVAL"
+    WAITED=$((WAITED + INTERVAL))
+done
+
+# ──────────────────────────────────────────────────────────────────────
+# Step 4: report
+# ──────────────────────────────────────────────────────────────────────
+
+CURRENT_PARTITION="$(find_latest_partition || true)"
+if [ -z "$CURRENT_PARTITION" ]; then
+    log "ERROR: no partition file found after ${WAIT_SECONDS}s in ${MACHINE_DIR}"
+    log "  confirm daemon is running and restarted after install"
+    exit 3
+fi
+
+BYTES="$(partition_bytes "$CURRENT_PARTITION")"
+MTIME_EPOCH="$(partition_mtime_epoch "$CURRENT_PARTITION")"
+MTIME_ISO="$(date -u -d "@${MTIME_EPOCH}" +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "$MTIME_EPOCH")"
+
+# Crude records/hour estimate: bytes since the partition's first mtime / avg record size.
+# Real sizing uses the writer's tracked count when we wire dashboards (Track 8).
+# For verify, 800 bytes/record plain or ~120 bytes/record gzipped is a reasonable
+# rough cut on Phase 0 records.
+AVG_BYTES=800
+case "$CURRENT_PARTITION" in
+    *.gz) AVG_BYTES=120 ;;
+esac
+RATE_PER_HOUR=$(( BYTES / AVG_BYTES ))
+
+log "latest partition: $(basename "$CURRENT_PARTITION")"
+log "  size: ${BYTES} bytes"
+log "  last write: ${MTIME_ISO}"
+log "  approx records (avg=${AVG_BYTES}B): ${RATE_PER_HOUR}"
+
+if [ "$DETECTED_WRITE" -eq 0 ]; then
+    log "ERROR: no new bytes written during ${WAIT_SECONDS}s verify window"
+    log "  daemon may be idle, not restarted, or shadow not wired"
+    exit 3
+fi
+
+log "OK — router shadow pipeline is capturing records"

--- a/scripts/tests/test_router_pipeline_scripts.sh
+++ b/scripts/tests/test_router_pipeline_scripts.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# test_router_pipeline_scripts.sh — shell tests for Phase 0 Track 7 scripts.
+#
+# Covers:
+#   1. syntax of all three scripts (bash -n)
+#   2. install --dry-run emits expected env content
+#   3. install --uninstall --dry-run is a no-op when nothing is installed
+#   4. disk-monitor levels (OK / WARN / ALERT) on synthetic datasets
+#   5. verify script fails closed when no drop-in is present
+#
+# This is a boring shell-level test. Python-based correctness lives in
+# sage/cognition/router/tests/.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAGE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+INSTALL="$SAGE_DIR/scripts/router_pipeline_install.sh"
+VERIFY="$SAGE_DIR/scripts/router_pipeline_verify.sh"
+MONITOR="$SAGE_DIR/scripts/router_pipeline_disk_monitor.sh"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1 — $2"; FAIL=$((FAIL + 1)); FAILED_NAMES+=("$1"); }
+
+run_case() {
+    local name="$1"; shift
+    echo "CASE: $name"
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# 1. Syntax
+# ──────────────────────────────────────────────────────────────────────
+
+run_case "syntax check on three scripts"
+for s in "$INSTALL" "$VERIFY" "$MONITOR"; do
+    if bash -n "$s" 2>/tmp/syntax_err; then
+        pass "bash -n $(basename "$s")"
+    else
+        fail "bash -n $(basename "$s")" "$(cat /tmp/syntax_err)"
+    fi
+done
+
+# ──────────────────────────────────────────────────────────────────────
+# 2. install --dry-run outputs expected env exports
+# ──────────────────────────────────────────────────────────────────────
+
+run_case "install --dry-run emits env exports"
+OUT="$(SAGE_MACHINE=sprout "$INSTALL" --dry-run 2>&1)"
+if echo "$OUT" | grep -q "SAGE_ROUTER_SHADOW=1"; then
+    pass "dry-run mentions SAGE_ROUTER_SHADOW=1"
+else
+    fail "dry-run mentions SAGE_ROUTER_SHADOW=1" "output: $OUT"
+fi
+if echo "$OUT" | grep -q "SAGE_ROUTER_DATA_DIR="; then
+    pass "dry-run mentions SAGE_ROUTER_DATA_DIR="
+else
+    fail "dry-run mentions SAGE_ROUTER_DATA_DIR=" "output: $OUT"
+fi
+if echo "$OUT" | grep -q "machine=sprout"; then
+    pass "dry-run honors SAGE_MACHINE override"
+else
+    fail "dry-run honors SAGE_MACHINE override" "output: $OUT"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# 3. uninstall --dry-run is safe when nothing is installed
+# ──────────────────────────────────────────────────────────────────────
+
+run_case "uninstall --dry-run when nothing installed"
+OUT="$(SAGE_MACHINE=sprout SAGE_DIR=$(mktemp -d) "$INSTALL" --uninstall --dry-run 2>&1 || true)"
+if echo "$OUT" | grep -q "nothing to remove"; then
+    pass "uninstall reports nothing to remove"
+else
+    fail "uninstall reports nothing to remove" "output: $OUT"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# 4. disk monitor levels
+# ──────────────────────────────────────────────────────────────────────
+
+run_case "disk monitor OK on tiny dataset"
+TMP="$(mktemp -d)"
+mkdir -p "$TMP/sprout"
+echo "one record" > "$TMP/sprout/$(date -u +%Y-%m-%d).jsonl"
+set +e
+OUT="$(SAGE_MACHINE=sprout "$MONITOR" --data-dir "$TMP" --json 2>&1)"
+RC=$?
+set -e
+if [ "$RC" -eq 0 ] && echo "$OUT" | grep -q '"level":"OK"'; then
+    pass "OK level on tiny dataset"
+else
+    fail "OK level on tiny dataset" "rc=$RC output=$OUT"
+fi
+rm -rf "$TMP"
+
+run_case "disk monitor WARN at warn threshold"
+TMP="$(mktemp -d)"
+mkdir -p "$TMP/sprout"
+dd if=/dev/zero of="$TMP/sprout/$(date -u +%Y-%m-%d).jsonl" bs=1M count=75 status=none
+set +e
+OUT="$(SAGE_MACHINE=sprout "$MONITOR" --data-dir "$TMP" --json 2>&1)"
+RC=$?
+set -e
+if [ "$RC" -eq 0 ] && echo "$OUT" | grep -q '"level":"WARN"'; then
+    pass "WARN level at 75MB (default warn=50MB)"
+else
+    fail "WARN level at 75MB" "rc=$RC output=$OUT"
+fi
+rm -rf "$TMP"
+
+run_case "disk monitor ALERT past alert threshold"
+TMP="$(mktemp -d)"
+mkdir -p "$TMP/sprout"
+dd if=/dev/zero of="$TMP/sprout/$(date -u +%Y-%m-%d).jsonl" bs=1M count=250 status=none
+set +e
+OUT="$(SAGE_MACHINE=sprout "$MONITOR" --data-dir "$TMP" --json 2>&1)"
+RC=$?
+set -e
+if [ "$RC" -eq 2 ] && echo "$OUT" | grep -q '"level":"ALERT"'; then
+    pass "ALERT level at 250MB with exit=2"
+else
+    fail "ALERT level at 250MB" "rc=$RC output=$OUT"
+fi
+rm -rf "$TMP"
+
+run_case "disk monitor respects custom thresholds"
+TMP="$(mktemp -d)"
+mkdir -p "$TMP/sprout"
+dd if=/dev/zero of="$TMP/sprout/$(date -u +%Y-%m-%d).jsonl" bs=1M count=10 status=none
+set +e
+OUT="$(SAGE_MACHINE=sprout "$MONITOR" --data-dir "$TMP" --warn-mb 5 --alert-mb 8 --json 2>&1)"
+RC=$?
+set -e
+if [ "$RC" -eq 2 ] && echo "$OUT" | grep -q '"level":"ALERT"'; then
+    pass "custom thresholds override defaults"
+else
+    fail "custom thresholds override defaults" "rc=$RC output=$OUT"
+fi
+rm -rf "$TMP"
+
+# ──────────────────────────────────────────────────────────────────────
+# 5. verify fails closed without drop-in
+# ──────────────────────────────────────────────────────────────────────
+
+run_case "verify fails closed with no drop-in"
+FAKE_SAGE="$(mktemp -d)"
+set +e
+OUT="$(SAGE_MACHINE=spritepanda SAGE_DIR="$FAKE_SAGE" "$VERIFY" --wait 1 2>&1)"
+RC=$?
+set -e
+if [ "$RC" -eq 1 ] && echo "$OUT" | grep -q "no router-shadow drop-in found"; then
+    pass "verify exits 1 with 'no drop-in found'"
+else
+    fail "verify exits 1 when no drop-in" "rc=$RC output=$OUT"
+fi
+rm -rf "$FAKE_SAGE"
+
+# ──────────────────────────────────────────────────────────────────────
+# Summary
+# ──────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────"
+echo "TOTAL: $((PASS + FAIL))   PASS: $PASS   FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+    echo "Failed cases:"
+    for n in "${FAILED_NAMES[@]}"; do echo "  - $n"; done
+    exit 1
+fi
+echo "OK"


### PR DESCRIPTION
## Track
Phase 0, Track 7 — Per-machine deployment (per `shared-context/arc-agi-3/phase2/brain-arch/router-sprint-1-phase-0.md`).

## What this ships

**Scripts (SAGE/scripts/)**
- `router_pipeline_install.sh` — idempotent drop-in installer. Detects the machine (via `SAGE_MACHINE` or hostname matching `sage/gateway/machine_config.py`), picks the daemon config target (systemd-system → systemd-user → profile-env fallback), and writes a dedicated drop-in file with exactly two lines:
  - `SAGE_ROUTER_SHADOW=1`
  - `SAGE_ROUTER_DATA_DIR=<resolved path>`

  Supports `--dry-run`, `--uninstall`, `--data-dir PATH`.
- `router_pipeline_verify.sh` — locates the drop-in, confirms `SAGE_ROUTER_SHADOW=1`, polls the dataset dir for new writes within a configurable window (default 60 s), and reports partition size / last-write / approx records.
- `router_pipeline_disk_monitor.sh` — cron-ready. Defaults WARN at 50 MB/day, ALERT at 200 MB/day; supports `--json` for log aggregation. Exit codes: 0 OK/WARN, 2 ALERT, 3 not installed.

**Tests (SAGE/scripts/tests/)**
- `test_router_pipeline_scripts.sh` — 12 shell cases: syntax on all three scripts, install --dry-run emits expected env exports, uninstall --dry-run safe when not installed, disk monitor OK/WARN/ALERT on synthetic datasets with default and custom thresholds, verify fails closed when no drop-in exists.

**Code patch (sage/core/sage_consciousness.py)**
- Added env-var fallback in `_init_router_shadow`: resolution order is now `config['router_shadow_dir']` → `$SAGE_ROUTER_DATA_DIR` → `{instance_dir}/router_shadow` → `/tmp/sage-router-shadow`. The env var is the knob the installer writes; config override still wins.

**Docs**
- `private-context/runbooks/router-pipeline.md` — operator runbook (enablement, canary order, rollback, monitoring, troubleshooting).
- `shared-context/arc-agi-3/phase2/brain-arch/router-pipeline-deployment-status.md` — fleet status template for ops.

## What this does NOT ship (deferred)

- Automatic daemon restart (operators restart manually so they can cross-check the verify timing).
- Fleet-wide orchestration (one machine at a time via the runbook's canary ladder).
- Dashboard auto-updates (Track 8).
- Pruner scheduling (Track 9 ships the pruner; wiring it into cron is a follow-up — acknowledged in the runbook).

## Tests added
- 12 shell cases in `scripts/tests/test_router_pipeline_scripts.sh`

## Test results

```
CASE: syntax check on three scripts
  PASS: bash -n router_pipeline_install.sh
  PASS: bash -n router_pipeline_verify.sh
  PASS: bash -n router_pipeline_disk_monitor.sh
CASE: install --dry-run emits env exports
  PASS: dry-run mentions SAGE_ROUTER_SHADOW=1
  PASS: dry-run mentions SAGE_ROUTER_DATA_DIR=
  PASS: dry-run honors SAGE_MACHINE override
CASE: uninstall --dry-run when nothing installed
  PASS: uninstall reports nothing to remove
CASE: disk monitor OK on tiny dataset
  PASS: OK level on tiny dataset
CASE: disk monitor WARN at warn threshold
  PASS: WARN level at 75MB (default warn=50MB)
CASE: disk monitor ALERT past alert threshold
  PASS: ALERT level at 250MB with exit=2
CASE: disk monitor respects custom thresholds
  PASS: custom thresholds override defaults
CASE: verify fails closed with no drop-in
  PASS: verify exits 1 with 'no drop-in found'

TOTAL: 12   PASS: 12   FAIL: 0
OK
```

Also re-ran the existing 242-case router test suite (`sage/cognition/router/tests/` + `sage/cognition/router/data/tests/`) — **242 passed** after the consciousness-loop patch.

## Acceptance criteria from sprint doc

- [x] Drop-in script adds `SAGE_ROUTER_SHADOW=1` to each machine's daemon env
- [x] Dataset writes land in expected location after daemon restart (verify script polls + reports)
- [x] Disk-usage monitor with alerting
- [x] Documentation in `private-context/runbooks/router-pipeline.md`
- [ ] Enabled on Sprout first as canary — **deferred to operator execution per runbook canary order**
- [ ] 24 h records captured cleanly — **same**

## Reviewer notes

**Daemon startup config paths discovered:**
- systemd: `sage/gateway/systemd/sage-daemon-sprout.service` + `sage-daemon-thor.service` — these are the live references. Other machines use a manual launcher via `sage/scripts/ensure_daemon.sh` → `python3 -m sage.gateway`. The installer targets systemd first, falls back to a profile env file (`sage/gateway/router-shadow.env`) that launchers should `source`.
- The service files use `Environment=SAGE_MACHINE=...`, so the installer's drop-in (also `Environment=`) composes correctly. A `.service.d/router-shadow.conf` drop-in is the clean systemd idiom for adding vars without editing the main unit.

**Idempotency mechanism:**
- Writing a *dedicated* drop-in file rather than appending to an existing RC. Re-running rewrites from scratch. There is no dedup logic because there is nothing to dedup. Uninstall removes exactly that file and nothing else.

**Canary order rationale** (in the runbook):
1. sprout — smallest blast radius, edge-validated already
2. nomad — oversight-pool laptop, second-smallest model
3. mcnugget — first non-CUDA (MPS) test
4. legion — first heavy-synth (4090)
5. thor — highest-value synthesis (Jetson AGX)
6. cbp — last (CPU-only WSL2, pipeline already burned in everywhere else)

24 h soak between steps.

**Disk threshold defaults** (diverging from sprint doc's 100 MB/day):
- Sprint doc cites 100 MB/day plain. Track 4 landed with gzip **on** by default; synthetic data compresses ~70× and real records compress materially less but still well inside single-digit MB/day.
- WARN at 50 MB/day — "notable but not alarming under gzip."
- ALERT at 200 MB/day — "gzip is off, or the loop is stuck in a tight tick."
- Both overridable via `--warn-mb` / `--alert-mb` or env vars.

**Companion commits (outside this PR):**
- `private-context` main: `runbooks/router-pipeline.md`
- `shared-context` main: `arc-agi-3/phase2/brain-arch/router-pipeline-deployment-status.md`

## Dependencies
- Requires Tracks 1–5 + 9 merged (already in main). Shadow hook gated by `SAGE_ROUTER_SHADOW=1` — off without this PR's installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)