### PR TITLE
[router] Sprint 2 R1: source-stamping via RouterRecord.metadata

### DIFF
--- a/sage/cognition/router/record.py
+++ b/sage/cognition/router/record.py
@@ -14,6 +14,8 @@ Schema versioning: every record carries ``schema_version``. The reader
 
 Spec: shared-context/arc-agi-3/phase2/brain-arch/router-sprint-1-phase-0.md
       (Track 1 deliverables)
+      shared-context/arc-agi-3/phase2/brain-arch/router-sprint-2-rollout-federation.md
+      (Sprint 2 R1: source-stamping via metadata)
 """
 
 import time
@@ -28,7 +30,22 @@ from sage.cognition.router.outputs import RouterOutput
 # Bumped when the record schema (or any of its nested schemas) changes
 # in a non-backward-compatible way. Readers must reject unknown versions
 # loudly rather than silently coerce.
-ROUTER_SCHEMA_VERSION = "v0.1.0"
+#
+# v0.1.0 → v0.2.0 (2026-04-17): added `metadata` field to RouterRecord
+# for source-stamping (raising / gameplay / idle / interactive) per
+# Sprint 2 R1. Backward-compatible read: from_dict tolerates missing
+# metadata, defaults to empty dict.
+ROUTER_SCHEMA_VERSION = "v0.2.0"
+
+
+# Valid values for metadata["source"]. A record's source is determined at
+# capture time from the SAGE_SESSION_SOURCE env var (set by raising
+# wrappers, game-play harnesses, etc.). Unknown or absent → "idle".
+VALID_RECORD_SOURCES = {"raising", "gameplay", "idle", "interactive"}
+
+
+# Env var consulted by the shadow hook at record-write time.
+SOURCE_ENV_VAR = "SAGE_SESSION_SOURCE"
 
 
 def _default_record_id() -> str:
@@ -61,6 +78,12 @@ class RouterRecord:
     # freeze the shape.
     outcome: Optional[Dict[str, Any]] = None
 
+    # Sprint 2 R1 — extensible capture-time metadata. Currently holds
+    # `source` (raising | gameplay | idle | interactive); future keys
+    # (e.g. `session_id`, `user_hint`) can be added without schema bumps
+    # as long as they stay JSON-serializable.
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
     # ──────────────────────────────────────────────────────────────
     # Validation
     # ──────────────────────────────────────────────────────────────
@@ -80,6 +103,14 @@ class RouterRecord:
             raise TypeError("router_output must be a RouterOutput instance")
         if self.outcome is not None and not isinstance(self.outcome, dict):
             raise TypeError("outcome must be dict or None")
+        if not isinstance(self.metadata, dict):
+            raise TypeError("metadata must be dict")
+        # Source is optional in metadata but if present must be in the closed set.
+        src = self.metadata.get("source")
+        if src is not None and src not in VALID_RECORD_SOURCES:
+            raise ValueError(
+                f"metadata['source']={src!r} not in {sorted(VALID_RECORD_SOURCES)}"
+            )
 
     # ──────────────────────────────────────────────────────────────
     # Serialization
@@ -100,6 +131,7 @@ class RouterRecord:
             "router_input": self.router_input.to_dict(),
             "router_output": self.router_output.to_dict(),
             "outcome": self.outcome,
+            "metadata": dict(self.metadata),
         }
 
     @classmethod
@@ -109,6 +141,9 @@ class RouterRecord:
         Schema versioning: we DO NOT reject unknown versions here; the
         caller (Track 4 dataset reader) owns that policy because it may
         want to route old records through a migration function.
+
+        Backward-compatible with v0.1.0 records: missing ``metadata`` →
+        empty dict.
         """
         return cls(
             record_id=data["record_id"],
@@ -118,6 +153,7 @@ class RouterRecord:
             router_input=RouterInput.from_dict(data["router_input"]),
             router_output=RouterOutput.from_dict(data["router_output"]),
             outcome=data.get("outcome"),
+            metadata=dict(data.get("metadata") or {}),
         )
 
     # ──────────────────────────────────────────────────────────────
@@ -141,4 +177,5 @@ class RouterRecord:
             router_input=self.router_input,
             router_output=self.router_output,
             outcome=dict(outcome),
+            metadata=dict(self.metadata),
         )

--- a/sage/cognition/router/shadow.py
+++ b/sage/cognition/router/shadow.py
@@ -104,7 +104,11 @@ from typing import Any, Callable, Optional
 
 from sage.cognition.router.inputs import RouterInput
 from sage.cognition.router.outputs import RouterOutput
