### PR TITLE
Thor: cross-machine log schema adapter for McNugget episodes

### DIFF
--- a/sage/cognition/episodic/game_log_binder.py
+++ b/sage/cognition/episodic/game_log_binder.py
@@ -21,6 +21,20 @@ from sage.cognition.episodic.data import Episode
 from sage.cognition.episodic.index import EpisodicIndex
 
 LOG_DIR = Path("/home/dp/ai-workspace/shared-context/arc-agi-3/fleet-learning/thor/logs")
+MCNUGGET_LOG_DIR = Path("/home/dp/ai-workspace/shared-context/arc-agi-3/fleet-learning/mcnugget/logs")
+
+
+def _safe_float(val, default=0.5) -> float:
+    """Convert to float, handling string confidence levels."""
+    if isinstance(val, (int, float)):
+        return float(val)
+    mapping = {"LOW": 0.2, "MEDIUM": 0.5, "HIGH": 0.8}
+    if isinstance(val, str) and val.upper() in mapping:
+        return mapping[val.upper()]
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return default
 
 
 def bind_plh_log(log_path: Path, index: EpisodicIndex) -> int:
@@ -156,32 +170,204 @@ def bind_competition_log(log_path: Path, index: EpisodicIndex) -> int:
     return count
 
 
+def bind_mcnugget_r7_log(log_path: Path, index: EpisodicIndex) -> int:
+    """Bind McNugget r7-* logs (rich traces with prediction/reflection)."""
+    with open(log_path) as f:
+        data = json.load(f)
+
+    trace = data.get("trace", [])
+    summary = data.get("summary", {})
+    game = summary.get("game", log_path.stem.split("-")[1] if "-" in log_path.stem else "unknown")
+
+    count = 0
+    for entry in trace:
+        action = entry.get("action", "")
+        if not action:
+            continue
+
+        prediction = entry.get("prediction", "")
+        result = entry.get("result", "")
+        diff = entry.get("pixel_diff", 0)
+        reflection = entry.get("reflection", "")
+        trust = entry.get("trust_update", {})
+        level_won = entry.get("level_won", False)
+        step = entry.get("step", 0)
+
+        reward = 0.0
+        success = None
+        if level_won:
+            reward = 1.0
+            success = True
+        elif diff == 0:
+            reward = -0.2
+            success = False
+        elif diff > 10:
+            reward = 0.3
+
+        ep = Episode(
+            session_id="mcnugget-r7",
+            cycle_id=step,
+            state_signature={
+                "game": game,
+                "experiment": "r7",
+                "prediction": prediction[:100] if prediction else "",
+            },
+            sensory_summary={
+                "result": result[:200] if result else "",
+                "reflection": reflection[:200] if reflection else "",
+                "pixel_diff": str(diff),
+            },
+            snarc_scores={
+                "surprise": 0.9 if level_won else (0.5 if diff > 10 else 0.2),
+                "novelty": 0.6 if step <= 5 else 0.3,
+                "arousal": 0.8 if level_won else 0.4,
+                "reward": max(0, reward),
+                "conflict": _safe_float(entry.get("confidence", 0.5)),
+            },
+            action_taken=action if isinstance(action, str) else str(action),
+            action_args={"trust": trust} if trust else {},
+            outcome=result[:100] if result else None,
+            reward=reward,
+            success=success,
+            tags=[game, "mcnugget", "r7", "game_play"] + (["level_up"] if level_won else []),
+        )
+        index.bind(ep)
+        count += 1
+
+    return count
+
+
+def bind_mcnugget_probe_log(log_path: Path, index: EpisodicIndex) -> int:
+    """Bind McNugget structured-probe-* logs."""
+    with open(log_path) as f:
+        data = json.load(f)
+
+    trace = data.get("trace", [])
+    game = data.get("game", "unknown")
+    won = data.get("won", False)
+
+    count = 0
+    for entry in trace:
+        action = entry.get("action", "")
+        if not action:
+            continue
+
+        phase = entry.get("phase", "")
+        diff = entry.get("pixel_diff", 0)
+        step_won = entry.get("won", False)
+        step = entry.get("step", 0)
+        action_data = entry.get("data", {})
+
+        reward = 0.0
+        success = None
+        if step_won:
+            reward = 1.0
+            success = True
+        elif diff == 0:
+            reward = -0.2
+            success = False
+        elif diff > 10:
+            reward = 0.3
+
+        ep = Episode(
+            session_id="mcnugget-probe",
+            cycle_id=step,
+            state_signature={
+                "game": game,
+                "experiment": "structured_probe",
+                "phase": phase,
+            },
+            sensory_summary={"pixel_diff": str(diff)},
+            snarc_scores={
+                "surprise": 0.9 if step_won else (0.4 if diff > 0 else 0.1),
+                "novelty": 0.7 if phase == "explore" else 0.3,
+                "arousal": 0.8 if step_won else 0.3,
+                "reward": max(0, reward),
+                "conflict": 0.1,
+            },
+            action_taken=action if isinstance(action, str) else str(action),
+            action_args=action_data if isinstance(action_data, dict) else {},
+            outcome=f"{diff}px" if diff else "no change",
+            reward=reward,
+            success=success,
+            tags=[game, "mcnugget", "structured_probe", "game_play"] + (["level_up"] if step_won else []),
+        )
+        index.bind(ep)
+        count += 1
+
+    return count
+
+
 def bind_all_logs(db_path: str = None) -> EpisodicIndex:
