### PR TITLE
[router] Sprint 2 R3: federation aggregator for fleet training corpus

### DIFF
--- a/sage/cognition/router/data/__init__.py
+++ b/sage/cognition/router/data/__init__.py
@@ -52,6 +52,13 @@ from sage.cognition.router.data.pruner import (
     RECOGNIZED_PIN_KINDS,
     PRUNER_VERSION,
 )
+from sage.cognition.router.data.federation import (
+    FleetAggregator,
+    FederationConfig,
+    PeerConfig,
+    PeerSummary,
+    AggregateSummary,
+)
 
 __all__ = [
     "RouterDatasetWriter",
@@ -69,4 +76,9 @@ __all__ = [
     "ACTIVE_WRITE_WINDOW_SECONDS",
     "RECOGNIZED_PIN_KINDS",
     "PRUNER_VERSION",
+    "FleetAggregator",
+    "FederationConfig",
+    "PeerConfig",
+    "PeerSummary",
+    "AggregateSummary",
 ]

--- a/sage/cognition/router/data/federation.py
+++ b/sage/cognition/router/data/federation.py
@@ -1,0 +1,686 @@
+"""
+FleetAggregator — Sprint 2 R3. Legion (data czar) runs this nightly to
+pull per-machine router shards and build a fleet-wide training corpus.
+
+Design (per router-sprint-2-rollout-federation.md):
+
+  * **Pull-model**. Legion walks each peer's shard dir, pulls records,
+    writes a single partitioned aggregate at
+    ``{aggregate_dir}/{YYYY-MM-DD}.jsonl.gz``.
+  * **Transport agnostic** per peer: ``local`` reads the filesystem
+    directly, ``ssh`` stages shards into a scratch dir via ``rsync``
+    (no credential management — relies on ssh-agent).
+  * **Deduplication by ``record_id``**. Records are unique across
+    machines; collisions are logged as anomalies. First-seen wins so
+    re-runs are idempotent (the aggregator loads existing aggregate
+    record_ids into the seen-set before pulling).
+  * **Failure isolation**: a peer being offline / unreadable / empty
+    does not stop aggregation of other peers. Each peer is wrapped in
+    ``try/except`` and its status lands in the run summary.
+  * **Source-stamp preservation**: every record is written through
+    verbatim. The R1 ``metadata.source`` field (and anything else) is
+    preserved untouched — no re-mapping, no normalization.
+  * **Schema-version tolerance**: v0.1.0 records (no metadata.source)
+    and v0.2.0 records (with metadata.source from R1) are both passed
+    through. The aggregator does not validate or rewrite the schema.
+  * **Atomic writes**: aggregate is written to ``{date}.jsonl.gz.tmp``
+    then ``os.replace``'d. A crash mid-run leaves the previous
+    aggregate intact.
+  * **Respects PRD §5.6**: pulls from ALREADY-pruned shards. The
+    aggregator does not prune, does not consult pin-kinds — that's the
+    per-machine pruner's job (tracks 9 / T8).
+
+Intentional non-goals:
+  * No torch dependency.
+  * No network daemon / push path. Nightly cron, pull-only.
+  * No cross-day reconciliation. One aggregate file per UTC date.
+  * No outcome sidecar merge (reader does that at replay time).
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field, asdict
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Set, Tuple, Union
+
+from sage.cognition.router.data.reader import RouterDatasetReader
+
+
+_log = logging.getLogger(__name__)
+
+
+# ── config model ───────────────────────────────────────────────────
+
+
+@dataclass
+class PeerConfig:
+    """One peer's configuration entry.
+
+    Attributes
+    ----------
+    machine:
+        Peer machine name (matches fleet manifest + shard subdir name).
+    transport:
+        ``local`` or ``ssh``. ``local`` reads the directory directly;
+        ``ssh`` stages it via ``rsync`` first.
+    path:
+        Shard root (may contain ``~`` or env vars — expanded at use time).
+    host:
+        SSH host (required when ``transport == "ssh"``).
+    ssh_user:
+        Optional SSH user override. Empty → use current user.
+    ssh_port:
+        Optional SSH port. None → default 22.
+    """
+
+    machine: str
+    transport: str = "local"
+    path: str = ""
+    host: Optional[str] = None
+    ssh_user: Optional[str] = None
+    ssh_port: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.transport not in ("local", "ssh"):
+            raise ValueError(
+                f"peer {self.machine!r}: transport must be 'local' or 'ssh', "
+                f"got {self.transport!r}"
+            )
+        if self.transport == "ssh" and not self.host:
+            raise ValueError(
+                f"peer {self.machine!r}: transport='ssh' requires 'host'"
+            )
+        if not self.machine:
+            raise ValueError("peer entries must have 'machine' set")
+        if not self.path:
+            raise ValueError(
+                f"peer {self.machine!r}: 'path' must be non-empty"
+            )
+
+
+@dataclass
+class FederationConfig:
+    """Top-level config loaded from ``fleet_shards.json``."""
+
+    peers: List[PeerConfig] = field(default_factory=list)
+    aggregate_dir: str = ""
+    schedule_utc: str = "02:00"
+
+    @classmethod
+    def from_file(cls, path: Union[str, Path]) -> "FederationConfig":
+        p = Path(path)
+        with open(p, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "FederationConfig":
+        peers = [PeerConfig(**entry) for entry in data.get("peers", [])]
+        return cls(
+            peers=peers,
+            aggregate_dir=data.get("aggregate_dir", ""),
+            schedule_utc=data.get("schedule_utc", "02:00"),
+        )
+
+
+# ── per-peer summary ───────────────────────────────────────────────
+
+
+@dataclass
+class PeerSummary:
+    """Result of aggregating one peer's shard for the target date."""
+
+    machine: str
+    transport: str
+    available: bool = False
+    records_seen: int = 0
+    records_new: int = 0
+    duplicates: int = 0
+    errors: List[str] = field(default_factory=list)
+    snarc_mean: Dict[str, float] = field(default_factory=dict)
+    decision_class_counts: Dict[str, int] = field(default_factory=dict)
+    source_counts: Dict[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class AggregateSummary:
+    """Top-level result of one aggregation run."""
+
+    target_date: str
+    aggregate_path: Optional[str]
+    total_records: int = 0
+    total_new: int = 0
+    duplicates: int = 0
+    cross_machine_collisions: int = 0
+    peers: List[PeerSummary] = field(default_factory=list)
+    started_at: float = 0.0
+    finished_at: float = 0.0
+    dry_run: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = asdict(self)
+        # asdict recurses into peers → already serialized
+        return d
+
+
+# ── aggregator ─────────────────────────────────────────────────────
+
+
+class FleetAggregator:
+    """Pulls per-machine router shards and builds a fleet-wide corpus.
+
+    Parameters
+    ----------
+    config:
+        ``FederationConfig`` — list of peers + aggregate dir.
+    clock:
+        Optional callable returning current UTC datetime. Tests inject
+        a fixed clock; production uses ``datetime.now(UTC)``.
+    ssh_command:
+        The ssh binary (default ``"ssh"``). Swap for tests.
+    rsync_command:
+        The rsync binary (default ``"rsync"``). Swap for tests.
+
+    Notes
+    -----
+    * The aggregator is stateless across runs. All state it needs
+      (seen record_ids, existing aggregate content) is loaded from
+      disk at the start of each ``run``.
+    * The default target date is YESTERDAY (UTC) — shards for "today"
+      may still be getting appends from the peer's live daemon.
+    """
+
+    #: Per-record_id collision log — populated during a run, cleared
+    #: between runs. Kept as an instance field for introspection tests.
+    cross_machine_collisions: Dict[str, List[str]]
+
+    def __init__(
+        self,
+        config: FederationConfig,
+        clock: Optional[Any] = None,
+        ssh_command: str = "ssh",
+        rsync_command: str = "rsync",
+    ) -> None:
+        if not config.aggregate_dir:
+            raise ValueError("FederationConfig.aggregate_dir must be set")
+        self.config = config
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._ssh = ssh_command
+        self._rsync = rsync_command
+        self.cross_machine_collisions = {}
+
+    # ── public entry points ────────────────────────────────────────
+
+    def run(
+        self,
+        target_date: Optional[Union[str, date]] = None,
+        dry_run: bool = False,
+    ) -> AggregateSummary:
+        """Aggregate one UTC date's shards from all peers.
+
+        Parameters
+        ----------
+        target_date:
+            ``YYYY-MM-DD`` or ``datetime.date``. Default: yesterday UTC.
+        dry_run:
+            If True, pull + enumerate but write nothing to disk.
+        """
+        started = time.time()
+        target = _coerce_date(target_date) if target_date else self._yesterday()
+        target_str = target.isoformat()
+        self.cross_machine_collisions = {}
+
+        summary = AggregateSummary(
+            target_date=target_str,
+            aggregate_path=None,
+            started_at=started,
+            dry_run=dry_run,
+        )
+
+        aggregate_path = self._aggregate_path_for(target)
+        # Ensure aggregate dir exists (no-op in dry-run).
+        if not dry_run:
+            try:
+                aggregate_path.parent.mkdir(parents=True, exist_ok=True)
+            except OSError as e:
+                _log.error("Cannot create aggregate dir %s: %s", aggregate_path.parent, e)
+                summary.finished_at = time.time()
+                return summary
+
+        # Load existing aggregate record_ids so re-runs are idempotent.
+        # `seen` accumulates record_ids observed ANYWHERE in this aggregation
+        # (existing aggregate file + earlier peers in this run).
+        # `seen_machine` maps record_id → first machine seen, for collision logs.
+        seen: Set[str] = set()
+        seen_machine: Dict[str, str] = {}
+        existing_records: List[Dict[str, Any]] = []
+        if aggregate_path.exists():
+            for rec in _iter_jsonl_gz(aggregate_path):
+                rid = rec.get("record_id")
+                if not rid:
+                    # No record_id → can't dedup. Preserve verbatim.
+                    existing_records.append(rec)
+                    continue
+                if rid in seen:
+                    continue
+                seen.add(rid)
+                seen_machine[rid] = rec.get("machine", "unknown")
+                existing_records.append(rec)
+
+        all_new_records: List[Dict[str, Any]] = []
+
+        for peer in self.config.peers:
+            peer_summary = self._aggregate_peer(
+                peer=peer,
+                target_date=target,
+                seen=seen,
+                seen_machine=seen_machine,
+                new_records_out=all_new_records,
+            )
+            summary.peers.append(peer_summary)
+
+        # Collision total: number of record_ids that showed up on more than
+        # one machine this run.
+        summary.cross_machine_collisions = len(self.cross_machine_collisions)
+
+        total_records = len(existing_records) + len(all_new_records)
+        summary.total_records = total_records
+        summary.total_new = len(all_new_records)
+        summary.duplicates = sum(p.duplicates for p in summary.peers)
+
+        if dry_run:
+            _log.info(
+                "DRY-RUN aggregate %s: existing=%d new=%d peers=%d",
+                target_str, len(existing_records), len(all_new_records),
+                len(summary.peers),
+            )
+            summary.aggregate_path = str(aggregate_path)
+            summary.finished_at = time.time()
+            return summary
+
+        # Write atomically: existing + new into a tmp, then os.replace.
+        tmp_path = aggregate_path.with_suffix(aggregate_path.suffix + ".tmp")
+        try:
+            with gzip.open(str(tmp_path), "wt", encoding="utf-8") as f:
+                for rec in existing_records:
+                    f.write(json.dumps(rec, separators=(",", ":"), default=str) + "\n")
+                for rec in all_new_records:
+                    f.write(json.dumps(rec, separators=(",", ":"), default=str) + "\n")
+            os.replace(tmp_path, aggregate_path)
+            summary.aggregate_path = str(aggregate_path)
+        except OSError as e:
+            _log.exception("Failed to write aggregate %s: %s", aggregate_path, e)
+            try:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+            except OSError:
+                pass
+
+        # Write per-peer summary sidecar next to the aggregate.
+        try:
+            summary_path = aggregate_path.with_name(
+                aggregate_path.name.replace(".jsonl.gz", ".summary.json")
+            )
+            with open(summary_path, "w", encoding="utf-8") as f:
+                json.dump(summary.to_dict(), f, indent=2, default=str)
+        except OSError as e:  # pragma: no cover — defensive
+            _log.warning("Failed to write summary sidecar: %s", e)
+
+        summary.finished_at = time.time()
+        _log.info(
+            "aggregate %s: total=%d new=%d peers=%d collisions=%d elapsed=%.2fs",
+            target_str, summary.total_records, summary.total_new,
+            len(summary.peers), summary.cross_machine_collisions,
+            summary.finished_at - summary.started_at,
+        )
+        return summary
+
+    # ── internals ──────────────────────────────────────────────────
+
+    def _yesterday(self) -> date:
+        """UTC yesterday — default aggregation target."""
+        return (self._clock() - timedelta(days=1)).date()
+
+    def _aggregate_path_for(self, target: date) -> Path:
+        return Path(self.config.aggregate_dir) / f"{target.isoformat()}.jsonl.gz"
+
+    def _aggregate_peer(
+        self,
+        peer: PeerConfig,
+        target_date: date,
+        seen: Set[str],
+        seen_machine: Dict[str, str],
+        new_records_out: List[Dict[str, Any]],
+    ) -> PeerSummary:
+        """Pull one peer's shard for the target date, appending
+        not-yet-seen records to ``new_records_out``.
+
+        Never raises — all errors go into ``peer_summary.errors`` and
+        the peer is marked unavailable.
+        """
+        peer_summary = PeerSummary(
+            machine=peer.machine,
+            transport=peer.transport,
+        )
+        staging_dir: Optional[Path] = None
+        try:
+            if peer.transport == "local":
+                shard_dir = Path(os.path.expanduser(os.path.expandvars(peer.path)))
+                if not shard_dir.exists():
+                    peer_summary.errors.append(f"shard dir missing: {shard_dir}")
+                    _log.warning(
+                        "peer %s: shard dir missing %s — skipping",
+                        peer.machine, shard_dir,
+                    )
+                    return peer_summary
+                source_base = shard_dir
+            else:
+                staging_dir = Path(tempfile.mkdtemp(prefix="fleetagg_"))
+                ok = self._rsync_pull(peer, target_date, staging_dir, peer_summary)
+                if not ok:
+                    return peer_summary
+                source_base = staging_dir
+
+            peer_summary.available = True
+
+            # Records live at {source_base}/{machine}/{target}.jsonl[.gz].
+            # Be tolerant: the peer may write directly to {source_base}
+            # without a machine subdir (self-rooted layout). Try both.
+            candidate_dirs = [source_base / peer.machine, source_base]
+            partitions: List[Path] = []
+            for d in candidate_dirs:
+                if not d.exists():
+                    continue
+                for ext in (".jsonl.gz", ".jsonl"):
+                    p = d / f"{target_date.isoformat()}{ext}"
+                    if p.exists():
+                        partitions.append(p)
+
+            if not partitions:
+                peer_summary.errors.append(
+                    f"no partition found for {target_date.isoformat()} "
+                    f"under {source_base}"
+                )
+                _log.info(
+                    "peer %s: no partition for %s — empty day (ok)",
+                    peer.machine, target_date,
+                )
+                return peer_summary
+
+            for part in partitions:
+                for rec in _iter_partition(part):
+                    peer_summary.records_seen += 1
+                    self._tally_record(rec, peer_summary)
+
+                    rid = rec.get("record_id")
+                    if not rid:
+                        # No record_id → keep it but cannot dedup.
+                        new_records_out.append(rec)
+                        peer_summary.records_new += 1
+                        continue
+                    if rid in seen:
+                        peer_summary.duplicates += 1
+                        first_machine = seen_machine.get(rid, "unknown")
+                        rec_machine = rec.get("machine", peer.machine)
+                        if first_machine != rec_machine:
+                            # Same record_id, different machine → anomaly.
+                            bucket = self.cross_machine_collisions.setdefault(rid, [first_machine])
+                            if rec_machine not in bucket:
+                                bucket.append(rec_machine)
+                            _log.warning(
+                                "cross-machine record_id collision %s: first=%s dup=%s",
+                                rid, first_machine, rec_machine,
+                            )
+                        continue
+                    seen.add(rid)
+                    seen_machine[rid] = rec.get("machine", peer.machine)
+                    new_records_out.append(rec)
+                    peer_summary.records_new += 1
+
+        except Exception as e:  # pragma: no cover — defensive
+            _log.exception("peer %s: unexpected error: %s", peer.machine, e)
+            peer_summary.errors.append(f"unexpected: {e}")
+        finally:
+            if staging_dir is not None and staging_dir.exists():
+                try:
+                    shutil.rmtree(staging_dir)
+                except OSError:  # pragma: no cover
+                    pass
+
+        # Finalize mean SNARC (sum → mean after all records seen).
+        if peer_summary.records_seen > 0 and peer_summary.snarc_mean:
+            for k in list(peer_summary.snarc_mean.keys()):
+                peer_summary.snarc_mean[k] /= peer_summary.records_seen
+
+        return peer_summary
+
+    def _rsync_pull(
+        self,
+        peer: PeerConfig,
+        target_date: date,
+        staging_dir: Path,
+        peer_summary: PeerSummary,
+    ) -> bool:
+        """rsync peer's shard dir into ``staging_dir``. Returns True on
+        success, False on failure (which is recorded in peer_summary).
+        """
+        remote_path = peer.path.rstrip("/") + "/"
+        host = peer.host or ""
+        user_prefix = f"{peer.ssh_user}@" if peer.ssh_user else ""
+        src = f"{user_prefix}{host}:{remote_path}"
+
+        ssh_flags = [self._ssh, "-o", "BatchMode=yes", "-o", "ConnectTimeout=10"]
+        if peer.ssh_port:
+            ssh_flags.extend(["-p", str(peer.ssh_port)])
+        ssh_cmd = " ".join(ssh_flags)
+
+        cmd = [
+            self._rsync,
+            "-az",
+            "--timeout=30",
+            "-e", ssh_cmd,
+            src,
+            str(staging_dir) + "/",
+        ]
+        try:
+            result = subprocess.run(
+                cmd, check=False, capture_output=True, text=True, timeout=120,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+            peer_summary.errors.append(f"rsync: {e}")
+            _log.warning("peer %s: rsync failed (%s)", peer.machine, e)
+            return False
+        if result.returncode != 0:
+            tail = (result.stderr or "").strip().splitlines()[-3:]
+            peer_summary.errors.append(
+                f"rsync rc={result.returncode}: {' | '.join(tail)}"
+            )
+            _log.warning(
+                "peer %s: rsync rc=%d (%s)",
+                peer.machine, result.returncode, tail,
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _tally_record(rec: Mapping[str, Any], peer_summary: PeerSummary) -> None:
+        """Update running aggregates (SNARC sum, decision class, source)."""
+        payload = rec.get("payload") or {}
+        snarc = None
+        ri = payload.get("router_input") if isinstance(payload, Mapping) else None
+        if isinstance(ri, Mapping):
+            snarc = ri.get("snarc")
+        if isinstance(snarc, Mapping):
+            for dim in ("surprise", "novelty", "arousal", "reward", "conflict"):
+                v = snarc.get(dim)
+                if isinstance(v, (int, float)):
+                    peer_summary.snarc_mean[dim] = (
+                        peer_summary.snarc_mean.get(dim, 0.0) + float(v)
+                    )
+
+        ro = payload.get("router_output") if isinstance(payload, Mapping) else None
+        if isinstance(ro, Mapping):
+            action = ro.get("action") or ro.get("decision_class")
+            if isinstance(action, str):
+                peer_summary.decision_class_counts[action] = (
+                    peer_summary.decision_class_counts.get(action, 0) + 1
+                )
+
+        # R1 source stamp — metadata.source. Tolerate both v0.1.0 (missing)
+        # and v0.2.0 (present) without complaining.
+        metadata = rec.get("metadata") if isinstance(rec, Mapping) else None
+        src_val: Optional[str] = None
+        if isinstance(metadata, Mapping):
+            s = metadata.get("source")
+            if isinstance(s, str):
+                src_val = s
+        if src_val is None:
+            src_val = "unknown"
+        peer_summary.source_counts[src_val] = (
+            peer_summary.source_counts.get(src_val, 0) + 1
+        )
+
+
+# ── module-level helpers ───────────────────────────────────────────
+
+
+def _coerce_date(d: Union[str, date]) -> date:
+    if isinstance(d, date) and not isinstance(d, datetime):
+        return d
+    if isinstance(d, datetime):
+        return d.date()
+    return datetime.strptime(str(d), "%Y-%m-%d").date()
+
+
+def _iter_partition(path: Path) -> Iterator[Dict[str, Any]]:
+    """Iterate records from a single .jsonl or .jsonl.gz partition.
+
+    Reuses RouterDatasetReader.read_file semantics — corrupt trailing
+    lines are logged and skipped, not raised.
+    """
+    # Dummy base_dir; we only call read_file.
+    reader = RouterDatasetReader(base_dir=path.parent)
+    yield from reader.read_file(path)
+
+
+def _iter_jsonl_gz(path: Path) -> Iterator[Dict[str, Any]]:
+    """Iterate records from an existing aggregate (.jsonl.gz)."""
+    try:
+        with gzip.open(str(path), "rt", encoding="utf-8") as f:
+            for line_no, raw in enumerate(f, start=1):
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError as e:
+                    _log.warning(
+                        "aggregate: corrupt line %s:%d — %s", path, line_no, e,
+                    )
+    except OSError as e:
+        _log.warning("aggregate: error reading %s: %s", path, e)
+
+
+# ── CLI ────────────────────────────────────────────────────────────
+
+
+def _default_config_path() -> Path:
+    """Default location for the fleet config (relative to SAGE repo)."""
+    # sage/cognition/router/data/federation.py → repo root is 4 parents up.
+    here = Path(__file__).resolve()
+    repo_root = here.parents[4]
+    return repo_root / "sage" / "gateway" / "fleet_shards.json"
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entry point.
+
+    Cron line installed by ``scripts/router_federation_install.sh``::
+
+        0 2 * * * /usr/bin/python3 -m sage.cognition.router.data.federation --run
+    """
+    parser = argparse.ArgumentParser(
+        prog="python -m sage.cognition.router.data.federation",
+        description="Fleet aggregator: pull per-machine router shards.",
+    )
+    parser.add_argument(
+        "--run", action="store_true",
+        help="Run aggregation (default if no other mode flag passed)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Enumerate and pull (for ssh peers) but write nothing",
+    )
+    parser.add_argument(
+        "--config", default=None,
+        help="Path to fleet_shards config. Default: "
+             "SAGE/sage/gateway/fleet_shards.json",
+    )
+    parser.add_argument(
+        "--date", default=None,
+        help="Target UTC date (YYYY-MM-DD). Default: yesterday UTC.",
+    )
+    parser.add_argument(
+        "--days", type=int, default=1,
+        help="Number of consecutive days to aggregate, ending at --date "
+             "(inclusive). Default: 1.",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="count", default=0,
+        help="Increase log verbosity (repeat for more).",
+    )
+    args = parser.parse_args(argv)
+
+    level = logging.WARNING - 10 * args.verbose
+    logging.basicConfig(
+        level=max(level, logging.DEBUG),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    config_path = Path(args.config) if args.config else _default_config_path()
+    if not config_path.exists():
+        _log.error("config not found: %s", config_path)
+        return 2
+
+    config = FederationConfig.from_file(config_path)
+    aggregator = FleetAggregator(config=config)
+
+    # Build date list — [date - days + 1, ..., date].
+    end = _coerce_date(args.date) if args.date else aggregator._yesterday()
+    days = max(1, args.days)
+    dates = [end - timedelta(days=offset) for offset in range(days - 1, -1, -1)]
+
+    # Exit 0 even if some peers were unavailable — partial aggregation
+    # is the whole point of failure isolation. We only signal error
+    # status when NO peer on the most recent aggregated date reported
+    # `available=True` (total fleet outage).
+    last_summary: Optional[AggregateSummary] = None
+    for d in dates:
+        summary = aggregator.run(target_date=d, dry_run=args.dry_run)
+        last_summary = summary
+        # Machine-readable stdout so cron / operators can grep.
+        print(json.dumps(summary.to_dict(), default=str))
+
+    if last_summary is not None and last_summary.peers and all(
+        not p.available for p in last_summary.peers
+    ):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/sage/cognition/router/data/tests/test_federation.py
+++ b/sage/cognition/router/data/tests/test_federation.py
@@ -1,0 +1,494 @@
+"""
+Tests for Router Sprint 2 R3 — federation aggregator.
+
+Covers:
+  * 3-machine fleet: aggregator pulls from all, dedups by record_id.
+  * Machine-offline simulation: missing dir → log + continue.
+  * Idempotency: re-run over same shards adds zero new records.
+  * Schema-version skew: v0.1.0 and v0.2.0 records coexist.
+  * Source-stamp preservation: records with metadata.source preserved.
+  * Cross-machine collision: same record_id on two machines is logged.
+  * Empty shard: 0-record partition handled gracefully.
+  * Atomic write: .tmp file does not leak on success.
+  * Per-peer summary: SNARC mean + decision-class counts correct.
+  * Config parsing: PeerConfig / FederationConfig validation.
+  * Dry-run: nothing written to disk.
+  * CLI main(): smoke test (temp config, local peers, target date).
+
+Runs with plain ``pytest``; no torch, no network.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from sage.cognition.router.data import (
+    FederationConfig,
+    FleetAggregator,
+    PeerConfig,
+    RouterDatasetWriter,
+    SCHEMA_VERSION,
+)
+from sage.cognition.router.data.federation import _iter_jsonl_gz, main
+
+
+# ── helpers ────────────────────────────────────────────────────────
+
+
+TARGET = date(2026, 4, 17)
+TARGET_STR = TARGET.isoformat()
+FIXED_CLOCK = lambda: datetime(2026, 4, 17, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_record(
+    i: int,
+    machine: str,
+    source: str = None,
+    action: str = None,
+) -> Dict[str, Any]:
+    """Synthetic record matching the Track 4 payload envelope.
+
+    If ``source`` is given, emit a v0.2.0 record with metadata.source
+    (R1's source-stamping schema). Otherwise emit a v0.1.0 record.
+    """
+    rec: Dict[str, Any] = {
+        "record_id": f"{machine}-rec-{i:06d}",
+        "schema_version": "0.1.0" if source is None else "0.2.0",
+        "timestamp": 1_700_000_000.0 + i,
+        "machine": machine,
+        "payload": {
+            "router_input": {
+                "tick": i,
+                "snarc": {
+                    "surprise": (i % 100) / 100.0,
+                    "novelty": ((i + 7) % 100) / 100.0,
+                    "arousal": ((i + 13) % 100) / 100.0,
+                    "reward": (((i + 31) % 200) - 100) / 100.0,
+                    "conflict": ((i + 17) % 100) / 100.0,
+                },
+                "wm_state_key": f"{i:016x}",
+            },
+            "router_output": {
+                "action": action or ["invoke", "habit", "noop"][i % 3],
+                "confidence": (i % 100) / 100.0,
+            },
+        },
+    }
+    if source is not None:
+        rec["metadata"] = {"source": source}
+    return rec
+
+
+def _seed_machine_shard(
+    base_dir: Path,
+    machine: str,
+    records: List[Dict[str, Any]],
+    target_date: date = TARGET,
+) -> Path:
+    """Write ``records`` to ``{base_dir}/{machine}/{target_date}.jsonl.gz``."""
+    fixed = datetime(
+        target_date.year, target_date.month, target_date.day,
+        12, 0, 0, tzinfo=timezone.utc,
+    )
+    writer = RouterDatasetWriter(
+        base_dir=base_dir, machine=machine,
+        compress=True, buffer_size=1, clock=lambda: fixed,
+    )
+    try:
+        for rec in records:
+            writer.append(rec)
+    finally:
+        writer.close()
+    return base_dir / machine / f"{target_date.isoformat()}.jsonl.gz"
+
+
+def _build_local_config(
+    aggregate_dir: Path,
+    machine_to_dir: Dict[str, Path],
+) -> FederationConfig:
+    peers = [
+        PeerConfig(machine=m, transport="local", path=str(d))
+        for m, d in machine_to_dir.items()
+    ]
+    return FederationConfig(
+        peers=peers,
+        aggregate_dir=str(aggregate_dir),
+    )
+
+
+def _read_aggregate(aggregate_dir: Path, target: date = TARGET) -> List[Dict[str, Any]]:
+    path = aggregate_dir / f"{target.isoformat()}.jsonl.gz"
+    return list(_iter_jsonl_gz(path))
+
+
+# ── tests ──────────────────────────────────────────────────────────
+
+
+def test_three_machine_fleet_aggregates_and_dedups(tmp_path: Path) -> None:
+    """3 machines with distinct record_ids → aggregate has union."""
+    aggregate = tmp_path / "aggregate"
+
+    a_dir = tmp_path / "a"; b_dir = tmp_path / "b"; c_dir = tmp_path / "c"
+    _seed_machine_shard(a_dir, "alpha", [_make_record(i, "alpha") for i in range(10)])
+    _seed_machine_shard(b_dir, "beta", [_make_record(i, "beta") for i in range(10)])
+    _seed_machine_shard(c_dir, "gamma", [_make_record(i, "gamma") for i in range(10)])
+
+    config = _build_local_config(
+        aggregate,
+        {
+            "alpha": a_dir,
+            "beta": b_dir,
+            "gamma": c_dir,
+        },
+    )
+    agg = FleetAggregator(config=config, clock=FIXED_CLOCK)
+    summary = agg.run(target_date=TARGET)
+
+    assert summary.total_records == 30
+    assert summary.total_new == 30
+    assert summary.cross_machine_collisions == 0
+    assert summary.aggregate_path is not None
+
+    records = _read_aggregate(aggregate)
+    assert len(records) == 30
+    assert sorted(set(r["machine"] for r in records)) == ["alpha", "beta", "gamma"]
+
+    # Per-peer summaries each saw 10 records.
+    for peer_summary in summary.peers:
+        assert peer_summary.available is True
+        assert peer_summary.records_seen == 10
+        assert peer_summary.records_new == 10
+        assert peer_summary.duplicates == 0
+
+
+def test_offline_peer_logged_and_skipped(tmp_path: Path, caplog) -> None:
+    """Missing shard dir → logged, aggregation continues for others."""
+    aggregate = tmp_path / "aggregate"
+    live_dir = tmp_path / "live"
+    missing_dir = tmp_path / "no-such-path"
+
+    _seed_machine_shard(live_dir, "live", [_make_record(i, "live") for i in range(5)])
+
+    config = FederationConfig(
+        peers=[
+            PeerConfig(machine="live", transport="local", path=str(live_dir)),
+            PeerConfig(machine="offline", transport="local", path=str(missing_dir)),
+        ],
+        aggregate_dir=str(aggregate),
+    )
+    agg = FleetAggregator(config=config, clock=FIXED_CLOCK)
+
+    with caplog.at_level(logging.WARNING):
+        summary = agg.run(target_date=TARGET)
+
+    assert summary.total_records == 5
+    # live peer succeeded, offline peer reported errors.
+    live_summary = next(p for p in summary.peers if p.machine == "live")
+    off_summary = next(p for p in summary.peers if p.machine == "offline")
+    assert live_summary.available is True
+    assert off_summary.available is False
+    assert any("shard dir missing" in err for err in off_summary.errors)
+
+
+def test_idempotent_rerun(tmp_path: Path) -> None:
+    """Re-running over same shards adds zero records."""
+    aggregate = tmp_path / "aggregate"
+    a_dir = tmp_path / "a"
+    _seed_machine_shard(a_dir, "alpha", [_make_record(i, "alpha") for i in range(7)])
+
+    config = _build_local_config(aggregate, {"alpha": a_dir})
+    agg = FleetAggregator(config=config, clock=FIXED_CLOCK)
+
+    s1 = agg.run(target_date=TARGET)
+    s2 = agg.run(target_date=TARGET)
+
+    assert s1.total_new == 7
+    assert s2.total_new == 0
+    assert s2.total_records == 7
+    # Records on disk should equal first run.
+    assert len(_read_aggregate(aggregate)) == 7
+
+
+def test_schema_version_skew_both_preserved(tmp_path: Path) -> None:
+    """Shards mixing v0.1.0 and v0.2.0 records → all preserved."""
+    aggregate = tmp_path / "aggregate"
+    a_dir = tmp_path / "a"; b_dir = tmp_path / "b"
+
+    _seed_machine_shard(
+        a_dir, "alpha",
+        [_make_record(i, "alpha") for i in range(3)],  # v0.1.0
+    )
+    _seed_machine_shard(
+        b_dir, "beta",
+        [_make_record(i, "beta", source="raising") for i in range(3)],  # v0.2.0
+    )
+
+    config = _build_local_config(aggregate, {"alpha": a_dir, "beta": b_dir})
+    agg = FleetAggregator(config=config, clock=FIXED_CLOCK)
+    summary = agg.run(target_date=TARGET)
+
+    records = _read_aggregate(aggregate)
+    versions = sorted(set(r["schema_version"] for r in records))
+    assert versions == ["0.1.0", "0.2.0"]
+
+    # v0.2.0 records kept their metadata.source.
+    v020 = [r for r in records if r["schema_version"] == "0.2.0"]
+    assert len(v020) == 3
+    assert all(r["metadata"]["source"] == "raising" for r in v020)
+    assert summary.total_records == 6
+
+
+def test_source_stamp_preservation(tmp_path: Path) -> None:
+    """records with source=raising preserved alongside source=gameplay."""
+    aggregate = tmp_path / "aggregate"
+    a_dir = tmp_path / "a"
+    records = [
+        _make_record(1, "alpha", source="raising"),
+        _make_record(2, "alpha", source="gameplay"),
+        _make_record(3, "alpha", source="idle"),
+        _make_record(4, "alpha", source="interactive"),
+    ]
+    _seed_machine_shard(a_dir, "alpha", records)
+
+    config = _build_local_config(aggregate, {"alpha": a_dir})
+    agg = FleetAggregator(config=config, clock=FIXED_CLOCK)
+    summary = agg.run(target_date=TARGET)
+
+    out = _read_aggregate(aggregate)
+    sources = sorted(r["metadata"]["source"] for r in out)
+    assert sources == ["gameplay", "idle", "interactive", "raising"]
+
+    # Per-peer source_counts reflect distribution.
+    peer_summary = summary.peers[0]
+    assert peer_summary.source_counts == {
+        "raising": 1, "gameplay": 1, "idle": 1, "interactive": 1,
+    }
+
+
+def test_cross_machine_collision_logged(tmp_path: Path, caplog) -> None:
+    """Same record_id on two machines → logged, first-seen wins."""
+    aggregate = tmp_path / "aggregate"
+    a_dir = tmp_path / "a"; b_dir = tmp_path / "b"
+
+    # Force identical record_id by using same index on both.
+    shared_id = "shared-rec-000001"
+    rec_a = _make_record(1, "alpha")
+    rec_a["record_id"] = shared_id
+    rec_a["payload"]["router_output"]["action"] = "invoke"
+    rec_b = _make_record(1, "beta")
+    rec_b["record_id"] = shared_id
+    rec_b["payload"]["router_output"]["action"] = "habit"  # would differ
+
+    _seed_machine_shard(a_dir, "alpha", [rec_a])
+    _seed_machine_shard(b_dir, "beta", [rec_b])
+
+    config = _build_local_config(aggregate, {"alpha": a_dir, "beta": b_dir})
+    agg = FleetAggregator(config=config, clock=FIXED_CLOCK)
+
+    with caplog.at_level(logging.WARNING):
+        summary = agg.run(target_date=TARGET)
+
+    assert summary.cross_machine_collisions == 1
+    assert shared_id in agg.cross_machine_collisions
+    assert sorted(agg.cross_machine_collisions[shared_id]) == ["alpha", "beta"]
+    # First-seen (alpha) wins.
+    records = _read_aggregate(aggregate)
+    assert len(records) == 1
+    assert records[0]["machine"] == "alpha"
+    assert records[0]["payload"]["router_output"]["action"] == "invoke"
+
+
+def test_empty_shard(tmp_path: Path) -> None:
+    """Peer with 0-record partition → handled gracefully, no crash."""
+    aggregate = tmp_path / "aggregate"
+    a_dir = tmp_path / "a"
+    # Shard dir exists but target-date partition does not. Writer with
+    # empty list doesn't create the dir; simulate an operator-prepared
+    # empty shard root (e.g., a machine that ran but emitted zero records
+    # for this date).
+    (a_dir / "alpha").mkdir(parents=True)
+
+    config = _build_local_config(aggregate, {"alpha": a_dir})
+    agg = FleetAggregator(config=config, clock=FIXED_CLOCK)
+    summary = agg.run(target_date=TARGET)
+
+    assert summary.total_records == 0
+    assert summary.total_new == 0
+    # Peer was reachable but had no partition for this date.
+    peer_summary = summary.peers[0]
+    assert peer_summary.available is True
+    assert peer_summary.records_seen == 0
+    # Error list notes the missing partition (informational, not fatal).
+    assert any("no partition found" in err for err in peer_summary.errors)
+
+
+def test_dry_run_writes_nothing(tmp_path: Path) -> None:
+    """--dry-run: aggregation runs, summary returns, but no disk write."""
+    aggregate = tmp_path / "aggregate"
+    a_dir = tmp_path / "a"
+    _seed_machine_shard(a_dir, "alpha", [_make_record(i, "alpha") for i in range(4)])
+
+    config = _build_local_config(aggregate, {"alpha": a_dir})
+    agg = FleetAggregator(config=config, clock=FIXED_CLOCK)
+    summary = agg.run(target_date=TARGET, dry_run=True)
+
+    assert summary.dry_run is True
+    assert summary.total_new == 4
+    # Nothing on disk — aggregate dir shouldn't even be created.
+    expected = aggregate / f"{TARGET_STR}.jsonl.gz"
+    assert not expected.exists()
+
+
+def test_per_peer_summary_snarc_and_decisions(tmp_path: Path) -> None:
+    """Per-peer SNARC mean + decision-class counts correctly computed."""
+    aggregate = tmp_path / "aggregate"
+    a_dir = tmp_path / "a"
+    # Hand-crafted records to make the math checkable.
+    records = [
+        _make_record(0, "alpha", action="invoke"),  # snarc[surprise]=0.0
+        _make_record(1, "alpha", action="invoke"),  # snarc[surprise]=0.01
+        _make_record(2, "alpha", action="habit"),   # snarc[surprise]=0.02
+    ]
+    _seed_machine_shard(a_dir, "alpha", records)
+
+    config = _build_local_config(aggregate, {"alpha": a_dir})
+    agg = FleetAggregator(config=config, clock=FIXED_CLOCK)
+    summary = agg.run(target_date=TARGET)
+
+    peer = summary.peers[0]
+    assert peer.decision_class_counts == {"invoke": 2, "habit": 1}
+    assert peer.records_seen == 3
+    assert pytest.approx(peer.snarc_mean["surprise"], abs=1e-9) == (0.0 + 0.01 + 0.02) / 3
+
+
+def test_atomic_write_no_tmp_leak(tmp_path: Path) -> None:
+    """Successful run leaves aggregate file but NO .tmp."""
+    aggregate = tmp_path / "aggregate"
+    a_dir = tmp_path / "a"
+    _seed_machine_shard(a_dir, "alpha", [_make_record(i, "alpha") for i in range(3)])
+
+    config = _build_local_config(aggregate, {"alpha": a_dir})
+    agg = FleetAggregator(config=config, clock=FIXED_CLOCK)
+    agg.run(target_date=TARGET)
+
+    files = sorted(p.name for p in aggregate.iterdir())
+    assert f"{TARGET_STR}.jsonl.gz" in files
+    # No .tmp leaks.
+    assert not any(name.endswith(".tmp") for name in files)
+    # Summary sidecar written.
+    assert f"{TARGET_STR}.summary.json" in files
+
+
+def test_summary_sidecar_contents(tmp_path: Path) -> None:
+    """Summary sidecar is valid JSON with per-peer details."""
+    aggregate = tmp_path / "aggregate"
+    a_dir = tmp_path / "a"; b_dir = tmp_path / "b"
+    _seed_machine_shard(a_dir, "alpha", [_make_record(i, "alpha") for i in range(5)])
+    _seed_machine_shard(b_dir, "beta", [_make_record(i, "beta") for i in range(3)])
+
+    config = _build_local_config(aggregate, {"alpha": a_dir, "beta": b_dir})
+    agg = FleetAggregator(config=config, clock=FIXED_CLOCK)
+    agg.run(target_date=TARGET)
+
+    sidecar = aggregate / f"{TARGET_STR}.summary.json"
+    data = json.loads(sidecar.read_text())
+    assert data["target_date"] == TARGET_STR
+    assert data["total_records"] == 8
+    machine_names = sorted(p["machine"] for p in data["peers"])
+    assert machine_names == ["alpha", "beta"]
+
+
+def test_peer_config_validation() -> None:
+    """PeerConfig rejects invalid transports / missing host / missing path."""
+    with pytest.raises(ValueError, match="transport must be"):
+        PeerConfig(machine="x", transport="ftp", path="/tmp")
+    with pytest.raises(ValueError, match="requires 'host'"):
+        PeerConfig(machine="x", transport="ssh", path="/tmp")
+    with pytest.raises(ValueError, match="'path' must be"):
+        PeerConfig(machine="x", transport="local", path="")
+    with pytest.raises(ValueError, match="'machine'"):
+        PeerConfig(machine="", transport="local", path="/tmp")
+    # Happy-path ssh + local.
+    p1 = PeerConfig(machine="a", transport="ssh", path="~/shards", host="a.local")
+    p2 = PeerConfig(machine="b", transport="local", path="/var/router")
+    assert p1.host == "a.local"
+    assert p2.transport == "local"
+
+
+def test_federation_config_from_file(tmp_path: Path) -> None:
+    """FederationConfig parses a JSON file and round-trips peers."""
+    cfg = {
+        "peers": [
+            {"machine": "alpha", "transport": "local", "path": "/tmp/alpha"},
+            {"machine": "beta", "transport": "ssh", "host": "beta.local",
+             "path": "~/shards"},
+        ],
+        "aggregate_dir": "/tmp/agg",
+        "schedule_utc": "03:00",
+    }
+    p = tmp_path / "cfg.json"
+    p.write_text(json.dumps(cfg))
+
+    fc = FederationConfig.from_file(p)
+    assert fc.aggregate_dir == "/tmp/agg"
+    assert fc.schedule_utc == "03:00"
+    assert len(fc.peers) == 2
+    assert fc.peers[0].transport == "local"
+    assert fc.peers[1].host == "beta.local"
+
+
+def test_cli_main_smoke(tmp_path: Path, capsys) -> None:
+    """CLI main() runs end-to-end with a local-only config."""
+    aggregate = tmp_path / "aggregate"
+    a_dir = tmp_path / "a"
+    _seed_machine_shard(a_dir, "alpha", [_make_record(i, "alpha") for i in range(2)])
+
+    cfg = {
+        "peers": [
+            {"machine": "alpha", "transport": "local", "path": str(a_dir)},
+        ],
+        "aggregate_dir": str(aggregate),
+        "schedule_utc": "02:00",
+    }
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg))
+
+    rc = main([
+        "--run", "--config", str(cfg_path),
+        "--date", TARGET_STR, "--days", "1",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    summary = json.loads(out.splitlines()[0])
+    assert summary["target_date"] == TARGET_STR
+    assert summary["total_records"] == 2
+
+
+def test_no_record_id_preserved_not_dedup(tmp_path: Path) -> None:
+    """Records without record_id are preserved but never dedup'd."""
+    aggregate = tmp_path / "aggregate"
+    a_dir = tmp_path / "a"
+    rec1 = _make_record(1, "alpha")
+    rec1.pop("record_id")
+    rec2 = _make_record(2, "alpha")
+    rec2.pop("record_id")
+    _seed_machine_shard(a_dir, "alpha", [rec1, rec2])
+
+    config = _build_local_config(aggregate, {"alpha": a_dir})
+    agg = FleetAggregator(config=config, clock=FIXED_CLOCK)
+    summary = agg.run(target_date=TARGET)
+    # First run: both survived.
+    assert summary.total_records == 2
+    # Second run: no dedup possible → records doubled.
+    # (Documented behavior: record_id is the dedup key; without it, any
+    # re-pull duplicates. The aggregator logs nothing special because
+    # there's nothing to compare against.)
+    summary2 = agg.run(target_date=TARGET)
+    assert summary2.total_records == 4

--- a/sage/gateway/fleet_shards.json
+++ b/sage/gateway/fleet_shards.json
@@ -1,0 +1,41 @@
+{
+  "_comment": "Template config for the router federation aggregator (Sprint 2 R3). Replace paths with real fleet paths before enabling cron. transport='local' reads the filesystem directly; transport='ssh' uses rsync-over-ssh via the user's ssh-agent.",
+  "peers": [
+    {
+      "machine": "cbp",
+      "transport": "local",
+      "path": "/mnt/c/exe/projects/ai-agents/private-context/training-data/router/cbp"
+    },
+    {
+      "machine": "sprout",
+      "transport": "ssh",
+      "host": "sprout.local",
+      "path": "~/ai-workspace/private-context/training-data/router/sprout"
+    },
+    {
+      "machine": "nomad",
+      "transport": "ssh",
+      "host": "nomad.local",
+      "path": "~/ai-workspace/private-context/training-data/router/nomad"
+    },
+    {
+      "machine": "mcnugget",
+      "transport": "ssh",
+      "host": "mcnugget.local",
+      "path": "~/ai-workspace/private-context/training-data/router/mcnugget"
+    },
+    {
+      "machine": "legion",
+      "transport": "local",
+      "path": "/home/dp/ai-workspace/private-context/training-data/router/legion"
+    },
+    {
+      "machine": "thor",
+      "transport": "ssh",
+      "host": "thor.local",
+      "path": "~/ai-workspace/private-context/training-data/router/thor"
+    }
+  ],
+  "aggregate_dir": "/home/dp/ai-workspace/private-context/training-data/router/_aggregate",
+  "schedule_utc": "02:00"
+}

--- a/scripts/router_federation_install.sh
+++ b/scripts/router_federation_install.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# router_federation_install.sh — Sprint 2 R3 installer for the fleet
+# federation aggregator (Legion = data czar).
+#
+# What this does
+#   Installs/uninstalls a user-crontab entry that runs the fleet
+#   aggregator nightly. The aggregator pulls per-machine router shards
+#   (via local fs or rsync-over-ssh) and writes a deduplicated,
+#   partitioned corpus at {aggregate_dir}/{YYYY-MM-DD}.jsonl.gz.
+#
+# What this does NOT do
+#   * Does not start/stop the SAGE daemon.
+#   * Does not touch /etc/crontab or any system-wide cron dir.
+#   * Does not manage SSH keys — relies on ssh-agent already loaded.
+#   * Does not run as root. Everything lives in the invoking user's
+#     crontab + home paths.
+#
+# Usage
+#   scripts/router_federation_install.sh --enable-cron   # add user-cron entry
+#   scripts/router_federation_install.sh --disable-cron  # remove it
+#   scripts/router_federation_install.sh --run-now       # execute immediately
+#   scripts/router_federation_install.sh --run-now --dry-run
+#   scripts/router_federation_install.sh --config PATH   # point at custom config
+#   scripts/router_federation_install.sh --status        # show install state
+#
+# Config
+#   Default: $SAGE_DIR/sage/gateway/fleet_shards.json — lists peer
+#   machines, their shard dirs, and transports. Ship a copy at deploy
+#   time with real fleet paths filled in.
+#
+# Exit codes
+#   0  success
+#   1  prereq failure (python / module not importable)
+#   2  usage error
+#   3  config missing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAGE_DIR="${SAGE_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+PYTHON_BIN="${PYTHON_BIN:-$(command -v python3 || true)}"
+CONFIG_PATH_DEFAULT="${SAGE_DIR}/sage/gateway/fleet_shards.json"
+
+MODE=""
+CONFIG_PATH="$CONFIG_PATH_DEFAULT"
+DRY_RUN=0
+SCHEDULE_CRON="${ROUTER_FEDERATION_CRON:-0 2 * * *}"
+CRON_TAG="# router-federation-aggregator (sprint2-r3)"
+
+log() { echo "[router-federation] $*"; }
+
+usage() {
+    sed -n '2,40p' "$0"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --enable-cron)  MODE="enable" ;;
+        --disable-cron) MODE="disable" ;;
+        --run-now)      MODE="run" ;;
+        --status)       MODE="status" ;;
+        --dry-run)      DRY_RUN=1 ;;
+        --config)       shift; CONFIG_PATH="${1:-}" ;;
+        --config=*)     CONFIG_PATH="${1#*=}" ;;
+        --cron)         shift; SCHEDULE_CRON="${1:-}" ;;
+        --cron=*)       SCHEDULE_CRON="${1#*=}" ;;
+        -h|--help)      usage; exit 0 ;;
+        *)
+            log "ERROR: unknown arg: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$MODE" ]; then
+    log "ERROR: must pass one of --enable-cron, --disable-cron, --run-now, --status" >&2
+    exit 2
+fi
+
+# ── prereqs ────────────────────────────────────────────────────────
+
+check_prereqs() {
+    if [ -z "$PYTHON_BIN" ] || ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+        log "ERROR: python3 not found in PATH" >&2
+        return 1
+    fi
+    if ! PYTHONPATH="$SAGE_DIR" "$PYTHON_BIN" -c \
+        "import sage.cognition.router.data.federation" >/dev/null 2>&1; then
+        log "ERROR: sage.cognition.router.data.federation not importable "\
+"from SAGE_DIR=$SAGE_DIR" >&2
+        return 1
+    fi
+    return 0
+}
+
+# ── cron helpers ───────────────────────────────────────────────────
+
+# Build the exact command the cron entry executes. Paths are absolute.
+cron_command() {
+    echo "cd \"$SAGE_DIR\" && PYTHONPATH=\"$SAGE_DIR\" \"$PYTHON_BIN\" "\
+"-m sage.cognition.router.data.federation --run --config \"$CONFIG_PATH\" "\
+">> \"$HOME/.sage-federation.log\" 2>&1"
+}
+
+cron_line() {
+    echo "$SCHEDULE_CRON $(cron_command) $CRON_TAG"
+}
+
+# Read the current crontab, filtering OUT any prior router-federation
+# entries (identified by the tag comment). Returns filtered crontab on
+# stdout. Never fails even when no crontab exists.
+current_crontab_filtered() {
+    local current=""
+    if current="$(crontab -l 2>/dev/null)"; then
+        : # ok
+    else
+        current=""
+    fi
+    # Drop any existing entries tagged as ours.
+    echo "$current" | grep -v -F "$CRON_TAG" || true
+}
+
+enable_cron() {
+    check_prereqs || return 1
+    if [ ! -f "$CONFIG_PATH" ]; then
+        log "ERROR: config not found: $CONFIG_PATH"
+        log "  create from template: $SAGE_DIR/sage/gateway/fleet_shards.json"
+        return 3
+    fi
+    local line
+    line="$(cron_line)"
+    local filtered
+    filtered="$(current_crontab_filtered)"
+    log "adding cron line:"
+    echo "  $line"
+    {
+        if [ -n "$filtered" ]; then
+            echo "$filtered"
+        fi
+        echo "$line"
+    } | crontab -
+    log "enabled. Cron schedule: $SCHEDULE_CRON"
+    log "log file: $HOME/.sage-federation.log"
+}
+
+disable_cron() {
+    local filtered
+    filtered="$(current_crontab_filtered)"
+    if [ -z "$filtered" ]; then
+        crontab -r 2>/dev/null || true
+    else
+        echo "$filtered" | crontab -
+    fi
+    log "disabled. Any router-federation cron entries removed."
+}
+
+status() {
+    log "SAGE_DIR=$SAGE_DIR"
+    log "config=$CONFIG_PATH"
+    if [ -f "$CONFIG_PATH" ]; then
+        log "  config present"
+    else
+        log "  config MISSING"
+    fi
+    log "python=$PYTHON_BIN"
+    log "schedule=$SCHEDULE_CRON"
+    log "cron entry:"
+    if crontab -l 2>/dev/null | grep -F "$CRON_TAG" >/dev/null; then
+        crontab -l 2>/dev/null | grep -F "$CRON_TAG" | sed 's/^/  /'
+    else
+        log "  (not installed)"
+    fi
+}
+
+run_now() {
+    check_prereqs || return 1
+    if [ ! -f "$CONFIG_PATH" ]; then
+        log "ERROR: config not found: $CONFIG_PATH"
+        return 3
+    fi
+    local extra_flags=()
+    if [ "$DRY_RUN" -eq 1 ]; then
+        extra_flags+=("--dry-run")
+    fi
+    log "running aggregator now (config=$CONFIG_PATH)"
+    cd "$SAGE_DIR"
+    PYTHONPATH="$SAGE_DIR" "$PYTHON_BIN" \
+        -m sage.cognition.router.data.federation \
+        --run --config "$CONFIG_PATH" "${extra_flags[@]}"
+}
+
+case "$MODE" in
+    enable)  enable_cron ;;
+    disable) disable_cron ;;
+    run)     run_now ;;
+    status)  status ;;
+esac