-from sage.cognition.router.record import RouterRecord
+from sage.cognition.router.record import (
+    RouterRecord,
+    SOURCE_ENV_VAR,
+    VALID_RECORD_SOURCES,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -119,6 +123,20 @@ logger = logging.getLogger(__name__)
 # hook construction by ``is_shadow_enabled()``; callers gate their
 # lazy instantiation on that helper.
 SHADOW_ENV_VAR = "SAGE_ROUTER_SHADOW"
+
+
+def _build_record_metadata() -> dict:
+    """Assemble metadata dict for a new RouterRecord at capture time.
+
+    Currently carries `source` from ``SAGE_SESSION_SOURCE`` env var.
+    Unknown or absent value → "idle" as a neutral default. The closed
+    vocabulary (VALID_RECORD_SOURCES) is enforced by RouterRecord's
+    validator — this function coerces unknown env values to "idle"
+    rather than letting record construction fail.
+    """
+    raw = os.environ.get(SOURCE_ENV_VAR, "").strip()
+    source = raw if raw in VALID_RECORD_SOURCES else "idle"
+    return {"source": source}
 
 
 def is_shadow_enabled() -> bool:
@@ -256,11 +274,15 @@ class RouterShadowHook:
 
             # Build the record. Defaults fill record_id (uuid4),
             # schema_version, timestamp, machine (later overridden
-            # by writer if empty).
+            # by writer if empty). Metadata carries source stamp from
+            # SAGE_SESSION_SOURCE env var (raising / gameplay / idle /
+            # interactive). Absent → "idle" as a neutral default.
+            metadata = _build_record_metadata()
             try:
                 record = RouterRecord(
                     router_input=router_input,
                     router_output=programmatic_output,
+                    metadata=metadata,
                 )
             except Exception as e:  # noqa: BLE001
                 logger.warning("router shadow record construction failed: %s", e)

--- a/sage/cognition/router/tests/test_schemas.py
+++ b/sage/cognition/router/tests/test_schemas.py
@@ -530,3 +530,108 @@ def test_valid_rationale_codes_cover_prd_examples():
                  "metacog_blocked", "goal_driven", "reflex",
                  "escalate_frontal", "federate_peer"):
         assert code in VALID_RATIONALE_CODES
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Sprint 2 R1 — source-stamping via metadata
+# ──────────────────────────────────────────────────────────────────────
+
+import os
+from sage.cognition.router.record import (
+    VALID_RECORD_SOURCES,
+    SOURCE_ENV_VAR,
+    ROUTER_SCHEMA_VERSION,
+)
+
+
+def _make_minimal_record(**kwargs):
+    """Helper: build a valid RouterRecord with minimal required args."""
+    ri = RouterInput(
+        tick=1, timestamp=123.0, goal_id=None,
+        wm_state_key="abc", wm_slot_counts={}, wm_goal_active=False,
+        wm_age_ticks=0, wm_pressure=0.0,
+        sensory_modalities=[], sensory_novelty=0.0, sensory_urgency=0.0,
+        snarc_surprise=0.0, snarc_novelty=0.0, snarc_arousal=0.0,
+        snarc_reward=0.0, snarc_conflict=0.0,
+        metabolic_state="wake", atp_level=50.0, atp_trend="stable",
+        recall_count=0, recall_best_similarity=0.0, recall_best_outcome=None,
+        habit_available=False, habit_confidence=0.0,
+        prior_invoke=0.0, prior_habit=0.0, prior_noop=0.0,
+        metacog_block_list=[],
+        cartridge_recall_count=0, cartridge_recall_best_similarity=0.0,
+        cartridge_recall_embedding=[0.0]*768,
+    )
+    ro = RouterOutput(
+        action="noop", plugin=None, plugin_tier=None, payload_hint=None,
+        habit_id=None, confidence=0.9, energy_estimate=0.0,
+        rationale_code="low_atp_rest",
+    )
+    return RouterRecord(router_input=ri, router_output=ro, **kwargs)
+
+
+def test_schema_version_bumped_to_v020():
+    assert ROUTER_SCHEMA_VERSION == "v0.2.0"
+    r = _make_minimal_record()
+    assert r.schema_version == "v0.2.0"
+
+
+def test_metadata_defaults_to_empty_dict():
+    r = _make_minimal_record()
+    assert r.metadata == {}
+
+
+def test_metadata_roundtrip_preserves_source():
+    r = _make_minimal_record(metadata={"source": "raising"})
+    d = r.to_dict()
+    assert d["metadata"] == {"source": "raising"}
+    r2 = RouterRecord.from_dict(d)
+    assert r2.metadata == {"source": "raising"}
+
+
+def test_metadata_source_validator_rejects_unknown():
+    import pytest
+    with pytest.raises(ValueError):
+        _make_minimal_record(metadata={"source": "unknown_source"})
+
+
+def test_metadata_source_validator_accepts_all_valid():
+    for src in VALID_RECORD_SOURCES:
+        r = _make_minimal_record(metadata={"source": src})
+        assert r.metadata["source"] == src
+
+
+def test_valid_record_sources_matches_prd():
+    # The closed vocabulary per Sprint 2 R1.
+    assert VALID_RECORD_SOURCES == {"raising", "gameplay", "idle", "interactive"}
+
+
+def test_from_dict_backward_compat_missing_metadata():
+    # Simulate a v0.1.0 record that didn't have metadata.
+    r = _make_minimal_record(metadata={"source": "idle"})
+    d = r.to_dict()
+    del d["metadata"]  # old-format record
+    d["schema_version"] = "v0.1.0"
+    r2 = RouterRecord.from_dict(d)
+    assert r2.metadata == {}
+
+
+def test_with_outcome_preserves_metadata():
+    r = _make_minimal_record(metadata={"source": "gameplay"})
+    r2 = r.with_outcome({"ok": True})
+    assert r2.metadata == {"source": "gameplay"}
+    # Non-mutating
+    assert r.outcome is None
+    assert r2.outcome == {"ok": True}
+
+
+def test_shadow_build_metadata_from_env(monkeypatch):
+    from sage.cognition.router.shadow import _build_record_metadata
+    # Absent env → idle
+    monkeypatch.delenv(SOURCE_ENV_VAR, raising=False)
+    assert _build_record_metadata() == {"source": "idle"}
+    # Valid value honored
+    monkeypatch.setenv(SOURCE_ENV_VAR, "raising")
+    assert _build_record_metadata() == {"source": "raising"}
+    # Invalid value coerced to idle (rather than failing record construction)
+    monkeypatch.setenv(SOURCE_ENV_VAR, "bogus")
+    assert _build_record_metadata() == {"source": "idle"}


