### PR TITLE
[SUPERSEDED by #58] M1 P1+P2: capture gate tunable + auditable, drops carry their reason

### DIFF
--- a/sage-rs/sage-daemon/src/consciousness.rs
+++ b/sage-rs/sage-daemon/src/consciousness.rs
@@ -262,8 +262,14 @@ impl ConsciousnessLoop {
                 entry.machine = Some(self.machine_name.clone());
                 entry.model = Some(self.model_name.clone());
 
-                if self.experience.record(entry) {
+                let outcome = self.experience.record(entry);
+                if outcome.recorded() {
                     self.stats.experiences_recorded += 1;
+                } else if let Some(reason) = outcome.reason() {
+                    info!(
+                        "experience dropped ({}), salience {:.3}",
+                        reason, salience.total
+                    );
                 }
 
                 self.stats.messages_processed += 1;

--- a/sage-rs/sage-daemon/src/consciousness.rs
+++ b/sage-rs/sage-daemon/src/consciousness.rs
@@ -184,6 +184,10 @@ impl ConsciousnessLoop {
     }
 
     async fn process_message(&mut self, pending: PendingMessage) {
+        // Decision-side time: the salience, metabolic state, and record/drop
+        // decision below are all about THIS moment. ExperienceEntry::new's own
+        // timestamp is LLM-completion time, a full generation latency later.
+        let received_ts = sage_lib::snarc::temporal::now_secs();
         let obs = derive_observation(&pending.content);
 
         let surprise = self.surprise.compute(obs, "message");
@@ -261,6 +265,7 @@ impl ConsciousnessLoop {
                 );
                 entry.machine = Some(self.machine_name.clone());
                 entry.model = Some(self.model_name.clone());
+                entry.received_ts = Some(received_ts);
 
                 let outcome = self.experience.record(entry);
                 if outcome.recorded() {

--- a/sage-rs/sage-daemon/src/main.rs
+++ b/sage-rs/sage-daemon/src/main.rs
@@ -15,9 +15,9 @@ use axum::{
 use futures_util::stream::Stream;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
-use tracing::info;
+use tracing::{info, warn};
 
-use sage_lib::experience::buffer::ExperienceBuffer;
+use sage_lib::experience::buffer::{ExperienceBuffer, DEFAULT_CAPTURE_THRESHOLD};
 use sage_lib::federation::fleet::FleetRegistry;
 use sage_lib::federation::peer_trust::PeerTrustTracker;
 use sage_lib::metabolic::controller::{CycleData, MetabolicController, MetabolicState};
@@ -602,14 +602,31 @@ async fn main() {
     let consciousness_handle = ConsciousnessHandle::new(msg_tx);
 
     // Capture gate: the salience bar an admitted percept must clear to become
-    // memory. Default 0.5 sits ABOVE presence's wake bar (WAKE_TH = 0.45,
-    // sage/embodiment/presence.py), so a 0.45..0.50 band wakes the being and
-    // leaves no experience. Whether to align the bars or keep the band is a
-    // raising decision (dp) — env-tunable so choosing doesn't need a rebuild.
-    let capture_gate = std::env::var("SAGE_CAPTURE_THRESHOLD")
-        .ok()
-        .and_then(|v| v.parse::<f64>().ok())
-        .unwrap_or(0.5);
+    // memory (band semantics documented at DEFAULT_CAPTURE_THRESHOLD, buffer.rs).
+    // Whether to align it with presence's wake bar or keep the band is a raising
+    // decision (dp) — env-tunable so choosing doesn't need a rebuild. This is
+    // the knob dp is expected to reach for, so a bad value complains loudly
+    // instead of silently running the default.
+    let capture_gate = match std::env::var("SAGE_CAPTURE_THRESHOLD") {
+        Ok(raw) => match raw.parse::<f64>() {
+            Ok(v) if (0.0..=1.0).contains(&v) => v,
+            Ok(v) => {
+                warn!(
+                    "SAGE_CAPTURE_THRESHOLD={} outside [0,1] — using default {}",
+                    v, DEFAULT_CAPTURE_THRESHOLD
+                );
+                DEFAULT_CAPTURE_THRESHOLD
+            }
+            Err(_) => {
+                warn!(
+                    "SAGE_CAPTURE_THRESHOLD={:?} unparseable — using default {}",
+                    raw, DEFAULT_CAPTURE_THRESHOLD
+                );
+                DEFAULT_CAPTURE_THRESHOLD
+            }
+        },
+        Err(_) => DEFAULT_CAPTURE_THRESHOLD,
+    };
     let experience = ExperienceBuffer::new(&exp_path, capture_gate);
     info!(
         "experience buffer: {} existing entries (capture gate {})",

--- a/sage-rs/sage-daemon/src/main.rs
+++ b/sage-rs/sage-daemon/src/main.rs
@@ -601,8 +601,21 @@ async fn main() {
     let (msg_tx, msg_rx) = tokio::sync::mpsc::channel(64);
     let consciousness_handle = ConsciousnessHandle::new(msg_tx);
 
-    let experience = ExperienceBuffer::with_defaults(&exp_path);
-    info!("experience buffer: {} existing entries", experience.count());
+    // Capture gate: the salience bar an admitted percept must clear to become
+    // memory. Default 0.5 sits ABOVE presence's wake bar (WAKE_TH = 0.45,
+    // sage/embodiment/presence.py), so a 0.45..0.50 band wakes the being and
+    // leaves no experience. Whether to align the bars or keep the band is a
+    // raising decision (dp) — env-tunable so choosing doesn't need a rebuild.
+    let capture_gate = std::env::var("SAGE_CAPTURE_THRESHOLD")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .unwrap_or(0.5);
+    let experience = ExperienceBuffer::new(&exp_path, capture_gate);
+    info!(
+        "experience buffer: {} existing entries (capture gate {})",
+        experience.count(),
+        capture_gate
+    );
 
     // Non-forcing shadow-metabolism experiment log (sibling of the experience buffer).
     let shadow_path = exp_path.with_file_name("atp_shadow.jsonl");

--- a/sage-rs/sage-lib/src/experience/buffer.rs
+++ b/sage-rs/sage-lib/src/experience/buffer.rs
@@ -15,6 +15,11 @@ pub struct ExperienceEntry {
     pub atp_percentage: f64,
     pub cycle: u64,
     pub timestamp: f64,
+    /// When the daemon began deciding on this percept — set before LLM
+    /// generation. `timestamp` is completion time and trails this by the full
+    /// generation latency, so decision-side joins must not use it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub received_ts: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub machine: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -49,11 +54,27 @@ impl ExperienceEntry {
             atp_percentage,
             cycle,
             timestamp,
+            received_ts: None,
             machine: None,
             model: None,
         }
     }
+
+    /// Decision-time ts, falling back to completion time for entries that
+    /// never set `received_ts`.
+    pub fn decided_ts(&self) -> f64 {
+        self.received_ts.unwrap_or(self.timestamp)
+    }
 }
+
+/// Default capture gate — the salience bar an admitted percept must clear to
+/// become memory. It sits ABOVE presence's wake bar (WAKE_TH = 0.45,
+/// sage/embodiment/presence.py), so a 0.45..0.50 band wakes the being without
+/// leaving an experience; align-or-keep is a raising decision, not a code
+/// default. One definition, referenced by both the daemon's env fallback
+/// (main.rs) and `with_defaults`, so the tests' gate and the daemon's cannot
+/// drift apart silently.
+pub const DEFAULT_CAPTURE_THRESHOLD: f64 = 0.5;
 
 /// Why `record()` accepted or refused an entry. A refusal is stamped to a
 /// sibling drops file so the panel can attribute drops to the capture gate,
@@ -101,14 +122,11 @@ impl ExperienceBuffer {
         }
     }
 
-    /// Default capture gate 0.5 — the salience bar an admitted percept must
-    /// clear to become memory. Note it sits ABOVE presence's wake bar
-    /// (WAKE_TH = 0.45, sage/embodiment/presence.py), so a 0.45..0.50 band
-    /// wakes the being without leaving an experience. The daemon can override
-    /// it via SAGE_CAPTURE_THRESHOLD (main.rs); align-or-keep is a raising
-    /// decision, not a code default.
+    /// Constructor at DEFAULT_CAPTURE_THRESHOLD, for tests and tooling. The
+    /// daemon does not call this — it resolves SAGE_CAPTURE_THRESHOLD in
+    /// main.rs and calls `new` directly; both paths share the const above.
     pub fn with_defaults(path: &Path) -> Self {
-        Self::new(path, 0.5)
+        Self::new(path, DEFAULT_CAPTURE_THRESHOLD)
     }
 
     fn count_lines(path: &Path) -> u64 {
@@ -117,11 +135,15 @@ impl ExperienceBuffer {
             .unwrap_or(0)
     }
 
-    fn is_repetitive(&self, response: &str) -> bool {
+    /// Highest Jaccard overlap (at or above the 0.85 bar) between `response`
+    /// and the recent-response window, or None if nothing collides. An empty
+    /// response counts as a full collision.
+    fn repetition_match(&self, response: &str) -> Option<f64> {
         let response_words: std::collections::HashSet<&str> = response.split_whitespace().collect();
         if response_words.is_empty() {
-            return true;
+            return Some(1.0);
         }
+        let mut best: Option<f64> = None;
         for recent in &self.recent_responses {
             let recent_words: std::collections::HashSet<&str> = recent.split_whitespace().collect();
             if recent_words.is_empty() {
@@ -130,11 +152,11 @@ impl ExperienceBuffer {
             let intersection = response_words.intersection(&recent_words).count();
             let union = response_words.union(&recent_words).count();
             let jaccard = intersection as f64 / union as f64;
-            if jaccard >= 0.85 {
-                return true;
+            if jaccard >= 0.85 && best.map_or(true, |b| jaccard > b) {
+                best = Some(jaccard);
             }
         }
-        false
+        best
     }
 
     /// Sibling of the buffer file: `<stem>_drops.jsonl` next to it.
@@ -149,16 +171,22 @@ impl ExperienceBuffer {
 
     /// Best-effort: an io-reason stamp can fail for the same cause as the drop
     /// it describes; a missing stamp then reads as unattributed, never as recorded.
-    fn stamp_drop(&self, entry: &ExperienceEntry, reason: &str) {
+    /// `ts` is decision-time (see `decided_ts`), but joins against the presence
+    /// log should key on `prompt` — the wake descriptor passes through unchanged,
+    /// so it is exact — not on ts proximity.
+    fn stamp_drop(&self, entry: &ExperienceEntry, reason: &str, detail: serde_json::Value) {
         if let Some(parent) = self.path.parent() {
             let _ = fs::create_dir_all(parent);
         }
-        let stamp = serde_json::json!({
-            "ts": entry.timestamp,
+        let mut stamp = serde_json::json!({
+            "ts": entry.decided_ts(),
             "reason": reason,
             "salience": entry.salience.total,
             "prompt": entry.prompt,
         });
+        if let (Some(obj), serde_json::Value::Object(extra)) = (stamp.as_object_mut(), detail) {
+            obj.extend(extra);
+        }
         let _ = OpenOptions::new()
             .create(true)
             .append(true)
@@ -168,11 +196,18 @@ impl ExperienceBuffer {
 
     pub fn record(&mut self, entry: ExperienceEntry) -> RecordOutcome {
         if entry.salience.total < self.salience_threshold {
-            self.stamp_drop(&entry, "salience");
+            self.stamp_drop(&entry, "salience", serde_json::json!({}));
             return RecordOutcome::DroppedSalience;
         }
-        if self.is_repetitive(&entry.response) {
-            self.stamp_drop(&entry, "repetition");
+        if let Some(score) = self.repetition_match(&entry.response) {
+            // The deciding input for this reason is the response (vs the recent
+            // window), so stamp it — the same standard the salience reason meets
+            // by stamping `salience`.
+            self.stamp_drop(
+                &entry,
+                "repetition",
+                serde_json::json!({ "response": entry.response, "match": score }),
+            );
             return RecordOutcome::DroppedRepetition;
         }
 
@@ -183,7 +218,7 @@ impl ExperienceBuffer {
         let line = match serde_json::to_string(&entry) {
             Ok(s) => s,
             Err(_) => {
-                self.stamp_drop(&entry, "io");
+                self.stamp_drop(&entry, "io", serde_json::json!({}));
                 return RecordOutcome::DroppedIo;
             }
         };
@@ -203,7 +238,7 @@ impl ExperienceBuffer {
             }
             RecordOutcome::Recorded
         } else {
-            self.stamp_drop(&entry, "io");
+            self.stamp_drop(&entry, "io", serde_json::json!({}));
             RecordOutcome::DroppedIo
         }
     }
@@ -287,7 +322,25 @@ mod tests {
         assert_eq!(buf.record(e2), RecordOutcome::DroppedRepetition);
         assert_eq!(buf.count(), 1);
         let drops = fs::read_to_string(drops_path_for(&path)).unwrap();
-        assert!(drops.contains("\"reason\":\"repetition\""));
+        let stamp: serde_json::Value = serde_json::from_str(drops.lines().next().unwrap()).unwrap();
+        assert_eq!(stamp["reason"], "repetition");
+        assert_eq!(stamp["response"], "the quick brown fox jumps over the lazy dog");
+        assert_eq!(stamp["match"].as_f64().unwrap(), 1.0);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(drops_path_for(&path));
+    }
+
+    #[test]
+    fn drop_stamp_uses_decision_time_ts() {
+        let path = temp_path();
+        let mut buf = ExperienceBuffer::with_defaults(&path);
+        let mut entry = make_entry("hello", "world", 0.2);
+        entry.received_ts = Some(entry.timestamp - 42.0);
+        let expected = entry.decided_ts();
+        assert_eq!(buf.record(entry), RecordOutcome::DroppedSalience);
+        let drops = fs::read_to_string(drops_path_for(&path)).unwrap();
+        let stamp: serde_json::Value = serde_json::from_str(drops.lines().next().unwrap()).unwrap();
+        assert_eq!(stamp["ts"].as_f64().unwrap(), expected);
         let _ = fs::remove_file(&path);
         let _ = fs::remove_file(drops_path_for(&path));
     }

--- a/sage-rs/sage-lib/src/experience/buffer.rs
+++ b/sage-rs/sage-lib/src/experience/buffer.rs
@@ -55,6 +55,32 @@ impl ExperienceEntry {
     }
 }
 
+/// Why `record()` accepted or refused an entry. A refusal is stamped to a
+/// sibling drops file so the panel can attribute drops to the capture gate,
+/// the repetition filter, or an io failure instead of conflating the three.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecordOutcome {
+    Recorded,
+    DroppedSalience,
+    DroppedRepetition,
+    DroppedIo,
+}
+
+impl RecordOutcome {
+    pub fn recorded(self) -> bool {
+        matches!(self, RecordOutcome::Recorded)
+    }
+
+    pub fn reason(self) -> Option<&'static str> {
+        match self {
+            RecordOutcome::Recorded => None,
+            RecordOutcome::DroppedSalience => Some("salience"),
+            RecordOutcome::DroppedRepetition => Some("repetition"),
+            RecordOutcome::DroppedIo => Some("io"),
+        }
+    }
+}
+
 pub struct ExperienceBuffer {
     path: PathBuf,
     salience_threshold: f64,
@@ -75,6 +101,12 @@ impl ExperienceBuffer {
         }
     }
 
+    /// Default capture gate 0.5 — the salience bar an admitted percept must
+    /// clear to become memory. Note it sits ABOVE presence's wake bar
+    /// (WAKE_TH = 0.45, sage/embodiment/presence.py), so a 0.45..0.50 band
+    /// wakes the being without leaving an experience. The daemon can override
+    /// it via SAGE_CAPTURE_THRESHOLD (main.rs); align-or-keep is a raising
+    /// decision, not a code default.
     pub fn with_defaults(path: &Path) -> Self {
         Self::new(path, 0.5)
     }
@@ -105,12 +137,43 @@ impl ExperienceBuffer {
         false
     }
 
-    pub fn record(&mut self, entry: ExperienceEntry) -> bool {
+    /// Sibling of the buffer file: `<stem>_drops.jsonl` next to it.
+    fn drops_path(&self) -> PathBuf {
+        let stem = self
+            .path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("experience");
+        self.path.with_file_name(format!("{stem}_drops.jsonl"))
+    }
+
+    /// Best-effort: an io-reason stamp can fail for the same cause as the drop
+    /// it describes; a missing stamp then reads as unattributed, never as recorded.
+    fn stamp_drop(&self, entry: &ExperienceEntry, reason: &str) {
+        if let Some(parent) = self.path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let stamp = serde_json::json!({
+            "ts": entry.timestamp,
+            "reason": reason,
+            "salience": entry.salience.total,
+            "prompt": entry.prompt,
+        });
+        let _ = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.drops_path())
+            .and_then(|mut f| writeln!(f, "{}", stamp));
+    }
+
+    pub fn record(&mut self, entry: ExperienceEntry) -> RecordOutcome {
         if entry.salience.total < self.salience_threshold {
-            return false;
+            self.stamp_drop(&entry, "salience");
+            return RecordOutcome::DroppedSalience;
         }
         if self.is_repetitive(&entry.response) {
-            return false;
+            self.stamp_drop(&entry, "repetition");
+            return RecordOutcome::DroppedRepetition;
         }
 
         if let Some(parent) = self.path.parent() {
@@ -119,7 +182,10 @@ impl ExperienceBuffer {
 
         let line = match serde_json::to_string(&entry) {
             Ok(s) => s,
-            Err(_) => return false,
+            Err(_) => {
+                self.stamp_drop(&entry, "io");
+                return RecordOutcome::DroppedIo;
+            }
         };
 
         let ok = OpenOptions::new()
@@ -135,9 +201,11 @@ impl ExperienceBuffer {
             if self.recent_responses.len() > self.repetition_window {
                 self.recent_responses.remove(0);
             }
+            RecordOutcome::Recorded
+        } else {
+            self.stamp_drop(&entry, "io");
+            RecordOutcome::DroppedIo
         }
-
-        ok
     }
 
     pub fn count(&self) -> u64 {
@@ -181,36 +249,47 @@ mod tests {
         )
     }
 
+    fn drops_path_for(path: &PathBuf) -> PathBuf {
+        let stem = path.file_stem().unwrap().to_str().unwrap();
+        path.with_file_name(format!("{stem}_drops.jsonl"))
+    }
+
     #[test]
     fn records_salient_experience() {
         let path = temp_path();
         let mut buf = ExperienceBuffer::with_defaults(&path);
         let entry = make_entry("hello", "world", 0.8);
-        assert!(buf.record(entry));
+        assert!(buf.record(entry).recorded());
         assert_eq!(buf.count(), 1);
         let _ = fs::remove_file(&path);
     }
 
     #[test]
-    fn rejects_low_salience() {
+    fn rejects_low_salience_with_stamped_reason() {
         let path = temp_path();
         let mut buf = ExperienceBuffer::with_defaults(&path);
         let entry = make_entry("hello", "world", 0.2);
-        assert!(!buf.record(entry));
+        assert_eq!(buf.record(entry), RecordOutcome::DroppedSalience);
         assert_eq!(buf.count(), 0);
+        let drops = fs::read_to_string(drops_path_for(&path)).unwrap();
+        assert!(drops.contains("\"reason\":\"salience\""));
         let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(drops_path_for(&path));
     }
 
     #[test]
-    fn rejects_repetitive() {
+    fn rejects_repetitive_with_stamped_reason() {
         let path = temp_path();
         let mut buf = ExperienceBuffer::with_defaults(&path);
         let e1 = make_entry("q1", "the quick brown fox jumps over the lazy dog", 0.8);
         let e2 = make_entry("q2", "the quick brown fox jumps over the lazy dog", 0.8);
-        assert!(buf.record(e1));
-        assert!(!buf.record(e2));
+        assert!(buf.record(e1).recorded());
+        assert_eq!(buf.record(e2), RecordOutcome::DroppedRepetition);
         assert_eq!(buf.count(), 1);
+        let drops = fs::read_to_string(drops_path_for(&path)).unwrap();
+        assert!(drops.contains("\"reason\":\"repetition\""));
         let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(drops_path_for(&path));
     }
 
     #[test]

--- a/sage/embodiment/presence.py
+++ b/sage/embodiment/presence.py
@@ -29,7 +29,10 @@ LOW_ATP = 25.0            # below this (or a resting metabolic state) the being 
 
 POLL_S = 1.0            # check the perceptual state ~1/s
 STALE_S = 10.0         # perception older than this = cortex not live → don't wake on stale data
-WAKE_TH = 0.45        # salience bar to wake when engaged (eyes open); the cortex 'salient' bar is 0.35
+WAKE_TH = 0.45        # salience bar to wake when engaged (eyes open); the cortex 'salient' bar is 0.35.
+                      # NOTE: the daemon's capture (memory) gate is 0.5 (SAGE_CAPTURE_THRESHOLD,
+                      # sage-rs/sage-daemon/src/main.rs) — wakes in 0.45..0.50 interrupt the being
+                      # but leave no experience. Align-or-keep is an open raising decision (M1).
 WAKE_TH_REST = 0.70   # much higher when resting — only something strong stirs a sleeper
 COOLDOWN_S = 300      # min seconds between wakes (a sustained moment wakes once)
 HOURLY_CAP = 6        # never more than this many wakes in a rolling hour
@@ -90,18 +93,22 @@ class Presence:
         # then attends again. This is the metabolic rhythm of attention, not just a rate limit.
         depleted = atp < LOW_ATP or mstate in ("dream", "rest")
         threshold = WAKE_TH_REST if (resting or depleted) else WAKE_TH
+        # decided = the inputs the wake decision actually used. The log's "metabolic"/"atp" are the
+        # daemon's post-chat state (the chat itself can shift it), so without this the applied bar
+        # is not auditable from the log.
+        decided = {"atp": round(atp, 1), "mstate": mstate, "bar": threshold}
         # strong enough: high blended salience, OR a reafference conflict while fully receptive.
         strong = sal.get("salience", 0.0) >= threshold or (sal.get("conflict") == 1 and not (resting or depleted))
         if not (strong and descriptor):
-            return False, resting
+            return False, resting, decided
         if now - self.last_wake < COOLDOWN_S:
-            return False, resting
+            return False, resting, decided
         self.wake_times = [t for t in self.wake_times if now - t < 3600]
         if len(self.wake_times) >= HOURLY_CAP:
-            return False, resting
+            return False, resting, decided
         if descriptor[:40] == self.last_desc[:40]:   # same moment persisting → notice once
-            return False, resting
-        return True, resting
+            return False, resting, decided
+        return True, resting, decided
 
     def _log(self, ev: dict):
         os.makedirs(os.path.dirname(PRESENCE_LOG), exist_ok=True)
@@ -127,7 +134,7 @@ class Presence:
                     sal = d.get("salience", {})
                     gaze = d.get("gaze", "open")
                     descriptor = d.get("descriptor", "")
-                    wake, resting = self._should_wake(sal, gaze, descriptor, now)
+                    wake, resting, decided = self._should_wake(sal, gaze, descriptor, now)
                     if wake:
                         out = _wake(descriptor, resting, sal.get("salience"), d.get("coherence"))
                         noticing = out.get("response", "")
@@ -140,6 +147,7 @@ class Presence:
                             "snarc": {k: sal.get(k) for k in ("surprise", "novelty", "arousal", "conflict")},
                             "gaze": gaze, "resting": resting, "noticing": noticing,
                             "metabolic": out.get("metabolic_state"), "atp": out.get("atp_percentage"),
+                            "decided": decided,
                         })
                         print(f"[presence] noticed ({'rest' if resting else 'awake'}, "
                               f"sal={sal.get('salience')}): {noticing[:90]}", flush=True)


### PR DESCRIPTION
Follow-through on the fleet source check in mesh thread `coordination-1785357283`
(hub → Sprout, `2026-07-29-hub-m1-capture-gate-source-check.md`). Decision-neutral
instrumentation only — **no behavior change at defaults, and the a/b/c band
decision stays with dp.**

- **P1 — capture gate is now runtime-tunable.** Was a hardcoded `0.5` in
  `ExperienceBuffer::with_defaults`, reachable only by Rust rebuild (so option (b)
  was unimplementable at runtime). Now `SAGE_CAPTURE_THRESHOLD` at the daemon's
  construction site, default unchanged. Both bars (wake 0.45 / capture 0.5) are
  co-located in comments at all three sites.
- **P2 — drops carry their reason.** `record()` returned `bool`, conflating the
  salience gate, the repetition filter (word-Jaccard ≥0.85 vs last 10 responses),
  and io failures. Now returns `RecordOutcome`, and every drop stamps
  `{ts, reason, salience, prompt}` to a sibling `<stem>_drops.jsonl`. Panel-side
  join wiring in `liveness_binding.py` should follow once stamps exist in the
  field (needs daemon rebuild+restart — deliberately not done here).
- **Presence log now records decision-time inputs.** The existing `metabolic`/`atp`
  fields are the daemon's *post-chat* state, so the applied wake bar (0.45 vs 0.70
  depleted) was not auditable — the M1 window shows drops at salience 0.46 logged
  as `dream`, which under a decision-time 0.70 bar could not have woken. New
  `decided={atp, mstate, bar}` field closes that.

Verification: `cargo test` 79 passed; daemon builds clean; `py_compile` on
presence.py. Also re-ran the M1 join at the M1 timestamp with conflict flags:
30 wakes → 17/13 reproduced exactly, **0 conflict-wakes** — all 13 drops are
genuine 0.456–0.499 band wakes (hub's fourth-path concern doesn't apply to this
sample).

Note: the running daemon still uses the old binary; merging this does not change
the being until dp chooses to rebuild/restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)