### PR DESCRIPTION
## Summary

Router Sprint 2 Track R3 — **FleetAggregator**: Legion (data czar) runs this nightly to pull per-machine router shards and build a single fleet-wide training corpus.

- `FleetAggregator` class in `sage/cognition/router/data/federation.py` — dedup by `record_id`, source-stamp preservation, schema-version tolerant, failure-isolated per peer, atomic writes, idempotent re-runs, `--dry-run` mode.
- `scripts/router_federation_install.sh` — `--enable-cron` / `--disable-cron` / `--run-now` / `--status` for the user crontab on Legion.
- `sage/gateway/fleet_shards.json` — peer config **template** (paths are placeholders; real fleet paths to be set at deploy time).
- `sage/cognition/router/data/tests/test_federation.py` — 15 tests covering the full contract.

Respects PRD §5.6 (aggregator pulls from ALREADY-pruned shards — does not re-prune). No torch dependency.

## How local-vs-ssh transport is chosen per peer

Each peer config entry declares `transport: "local"` or `transport: "ssh"`.
- **local**: the aggregator reads `path` directly (e.g. `/mnt/c/...` on CBP where everything is under one filesystem). No SSH required.
- **ssh**: the aggregator stages the peer's shard dir into a temp dir via `rsync -az --timeout=30 -e "ssh -o BatchMode=yes -o ConnectTimeout=10"`, then reads from the staging dir. Credentials come from ssh-agent (no passwords, no tokens). Optional `ssh_user` and `ssh_port` overrides per peer. Staging dir is removed after each peer.