### PR DESCRIPTION
## Track
Sprint 2 R1 — source-stamping on router records (per `shared-context/arc-agi-3/phase2/brain-arch/router-sprint-2-rollout-federation.md`)

## What this ships
- Schema bump v0.1.0 → v0.2.0
- `RouterRecord.metadata: Dict[str, Any]` field (currently holds `source`)
- `VALID_RECORD_SOURCES = {"raising", "gameplay", "idle", "interactive"}`
- `SOURCE_ENV_VAR = "SAGE_SESSION_SOURCE"` — env var consulted at capture time
- Shadow hook populates metadata via new `_build_record_metadata()` helper
- Unknown/absent source → "idle" (coerces rather than failing record construction — stale env value doesn't break capture)

## What this does NOT ship (deliberate)
- Raising-wrapper env exports (`export SAGE_SESSION_SOURCE=raising`) — touches many scripts, better as a coordinated follow-up once R3/R4 land
- Game-play harness exports — same reason
- Raising mode classification (R5) — deferred pending raising-track coordination

## Backward compatibility
- `from_dict` tolerates v0.1.0 records (missing `metadata` → empty dict)
- All 256 pre-existing router tests still pass unchanged (now 265 with R1 additions)
- `with_outcome` preserves metadata (non-mutating)

## Tests added (10)
- `test_schema_version_bumped_to_v020`
- `test_metadata_defaults_to_empty_dict`
- `test_metadata_roundtrip_preserves_source`
- `test_metadata_source_validator_rejects_unknown`
- `test_metadata_source_validator_accepts_all_valid`
- `test_valid_record_sources_matches_prd`
- `test_from_dict_backward_compat_missing_metadata`
- `test_with_outcome_preserves_metadata`
- `test_shadow_build_metadata_from_env`
- + the helper `_make_minimal_record` used by all of them

## Test results
`python3 -m pytest sage/cognition/router/ -v` → **265 passed** (was 256).

## Downstream consumers unblocked
- **R3 federation aggregator** can partition training corpus by source
- **R4 dashboard** can add per-source slices to agent-zero metrics
- **R5 raising mode classification** slots in as another metadata key without schema bump
- **Phase 1 training** can opt out of source=raising records if distribution turns unhealthy

## Reviewer notes
- Schema bump is cheap (backward-compat read path). Version field exists specifically for this.
- Closed source vocabulary prevents sprawl — new values require a coordinated PR like slot types in WM.
- Shadow helper coerces unknown → idle (not fail-loud) because stale env vars across fleet machines during rollout shouldn't break capture. This is the opposite of the JSON-serializable guard (which is fail-loud) — different risk profile.
- Raising/game wrapper script updates are a follow-up PR to minimize scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)