### PR TITLE
gameplay_capture: carry known_good action as supervised label

### DIFF
--- a/sage/cognition/thalamic_router/gameplay_capture.py
+++ b/sage/cognition/thalamic_router/gameplay_capture.py
@@ -375,7 +375,16 @@ class GameplayCapture:
                 self.errors.append(f"step {step.index}: decide failed: {e!r}")
                 continue
 
-            # Build the record with provenance metadata
+            # Build the record with provenance metadata.
+            #
+            # `known_good_*` fields are the supervised-training labels. Since
+            # this trace is a WIN, the action actually taken at this tick is
+            # by definition a good next action. This lets downstream training
+            # use the record as a supervised triple:
+            #   state → (baseline-proposed dispatch)  [router BC]
+            #   state → known_good_action             [action prediction]
+            #   state × skill_params → known_good_action [motor-skill BC]
+            # Plus outcome-weighted shaping: sample weight ∝ game_outcome.won.
             metadata = {
                 "source": "gameplay",
                 "game": self.trace.game,
@@ -385,6 +394,10 @@ class GameplayCapture:
                 "step_index": step.index,
                 "level": step.level,
                 "synthetic_kernel_state": True,
+                # Supervised labels from the winning trace
+                "known_good_action": step.action,
+                "known_good_data": step.data,
+                "known_good_level": step.level,
             }
             record = RouterRecord(
                 router_input=router_input,

--- a/sage/cognition/thalamic_router/tests/test_gameplay_capture.py
+++ b/sage/cognition/thalamic_router/tests/test_gameplay_capture.py
@@ -186,6 +186,10 @@ def test_capture_end_to_end_emits_records(tmp_path):
         assert rec.metadata.get("game") == "testgame"
         assert rec.metadata.get("synthetic_kernel_state") is True
         assert "game_outcome" in rec.metadata
+        # Supervised-training labels
+        assert "known_good_action" in rec.metadata
+        assert rec.metadata["known_good_action"] in (1, 3, 6)   # from _make_trace_3_steps
+        assert "known_good_level" in rec.metadata
 
 
 def test_capture_writes_to_partition(tmp_path):
@@ -271,3 +275,36 @@ def test_capture_all_records_have_valid_router_output(tmp_path):
     for rec in capture.records:
         ok, reason = rec.router_output.validate()
         assert ok, f"invalid output: {reason}"
+
+
+def test_capture_known_good_labels_match_trace_actions(tmp_path):
+    """Each record's known_good_action must equal the corresponding TraceStep.action."""
+    trace = _make_trace_3_steps()
+    writer = RouterDatasetWriter(base_dir=tmp_path / "dataset",
+                                 machine="cbp", compress=False)
+    capture = GameplayCapture(trace=trace, writer=writer, machine="cbp",
+                              env_factory=_make_env_factory())
+    capture.run()
+    writer.close()
+    assert len(capture.records) == 3
+    assert capture.records[0].metadata["known_good_action"] == 1   # UP
+    assert capture.records[1].metadata["known_good_action"] == 3   # LEFT
+    assert capture.records[2].metadata["known_good_action"] == 6   # CLICK
+    # Click step carries click data
+    assert capture.records[2].metadata["known_good_data"] == {"x": 10, "y": 20}
+    # Non-click steps have None data
+    assert capture.records[0].metadata["known_good_data"] is None
+
+
+def test_capture_known_good_levels_match_trace_levels(tmp_path):
+    """known_good_level passes through the trace's per-step level."""
+    trace = _make_trace_3_steps()
+    writer = RouterDatasetWriter(base_dir=tmp_path / "dataset",
+                                 machine="cbp", compress=False)
+    capture = GameplayCapture(trace=trace, writer=writer, machine="cbp",
+                              env_factory=_make_env_factory())
+    capture.run()
+    writer.close()
+    assert capture.records[0].metadata["known_good_level"] == 0
+    assert capture.records[1].metadata["known_good_level"] == 0
+    assert capture.records[2].metadata["known_good_level"] == 1


### PR DESCRIPTION
## Summary
Per Dennis's observation: the gameplay records **are** supervised training triples, but we were only capturing what our baseline PROPOSED, not what actually was the right move. The winning trace's per-step action is by definition a good next action — encode it in metadata so downstream training can use it as the teacher signal.

## What this ships
Three new fields on every gameplay record's metadata:
- `known_good_action: int` — GameAction value the winning trace took
- `known_good_data: Dict|None` — click coords for CLICK actions, None otherwise
- `known_good_level: int` — game level at this step

## What this unlocks

| Training task | Target | State |
|---|---|---|
| Router BC | `baseline_dispatch` | already worked |
| Action prediction | `known_good_action` | **NEW** — direct action-level supervision |
| Motor-skill BC by demonstration | `known_good_action` given `(state, skill_params)` | **NEW** — when motor-skills land |
| Outcome-weighted shaping | `sample_weight ∝ game_outcome.won` | **NEW** |
| Backprop through chained components | terminal-loss on winning action | **NEW** — whole-stack gradient |

> "This is what SAGE should do next to evaluate what it proposes next" — the proposal and the ground truth are now both in every record.

## Backward compatibility
RouterRecord schema unchanged (metadata is an open dict). Old consumers that don't look at the new fields are unaffected. The PR #21 records emitted before this merge don't have the new labels, but that's 148 records on CBP — easy to re-capture via `fleet_gameplay_capture.sh`.

## Tests
2 new unit tests (18 total in the module). Verify:
- `known_good_action` exactly matches the trace action (1/3/6 for UP/LEFT/CLICK)
- Click-step `known_good_data` carries `{x, y}` coords
- `known_good_level` passes through correctly

## Recommendation post-merge
Re-run `fleet_gameplay_capture.sh` on machines that already ran it (currently CBP only) so their records get upgraded with the new labels. Machines that haven't run it yet just get the labels natively on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)