## Dedup semantics (record_id wins, first-seen wins on collision)

- Primary dedup key: `record_id`.
- Before reading peers, the aggregator loads existing aggregate (if any) and seeds the seen-set with its `record_id`s → **idempotent re-runs add zero new records**.
- When a `record_id` appears on two peers in the same run, the **first peer processed wins** (config order). The duplicate is counted in that peer's `duplicates`, and if the machine field differs between the two observations the collision is logged (WARNING) and tracked in `FleetAggregator.cross_machine_collisions` for post-run inspection.
- Records without `record_id` (ancient shards, corrupt schemas) are preserved verbatim but **never dedup'd** — documented behavior (see `test_no_record_id_preserved_not_dedup`). Post-R1 this should not occur.

## Failure-isolation strategy per peer

Each peer is wrapped in `try/except`. Failure modes and their treatment:
- **Local path missing** → `PeerSummary.available = False`, `errors` records "shard dir missing", continue to next peer.
- **SSH unreachable / rsync nonzero** → `available = False`, `errors` captures last 3 lines of stderr with `rc=N`, continue.
- **SSH reachable but partition absent for target date** → `available = True`, `records_seen = 0`, `errors` notes "no partition found" (informational).
- **Corrupt JSONL line** → RouterDatasetReader-style per-line log + skip (does not kill the partition, does not kill the peer).
- **Unexpected exception** → caught, logged, `errors` captures message, next peer proceeds.
- **Aggregate write OSError** → logged; `.tmp` cleaned up; aggregate left at previous state.