-    """Bind all Thor game logs into an episodic index."""
+    """Bind game logs from all fleet machines into an episodic index."""
     index = EpisodicIndex(db_path=db_path)
 
-    if not LOG_DIR.exists():
-        print(f"Log directory not found: {LOG_DIR}")
-        return index
+    # --- Thor logs ---
+    thor_total = 0
+    if LOG_DIR.exists():
+        for log_file in sorted(LOG_DIR.glob("*.json")):
+            try:
+                name = log_file.stem
+                if "plh" in name or "goalscaffold" in name or "twopipe" in name:
+                    count = bind_plh_log(log_file, index)
+                elif "competition" in name:
+                    count = bind_competition_log(log_file, index)
+                elif "autonomous" in name:
+                    continue
+                else:
+                    count = bind_plh_log(log_file, index)
+                thor_total += count
+                print(f"  thor/{name}: {count} episodes")
+            except Exception as e:
+                print(f"  thor/{name}: ERROR {e}")
+    print(f"\nThor: {thor_total} episodes")
 
-    total = 0
-    for log_file in sorted(LOG_DIR.glob("*.json")):
-        try:
-            name = log_file.stem
-            if "plh" in name or "goalscaffold" in name or "twopipe" in name:
-                count = bind_plh_log(log_file, index)
-            elif "competition" in name:
-                count = bind_competition_log(log_file, index)
-            elif "autonomous" in name:
-                continue  # Different format, skip for now
-            else:
-                count = bind_plh_log(log_file, index)  # Try generic
+    # --- McNugget logs ---
+    mc_total = 0
+    if MCNUGGET_LOG_DIR.exists():
+        for log_file in sorted(MCNUGGET_LOG_DIR.glob("*.json")):
+            try:
+                name = log_file.stem
+                with open(log_file) as f:
+                    data = json.load(f)
 
-            total += count
-            print(f"  {name}: {count} episodes")
-        except Exception as e:
-            print(f"  {name}: ERROR {e}")
+                if "trace" in data and data["trace"]:
+                    # Has per-action traces — bind them
+                    first_entry = data["trace"][0]
+                    if "prediction" in first_entry or "reflection" in first_entry:
+                        count = bind_mcnugget_r7_log(log_file, index)
+                    elif "phase" in first_entry:
+                        count = bind_mcnugget_probe_log(log_file, index)
+                    else:
+                        # Generic trace — try probe format
+                        count = bind_mcnugget_probe_log(log_file, index)
+                    mc_total += count
+                    print(f"  mcnugget/{name}: {count} episodes")
+                else:
+                    # Summary-only logs (harness-v1) — bind as single episode per result
+                    results = data.get("results", [])
+                    game = data.get("game", "unknown")
+                    for r in results:
+                        ep = Episode(
+                            session_id="mcnugget-harness",
+                            state_signature={"game": game, "experiment": "harness_v1", "level": r.get("level", 0)},
+                            snarc_scores={"surprise": 0.8 if r.get("won") else 0.3, "reward": 1.0 if r.get("won") else 0.0},
+                            action_taken=f"harness_v1_L{r.get('level', '?')}",
+                            outcome="won" if r.get("won") else f"lost ({r.get('actions', '?')} actions)",
+                            reward=1.0 if r.get("won") else -0.1,
+                            success=r.get("won"),
+                            tags=[game.split("-")[0] if "-" in game else game, "mcnugget", "harness_v1", "game_play"]
+                                 + (["level_up"] if r.get("won") else []),
+                        )
+                        index.bind(ep)
+                        mc_total += 1
+                    if results:
+                        print(f"  mcnugget/{name}: {len(results)} summary episodes")
+            except Exception as e:
+                print(f"  mcnugget/{name}: ERROR {e}")
+    print(f"McNugget: {mc_total} episodes")
 
+    total = thor_total + mc_total
     print(f"\nTotal: {total} episodes bound")
     print(f"Stats: {index.stats()}")
 


### PR DESCRIPTION
## Summary
- McNugget logs use 3 different formats from Thor's. Added parsers for all 3:
  - `r7-*`: rich traces (prediction, confidence, reflection, trust_update)
  - `structured-probe-*`: phase-based traces (phase, step, action, pixel_diff, won)
  - `harness-v1-*`: summary-only (binds one episode per level result)
- `_safe_float()` handles McNugget's string confidence levels ("LOW"/"MEDIUM"/"HIGH")
- Result: **432 episodes** from 2 machines (305 Thor + 127 McNugget) vs 305 before

## Test plan
- [x] 14/14 episodic test suite passing
- [x] `bind_all_logs()` produces 432 episodes with no errors
- [x] Cross-machine retrieval: `EpisodicCue(tags=["mcnugget"])` returns McNugget episodes
- [x] McNugget `level_up` episodes appear in `EpisodicCue(tags=["level_up"])` recall
- [ ] CBP review: verify schema adapter handles future log format changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)