Smoke-tested on CBP (worktree) with all 6 peers configured against non-resolvable hostnames: CBP's local peer succeeded (0 records, no partition yet); all 5 SSH peers returned rc=255; run completed cleanly with `total_records=0` and exit 0. This is the intended behavior — partial aggregation is a feature.

## Schema-version compatibility (v0.1.0 and post-R1 v0.2.0)

The aggregator does not validate schema. It passes records through verbatim:
- v0.1.0 shards (no `metadata.source`) → preserved.
- v0.2.0 shards (with `metadata.source: raising|gameplay|idle|interactive` from R1) → preserved, and `PeerSummary.source_counts` tallies the distribution.
- Mixed-version runs during R1 rollout are expected and handled (see `test_schema_version_skew_both_preserved`).
- Unknown future `schema_version` → passed through (RouterDatasetReader handles this at the read layer).

## Cron install command exact format for Legion's crontab

```bash
./scripts/router_federation_install.sh --enable-cron
```

This writes exactly one line to the invoking user's crontab (no sudo, no system-wide cron.d):

```
0 2 * * * cd "$SAGE_DIR" && PYTHONPATH="$SAGE_DIR" "$(which python3)" -m sage.cognition.router.data.federation --run --config "$CONFIG_PATH" >> "$HOME/.sage-federation.log" 2>&1 # router-federation-aggregator (sprint2-r3)
```

- `SAGE_DIR` resolves to the repo root at install time (absolute).
- `CONFIG_PATH` defaults to `$SAGE_DIR/sage/gateway/fleet_shards.json`; override with `--config PATH`.
- Schedule override: `--cron "30 2 * * *"` or `ROUTER_FEDERATION_CRON` env var.
- Uninstall is tag-based (`# router-federation-aggregator (sprint2-r3)`) so re-enabling doesn't duplicate, and uninstalling doesn't touch unrelated cron entries.
- Logs land in `~/.sage-federation.log`.

Operator quick reference:
```bash
./scripts/router_federation_install.sh --status        # show install state
./scripts/router_federation_install.sh --run-now        # execute immediately
./scripts/router_federation_install.sh --run-now --dry-run
./scripts/router_federation_install.sh --disable-cron
```

## Assumptions about peer filesystem paths that will need to be confirmed on the real fleet

1. **Shard root layout**: the aggregator expects each peer's shard root to contain a `{machine}/{YYYY-MM-DD}.jsonl[.gz]` subdir structure (matches RouterDatasetWriter). It also falls back to a "self-rooted" layout where the partition sits directly in `path`, in case operators deploy a slightly different layout.
2. **SSH hostnames** in `fleet_shards.json` are placeholders (`sprout.local`, `nomad.local`, etc.). Legion's `/etc/hosts`, `~/.ssh/config`, or real DNS need to resolve these. Confirm at deploy time.
3. **SSH user**: no `ssh_user` set means "current user" (i.e. `dp` on Legion → `dp@sprout.local`). If fleet machines use different usernames, add `ssh_user` per peer.
4. **Peer shard paths** assume `~/ai-workspace/private-context/training-data/router/{machine}` on non-CBP Linux machines; CBP uses `/mnt/c/exe/projects/ai-agents/private-context/training-data/router/cbp`. Real paths TBD per machine at rollout time.
5. **Aggregate dir** defaults to `/home/dp/ai-workspace/private-context/training-data/router/_aggregate` on Legion — matches the enablement packet and PRD §5 layout. Parent dir must exist and be writable.
6. **Cron user**: runs as whoever enabled it. Expected to be `dp` on Legion (per enablement packet Step 5). ssh-agent must be available to that user's cron environment for SSH transport to work — operator may need to add `SSH_AUTH_SOCK` to the crontab or use a keychain-backed agent.

## Test plan

- [x] 15 new tests (all passing; full data/tests suite: 58 passing)
- [x] 3-machine fleet aggregates + dedups
- [x] Offline peer logged and skipped, others aggregate normally
- [x] Idempotent re-run: second run adds zero records
- [x] v0.1.0 and v0.2.0 records coexist in same aggregate
- [x] `metadata.source` (raising/gameplay/idle/interactive) preserved
- [x] Cross-machine `record_id` collision logged, first-seen wins
- [x] Empty shard dir handled gracefully (0 records, no crash)
- [x] Atomic write: no `.tmp` leak on success
- [x] Summary sidecar (`.summary.json`) written next to aggregate
- [x] PeerConfig validation rejects bad transport / missing host / empty path
- [x] FederationConfig round-trips from JSON file
- [x] CLI main() end-to-end smoke test
- [x] `python3 -m py_compile` passes
- [x] `bash -n scripts/router_federation_install.sh` passes
- [x] Smoke test on CBP: `--run-now --dry-run` completes cleanly with 5 unreachable SSH peers + 1 local peer — exit 0, all peer states captured in summary
- [ ] Deploy test on Legion (post-merge) with real fleet paths