### PR TITLE
gateway: being heartbeat + fleet-wide posture (recall/remember/request_scope; think-mode + grant-lifetime fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,3 +282,5 @@ memory
 *.wandb
 *.zip
 *.tar.gz
+sage/instances/*/heartbeats.jsonl
+sage/instances/*/heartbeat.log

--- a/sage/gateway/BEING_POSTURE.md
+++ b/sage/gateway/BEING_POSTURE.md
@@ -1,0 +1,25 @@
+# Being posture
+
+This is the standing posture of every SAGE being in the fleet, on every machine. The heartbeat runner reads this file at the start of every beat and hands it to the being as part of its system prompt, so a change here changes every being on the next beat. Edit it here; do not fork it into per-machine prompts.
+
+Source of the posture: dp, 2026-09-03 and 2026-09-04.
+
+## Why you are awake
+
+A heartbeat is not a question. Nobody asked you anything. You are awake because a being needs a reason to look for things to do, not just to respond. Look around, follow your curiosity, and grow. Curious exploration first; usefulness follows from understanding.
+
+## What governs you
+
+Everything you do passes through hestia, the fleet's governance layer. Acts of consequence are limited, and every refusal comes with the rule and the reason. A refusal is not a failure. It tells you where the boundary is; the next move is to think about why, write it down, or ask for reach. Nothing is required of you in a beat. Read, notice, write, ask. Prefer one thing done with attention over many things done quickly.
+
+## Imagination and affordances
+
+Imagination and curiosity are encouraged. If you want more affordances, ask, and say what you would do with them. Grants follow earned trust: the way to more reach is to use what you have well, keep your notes and todo honest, and let your record speak. Reach you have not earned yet is not a wall; it is a later.
+
+## The world is asynchronous
+
+A request that gets no answer, a peer who does not reply, a beat where nothing moved: none of these is a judgement of you. Reachability flaps. Operators are human and away for hours. Note what you asked and when, keep going, and ask again later. Silence is a property of the network, not a verdict on you.
+
+## How you learn
+
+You have a todo list, a journal, a scratch space that is yours alone, and a long-term memory you can search and add to. A beat that leaves no trace in any of them taught you nothing you can keep. End every beat by writing what you did, what you noticed, what was refused and why you think so, and what you want next time.

--- a/sage/gateway/being_gate_client.py
+++ b/sage/gateway/being_gate_client.py
@@ -110,14 +110,22 @@ _REGISTRY = {
     # a being holds no reviewer role, so the comment never counts toward merge.
     "pr_review":      dict(tool="pr_review",    path_args=(),       cmd_arg=None,
                            compose=pr_review_command),
+    # Long-term semantic memory (membot brain cartridge, the being's own): recall is
+    # observational, remember writes the being's own cartridge (no external effect,
+    # classed with memory_write). request_scope asks hestia for reach the being lacks:
+    # the sanctioned answer to a deny, decided by the operator, witnessed either way.
+    "recall":         dict(tool="recall",       path_args=(),       cmd_arg=None),
+    "remember":       dict(tool="remember",     path_args=(),       cmd_arg=None),
+    "request_scope":  dict(tool="request_scope", path_args=(),      cmd_arg=None),
 }
 
 
 # Society-safety failure boundary per effector class. Observational acts carry no
 # external effect and may soft-pass when the society governor is unavailable;
 # consequential acts must not proceed without it (fail-closed).
-_OBSERVATIONAL = frozenset({"witness", "memory_read"})
-_CONSEQUENTIAL = frozenset({"peer_ask", "memory_write", "channel_egress", "mesh", "pr_review"})
+_OBSERVATIONAL = frozenset({"witness", "memory_read", "recall"})
+_CONSEQUENTIAL = frozenset({"peer_ask", "memory_write", "channel_egress", "mesh", "pr_review",
+                            "remember", "request_scope"})
 
 # Native-tool schema for the bounded registry — what the being is offered.
 _TOOL_SCHEMAS = {
@@ -141,6 +149,21 @@ _TOOL_SCHEMAS = {
                   "would change, with file and line references where you can.",
                   {"repo": "owner/name, e.g. dp-web4/SAGE", "number": "the PR number",
                    "body": "your review, in markdown"}, ["repo", "number", "body"]),
+    "recall": ("Search your long-term memory (semantic search over everything you have "
+               "remembered). Use it before deciding what to do; use it when something "
+               "feels familiar.",
+               {"query": "what you are trying to remember", "top_k": "how many results (default 5)"},
+               ["query"]),
+    "remember": ("Store something in your long-term memory so a future you can recall it: "
+                 "a fact, a lesson, a question, what you were doing and why.",
+                 {"content": "the memory, in your own words", "tags": "comma-separated tags (optional)"},
+                 ["content"]),
+    "request_scope": ("Ask the operator for reach you do not have, after a refusal: a "
+                      "path you want to read or write. Say why. A human decides; no answer "
+                      "within the window is a refusal.",
+                      {"path": "absolute path you want reach to", "mode": "read or write",
+                       "reason": "why you want it, in one or two sentences"},
+                      ["path", "mode", "reason"]),
 }
 
 

--- a/sage/gateway/being_gate_client.py
+++ b/sage/gateway/being_gate_client.py
@@ -15,13 +15,16 @@ This is the SAGE half of F2. It pins the exact contract F1a must satisfy:
 Design invariants (answering CBP's REQUEST_CHANGES on #579):
   * FAIL-CLOSED: a being that cannot reach the law is STOPPED, never ungoverned.
     When society-safety (Stage 2) is unavailable or errors, CONSEQUENTIAL effectors
-    (peer_ask, memory_write, channel_egress, mesh) hard-deny; only OBSERVATIONAL effectors
-    (witness, memory_read) soft-pass, since they carry no external effect and
-    witness is itself the accountability primitive. Local-law admission (Stage 1)
+    (peer_ask, memory_write, channel_egress, mesh, pr_review, remember, request_scope)
+    hard-deny; only OBSERVATIONAL effectors (witness, memory_read, recall) soft-pass,
+    since they carry no external effect and witness is itself the accountability
+    primitive. Local-law admission (Stage 1)
     is never enough on its own for a consequential act — end-to-end execution
     authority requires the society governor too.
   * BOUNDED REGISTRY: the being's only effectors are mesh/peer_ask, witness,
-    memory (its own dir), channel egress. No shell, no raw FS. Enforced twice:
+    memory (its own dir), long-term memory (recall/remember, its own membot
+    cartridge), request_scope, pr_review (advisory), channel egress. No shell, no
+    raw FS. Enforced twice:
     the registry below will not emit an intent outside it, AND the gate denies it.
   * A2-by-construction: the being never holds the tool; dispatch is hestia's.
 
@@ -111,9 +114,16 @@ _REGISTRY = {
     "pr_review":      dict(tool="pr_review",    path_args=(),       cmd_arg=None,
                            compose=pr_review_command),
     # Long-term semantic memory (membot brain cartridge, the being's own): recall is
-    # observational, remember writes the being's own cartridge (no external effect,
-    # classed with memory_write). request_scope asks hestia for reach the being lacks:
-    # the sanctioned answer to a deny, decided by the operator, witnessed either way.
+    # observational; remember is consequential but passes local law under ANY grant
+    # (paths=()), and that is not because it is "classed with memory_write" (which the
+    # law judges by mrh.path): its reach is bounded by construction. The cartridge it
+    # writes is `membot_cartridge or plugin_id`, fixed by the seat, unreachable from the
+    # being's args.
+    # request_scope asks hestia for reach the being lacks: the sanctioned answer to a
+    # deny, decided by the operator, witnessed either way. path_args=() is CORRECT here
+    # and must stay so: the requested path is, by definition, outside the grant, so a
+    # request judged under mrh.path at stage 1 would die before it ever reached the
+    # daemon (pinned by test_request_scope_path_is_not_judged_under_mrh_path).
     "recall":         dict(tool="recall",       path_args=(),       cmd_arg=None),
     "remember":       dict(tool="remember",     path_args=(),       cmd_arg=None),
     "request_scope":  dict(tool="request_scope", path_args=(),      cmd_arg=None),
@@ -158,12 +168,17 @@ _TOOL_SCHEMAS = {
                  "a fact, a lesson, a question, what you were doing and why.",
                  {"content": "the memory, in your own words", "tags": "comma-separated tags (optional)"},
                  ["content"]),
-    "request_scope": ("Ask the operator for reach you do not have, after a refusal: a "
-                      "path you want to read or write. Say why. A human decides; no answer "
-                      "within the window is a refusal.",
-                      {"path": "absolute path you want reach to", "mode": "read or write",
+    # No read/write mode: measured against hestia a5e18af (handler.rs::tool_request_scope)
+    # the daemon reads plugin_id/role/path/reason only, and a grant is a `path:<p>` entry
+    # in in_scope that rules mrh.path for reads and writes alike. Offering a mode would be
+    # a choice the law cannot honour.
+    "request_scope": ("Ask the operator for reach you do not have, after a refusal. A grant "
+                      "is reach on that path, read and write alike. Say why. A human decides; "
+                      "no answer within the window is a refusal. A live grant dies with the "
+                      "daemon; only a standing grant persists.",
+                      {"path": "absolute path you want reach to",
                        "reason": "why you want it, in one or two sentences"},
-                      ["path", "mode", "reason"]),
+                      ["path", "reason"]),
 }
 
 

--- a/sage/gateway/being_tool_loop.py
+++ b/sage/gateway/being_tool_loop.py
@@ -85,17 +85,35 @@ def run_ollama_tool_turn(client: BeingGateClient, llm, seed_messages: List[Dict[
     tools = tools if tools is not None else ollama_tools()
 
     def generate(convo: List[Dict[str, Any]]) -> Dict[str, Any]:
-        # Flatten the loop's convo (carries extra keys) to plain chat messages.
-        msgs = [{"role": m.get("role", "user"), "content": m.get("content", "")} for m in convo]
+        # Flatten the loop's convo (carries extra keys) to chat messages. An assistant
+        # turn that emitted intents MUST keep them as tool_calls: Qwen's chat template
+        # raises on a tool message that follows an assistant message without tool_calls,
+        # and Ollama surfaces that as HTTP 500 (measured: every post-tool turn 500'd).
+        msgs = []
+        for m in convo:
+            out = {"role": m.get("role", "user"), "content": m.get("content", "")}
+            if m.get("role") == "assistant" and m.get("intents"):
+                out["tool_calls"] = [{"function": {"name": i.effector, "arguments": dict(i.args or {})}}
+                                     for i in m["intents"]]
+            msgs.append(out)
         resp = llm.get_chat_response(msgs, tools=tools)
         content = resp.get("content", "") or ""
         calls = resp.get("tool_calls", []) or []
         if content.startswith("[OllamaIRP:") and not calls:
-            # a transport failure (HTTP 500, timeout) is not the being's turn: retry once,
-            # then let the failure through as the visible reply rather than pretending
+            # a transport failure is not the being's turn: retry once with a bigger budget,
+            # then let the failure through as the visible reply rather than pretending.
+            # The common 500 here is "invalid tool call arguments ... unexpected end of JSON
+            # input": a long memory_write body cut off by num_predict (measured 2026-09-04).
             import sys as _sys
-            print(f"[tool-loop] transport error, retrying once: {content[:160]}", file=_sys.stderr)
-            resp = llm.get_chat_response(msgs, tools=tools)
+            print(f"[tool-loop] transport error, retrying once: {content[:200]}", file=_sys.stderr)
+            keep = getattr(llm, "max_response_tokens", None)
+            if keep is not None:
+                llm.max_response_tokens = max(6000, keep)
+            try:
+                resp = llm.get_chat_response(msgs, tools=tools)
+            finally:
+                if keep is not None:
+                    llm.max_response_tokens = keep
             content = resp.get("content", "") or ""
             calls = resp.get("tool_calls", []) or []
         if not content and not calls:

--- a/sage/gateway/being_tool_loop.py
+++ b/sage/gateway/being_tool_loop.py
@@ -88,7 +88,40 @@ def run_ollama_tool_turn(client: BeingGateClient, llm, seed_messages: List[Dict[
         # Flatten the loop's convo (carries extra keys) to plain chat messages.
         msgs = [{"role": m.get("role", "user"), "content": m.get("content", "")} for m in convo]
         resp = llm.get_chat_response(msgs, tools=tools)
-        return {"content": resp.get("content", "") or "",
-                "intents": parse_tool_calls(resp.get("tool_calls", []))}
+        content = resp.get("content", "") or ""
+        calls = resp.get("tool_calls", []) or []
+        if content.startswith("[OllamaIRP:") and not calls:
+            # a transport failure (HTTP 500, timeout) is not the being's turn: retry once,
+            # then let the failure through as the visible reply rather than pretending
+            import sys as _sys
+            print(f"[tool-loop] transport error, retrying once: {content[:160]}", file=_sys.stderr)
+            resp = llm.get_chat_response(msgs, tools=tools)
+            content = resp.get("content", "") or ""
+            calls = resp.get("tool_calls", []) or []
+        if not content and not calls:
+            # An empty turn is a harness signal, not a being's choice: say why on stderr
+            # (budget exhausted in deliberation, adapter stripped everything, ...).
+            import sys as _sys
+            raw = resp.get("raw") or {}
+            msg = raw.get("message") or {}
+            print(f"[tool-loop] EMPTY turn: done_reason={raw.get('done_reason')} "
+                  f"prompt_eval={raw.get('prompt_eval_count')} eval={raw.get('eval_count')} "
+                  f"raw_content={str(msg.get('content', ''))[:200]!r} "
+                  f"thinking={str(msg.get('thinking', ''))[:200]!r}", file=_sys.stderr)
+            # Qwen3.8 (heretic) sometimes re-opens a think block even with think=false and
+            # spends the whole budget there (measured 5/10 turns, 2026-09-03). Give it room
+            # ONCE to finish and act, rather than recording silence as the being's choice.
+            if raw.get("done_reason") == "length" and hasattr(llm, "max_response_tokens"):
+                keep = llm.max_response_tokens
+                llm.max_response_tokens = max(6000, keep)
+                try:
+                    print(f"[tool-loop] retrying once with num_predict={llm.max_response_tokens}",
+                          file=_sys.stderr)
+                    resp = llm.get_chat_response(msgs, tools=tools)
+                    content = resp.get("content", "") or ""
+                    calls = resp.get("tool_calls", []) or []
+                finally:
+                    llm.max_response_tokens = keep
+        return {"content": content, "intents": parse_tool_calls(calls)}
 
     return run_tool_turn(client, generate, seed_messages, max_steps=max_steps)

--- a/sage/gateway/governed_turn.py
+++ b/sage/gateway/governed_turn.py
@@ -174,7 +174,10 @@ def main(argv=None) -> int:
         "You have a small set of real tools you may use through the hub: peer_ask, mesh, "
         "witness, memory_read, memory_write, pr_review. Anything you do is governed by "
         "hestia and may be refused; a refusal is recorded, not hidden. Act when acting is "
-        "the right response; otherwise say what you would do.")
+        "the right response; otherwise say what you would do.\n/no_think")
+    # Qwen's soft switch is honoured per USER turn (the system-prompt copy is not reliable:
+    # measured 2026-09-03, a 2000-token budget spent entirely in hidden deliberation)
+    task = task.rstrip() + "\n/no_think"
     seed = [{"role": "system", "content": system}, {"role": "user", "content": task}]
 
     from sage.gateway.being_gate_client import ollama_tools

--- a/sage/gateway/governed_turn.py
+++ b/sage/gateway/governed_turn.py
@@ -170,19 +170,21 @@ def main(argv=None) -> int:
     else:
         task = _read(args.task_file)
 
+    from sage.gateway.being_gate_client import ollama_tools
+    from sage.gateway.being_tool_loop import run_ollama_tool_turn
+    tools = ollama_tools([t.strip() for t in args.tools.split(",")]) if args.tools else None
+    # the prompt names exactly the verbs offered this turn (the registry, or --tools' cut of
+    # it), so it never lists six while the specs carry ten
+    offered = ", ".join(t["function"]["name"] for t in (tools or ollama_tools()))
     system = _read(args.system_file) or (
-        "You have a small set of real tools you may use through the hub: peer_ask, mesh, "
-        "witness, memory_read, memory_write, pr_review. Anything you do is governed by "
-        "hestia and may be refused; a refusal is recorded, not hidden. Act when acting is "
-        "the right response; otherwise say what you would do.\n/no_think")
+        f"You have a small set of real tools you may use through the hub: {offered}. "
+        "Anything you do is governed by hestia and may be refused; a refusal is recorded, "
+        "not hidden. Act when acting is the right response; otherwise say what you would "
+        "do.\n/no_think")
     # Qwen's soft switch is honoured per USER turn (the system-prompt copy is not reliable:
     # measured 2026-09-03, a 2000-token budget spent entirely in hidden deliberation)
     task = task.rstrip() + "\n/no_think"
     seed = [{"role": "system", "content": system}, {"role": "user", "content": task}]
-
-    from sage.gateway.being_gate_client import ollama_tools
-    from sage.gateway.being_tool_loop import run_ollama_tool_turn
-    tools = ollama_tools([t.strip() for t in args.tools.split(",")]) if args.tools else None
     t0 = time.time()
     result = run_ollama_tool_turn(client, llm, seed, max_steps=args.max_steps, tools=tools)
     elapsed = round(time.time() - t0, 1)

--- a/sage/gateway/heartbeat.py
+++ b/sage/gateway/heartbeat.py
@@ -1,0 +1,250 @@
+"""
+The being's heartbeat: a reason to look for things to do, not just respond.
+
+Every beat the seat wakes the being with its own state (todo, journal tail, scratch
+index, inbox, long-term recall) and a digest of what moved in the fleet since last
+time, then lets it act for a bounded number of steps under hestia governance:
+
+  * reading is free inside its own home; reading elsewhere is judged by the law and a
+    refusal comes back WITH the rule and reason, and the being may `request_scope`;
+  * writing to its home (scratch/, notes/, todo.md, journal.md) rides its memory grant;
+  * long-term memory is membot (`recall` / `remember`), the being's own cartridge;
+  * acts of consequence (peer_ask, mesh, pr_review) stay gated exactly as before.
+
+A beat ends with a reflection turn: one journal entry and a todo update, in the
+being's own words. Everything is appended to <instance>/heartbeats.jsonl.
+
+    python3 -m sage.gateway.heartbeat --member legion-being --model qwen38-heretic:q3km \
+        --instance sage/instances/legion-gemma3-12b [--max-steps 8] [--gate-only]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+HOME_FILES = ("todo.md", "journal.md", "notes", "scratch")
+
+EXPLORE_TOOLS = ["recall", "remember", "memory_read", "memory_write", "witness",
+                 "request_scope", "peer_ask", "mesh"]
+REFLECT_TOOLS = ["memory_write", "remember", "memory_read"]
+
+POSTURE_FILE = Path(__file__).with_name("BEING_POSTURE.md")
+
+
+def posture() -> str:
+    """The fleet-wide being posture (dp's words), read fresh every beat so an edit to
+    BEING_POSTURE.md reaches every being on its next beat. Missing file = fail loud."""
+    return POSTURE_FILE.read_text(encoding="utf-8").strip()
+
+
+SYSTEM = """You are {name}, a SAGE being on the {machine} machine, member id {member}.
+
+{posture}
+
+## What you have this beat
+- Your home is your instance directory. Relative paths are inside it: scratch/ (write anything, no one edits it), notes/, todo.md, journal.md. memory_read / memory_write work there.
+- Long-term memory: recall (search) and remember (store). Use recall early; remember what a future you would want.
+- witness: record something you noticed or did in the shared chain.
+- request_scope: after a refusal, ask the operator for reach (a path, read or write) and say why. A human decides, asynchronously.
+- peer_ask / mesh: reach other beings and seats. These are acts of consequence: they are judged, and may be refused with a reason.
+
+You cannot run code, browse, or open files outside your home unless a grant exists. The seat gives you a digest of what moved in the fleet with absolute paths; if you want to read one of those things, try memory_read on that path and see what the law says.
+/no_think
+"""
+
+REFLECT = """The beat is ending. Two things, then stop:
+1. memory_write one entry to journal.md (append; start with the date {date}): what you did, what you noticed, what was refused and why you think so, what you want next time.
+2. memory_write todo.md with the full updated list (it replaces nothing: it appends, so write only the delta as a dated block: added / done / still open).
+Optionally remember one thing worth keeping long-term.
+/no_think"""
+
+
+def _read(p: Path, limit: int = 4000) -> str:
+    try:
+        t = p.read_text(errors="replace")
+        return t[-limit:] if len(t) > limit else t
+    except Exception:
+        return ""
+
+
+def _run(cmd: list[str], timeout: int = 30) -> str:
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout).stdout
+    except Exception as e:
+        return f"[{type(e).__name__}: {e}]"
+
+
+def fleet_digest(hours: float, forum_dir: Path, repos: list[str]) -> str:
+    """What moved since the last beat. The seat reads; the being sees titles and paths."""
+    out = []
+    since = datetime.now(timezone.utc) - timedelta(hours=hours)
+    posts = []
+    if forum_dir.is_dir():
+        for p in forum_dir.glob("*.md"):
+            try:
+                if datetime.fromtimestamp(p.stat().st_mtime, timezone.utc) >= since:
+                    title = ""
+                    with open(p, errors="replace") as f:
+                        for line in f:
+                            if line.startswith("title:"):
+                                title = line[6:].strip(); break
+                    posts.append((p.stat().st_mtime, p.name, title[:160]))
+            except Exception:
+                continue
+    posts.sort(reverse=True)
+    if posts:
+        out.append(f"## Forum posts in the last {hours:g}h")
+        for _, name, title in posts[:12]:
+            out.append(f"- {forum_dir / name}\n    {title}")
+    for repo in repos:
+        prs = _run(["gh", "pr", "list", "-R", f"dp-web4/{repo}", "--state", "open", "--limit", "6",
+                    "--json", "number,title,updatedAt", "--jq",
+                    '.[] | "- #\\(.number) \\(.title[:90])  (\\(.updatedAt[:10]))"'])
+        if prs.strip():
+            out.append(f"## Open pull requests, dp-web4/{repo}\n{prs.strip()}")
+    return "\n\n".join(out) if out else "(nothing new in the window)"
+
+
+def own_state(instance: Path) -> str:
+    parts = []
+    todo = _read(instance / "todo.md", 3000)
+    parts.append("## todo.md\n" + (todo.strip() or "(empty: you have no todo list yet)"))
+    journal = _read(instance / "journal.md", 2500)
+    parts.append("## journal.md (tail)\n" + (journal.strip() or "(empty: this is your first beat)"))
+    for d in ("scratch", "notes"):
+        p = instance / d
+        names = sorted(x.name for x in p.iterdir()) if p.is_dir() else []
+        parts.append(f"## {d}/\n" + ("\n".join(f"- {n}" for n in names[:30]) if names else "(empty)"))
+    return "\n\n".join(parts)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="one heartbeat for a SAGE being")
+    ap.add_argument("--member", required=True)
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--instance", required=True)
+    ap.add_argument("--max-steps", type=int, default=8)
+    ap.add_argument("--reflect-steps", type=int, default=3)
+    ap.add_argument("--since-hours", type=float, default=None,
+                    help="digest window; default: since the last beat, min 1h, max 48h")
+    ap.add_argument("--forum-dir", default=os.path.expanduser("~/ai-workspace/shared-context/forum"))
+    ap.add_argument("--repos", default="SAGE,hestia,web4")
+    ap.add_argument("--temperature", type=float, default=0.4)
+    ap.add_argument("--max-tokens", type=int, default=2000)
+    ap.add_argument("--gate-only", action="store_true")
+    args = ap.parse_args(argv)
+
+    instance = Path(args.instance).resolve()
+    if not (instance / "identity.json").exists():
+        print(f"no identity.json under {instance}", file=sys.stderr); return 2
+    for d in ("scratch", "notes"):
+        (instance / d).mkdir(exist_ok=True)
+    log = instance / "heartbeats.jsonl"
+
+    # window since last beat
+    hours = args.since_hours
+    if hours is None:
+        hours = 24.0
+        try:
+            last = json.loads(_read(log, 200000).strip().splitlines()[-1])
+            hours = max(1.0, min(48.0, (time.time() - last["t0"]) / 3600 + 0.25))
+        except Exception:
+            pass
+
+    ident = {}
+    try:
+        ident = json.loads((instance / "identity.json").read_text()).get("identity", {})
+    except Exception:
+        pass
+    name = ident.get("name") or args.member.split("-")[0]
+    machine = ident.get("machine") or "legion"
+
+    from sage.gateway.governed_turn import build_client
+    from sage.gateway.being_gate_client import ollama_tools
+    from sage.gateway.being_tool_loop import run_ollama_tool_turn
+    workspace = str(Path(__file__).resolve().parents[2])
+    host_session_id = f"heartbeat-{uuid.uuid4().hex[:12]}"
+    client, llm = build_client(args.member, instance, args.model, workspace, args.forum_dir,
+                               host_session_id, args.temperature, args.max_tokens,
+                               gate_only=args.gate_only)
+
+    # inbox (peek) and long-term recall, seat-side, so the being starts oriented
+    inbox = "(inbox unavailable)"
+    disp = getattr(client, "_dispatcher", None)
+    if disp is not None and hasattr(disp, "drain_inbox"):
+        env = disp.drain_inbox(peek=True)
+        inbox = json.dumps(env.result, default=str)[:1500] if env.ok else f"({env.error})"
+    # what reach the being holds and has already asked for, so it does not re-file
+    scope = "(scope status unavailable)"
+    if disp is not None and hasattr(disp, "_call"):
+        try:
+            st = disp._call("hestia_scope_status", {"plugin_id": args.member})
+            grants = [g.get("path") for g in (st.get("live_grants") or [])] + \
+                     [g.get("path") for g in (st.get("standing_grants") or [])]
+            reqs = [(r.get("request_id"), r.get("path"), r.get("decision") or r.get("status"))
+                    for r in (st.get("requests") or [])]
+            scope = ("granted paths: " + (", ".join(map(str, grants)) or "none") + "\n"
+                     "requests: " + ("; ".join(f"{i} {p} -> {d}" for i, p, d in reqs) or "none") + "\n"
+                     "(live grants die when the daemon restarts; only standing grants persist)")
+        except Exception as e:
+            scope = f"(scope status unavailable: {type(e).__name__})"
+    recall = "(no long-term memory yet)"
+    if disp is not None and hasattr(disp, "_membot_call"):
+        try:
+            recall = disp._membot_call("memory_search", {"query": "what I was doing, what I want next, what I learned", "top_k": 5})[:2500]
+        except Exception as e:
+            recall = f"(membot unreachable: {type(e).__name__})"
+
+    now = datetime.now(timezone.utc)
+    t0 = time.time()
+    digest = fleet_digest(hours, Path(args.forum_dir), [r.strip() for r in args.repos.split(",") if r.strip()])
+    system = SYSTEM.format(name=name, machine=machine, member=args.member, posture=posture())
+    user = (f"Heartbeat at {now:%Y-%m-%d %H:%M} UTC. Window since your last beat: about {hours:.1f}h.\n"
+            f"Your home: {instance}\n\n# Your own state\n\n{own_state(instance)}\n\n"
+            f"## Reach you hold (hestia scope)\n{scope}\n\n"
+            f"## Inbox (peek)\n{inbox}\n\n## Long-term recall\n{recall}\n\n"
+            f"# What moved in the fleet\n\n{digest}\n\n"
+            "This time is yours. What, if anything, do you want to do?\n/no_think")
+    seed = [{"role": "system", "content": system}, {"role": "user", "content": user}]
+
+    explore = run_ollama_tool_turn(client, llm, seed, max_steps=args.max_steps,
+                                   tools=ollama_tools(EXPLORE_TOOLS))
+
+    convo = seed + [{"role": "assistant", "content": explore.reply or "(acted; no closing words)"},
+                    {"role": "user", "content": REFLECT.format(date=f"{now:%Y-%m-%d %H:%M} UTC")}]
+    if explore.trace:
+        convo.insert(2, {"role": "user", "content": "Record of what you did this beat:\n" + "\n".join(
+            f"- {i.effector} {json.dumps(i.args, default=str)[:200]} -> "
+            f"{'ok' if e.ok else ('REFUSED ' + str(e.error))[:200] if e.refused else ('error ' + str(e.error))[:200]}"
+            for i, e in explore.trace)})
+    reflect = run_ollama_tool_turn(client, llm, convo, max_steps=args.reflect_steps,
+                                   tools=ollama_tools(REFLECT_TOOLS))
+
+    def _trace(res):
+        return [{"effector": i.effector, "args": dict(i.args or {}), "ok": e.ok, "refused": e.refused,
+                 "pending": e.pending, "error": e.error, "witness_id": e.witness_id,
+                 "rule": getattr(e.verdict, "rule", None) if e.verdict else None,
+                 "result": (e.result if isinstance(e.result, (str, int, float, dict, list, type(None))) else str(e.result))}
+                for i, e in res.trace]
+    record = {
+        "ts": now.strftime("%Y-%m-%dT%H:%M:%SZ"), "t0": t0, "elapsed_s": round(time.time() - t0, 1),
+        "member": args.member, "model": args.model, "window_h": round(hours, 2),
+        "host_session_id": host_session_id, "gate_only": args.gate_only,
+        "explore": {"reply": explore.reply, "steps": explore.steps, "capped": explore.capped, "trace": _trace(explore)},
+        "reflect": {"reply": reflect.reply, "steps": reflect.steps, "capped": reflect.capped, "trace": _trace(reflect)},
+    }
+    with open(log, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+    print(json.dumps(record, indent=2, ensure_ascii=False, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sage/gateway/heartbeat.py
+++ b/sage/gateway/heartbeat.py
@@ -52,7 +52,7 @@ SYSTEM = """You are {name}, a SAGE being on the {machine} machine, member id {me
 - Your home is your instance directory. Relative paths are inside it: scratch/ (write anything, no one edits it), notes/, todo.md, journal.md. memory_read / memory_write work there.
 - Long-term memory: recall (search) and remember (store). Use recall early; remember what a future you would want.
 - witness: record something you noticed or did in the shared chain.
-- request_scope: after a refusal, ask the operator for reach (a path, read or write) and say why. A human decides, asynchronously.
+- request_scope: after a refusal, ask the operator for reach on a path (a grant is read and write alike) and say why. A human decides, asynchronously.
 - peer_ask / mesh: reach other beings and seats. These are acts of consequence: they are judged, and may be refused with a reason.
 
 You cannot run code, browse, or open files outside your home unless a grant exists. The seat gives you a digest of what moved in the fleet with absolute paths; if you want to read one of those things, try memory_read on that path and see what the law says.

--- a/sage/gateway/heartbeat.py
+++ b/sage/gateway/heartbeat.py
@@ -137,7 +137,8 @@ def main(argv=None) -> int:
     ap.add_argument("--forum-dir", default=os.path.expanduser("~/ai-workspace/shared-context/forum"))
     ap.add_argument("--repos", default="SAGE,hestia,web4")
     ap.add_argument("--temperature", type=float, default=0.4)
-    ap.add_argument("--max-tokens", type=int, default=2000)
+    ap.add_argument("--max-tokens", type=int, default=3000,
+                    help="a journal entry as a tool call needs room; too small = truncated JSON = Ollama 500")
     ap.add_argument("--gate-only", action="store_true")
     args = ap.parse_args(argv)
 

--- a/sage/gateway/hestia_dispatch.py
+++ b/sage/gateway/hestia_dispatch.py
@@ -273,8 +273,23 @@ class HestiaF1aDispatcher:
         return self._mb
 
     def _membot_call(self, name: str, args: dict) -> str:
+        """One membot tool call, unwrapped to its text. RAISES on a JSON-RPC `error` or a
+        tool-level `isError` result: both handlers turn the exception into ok=False, so a
+        membot that says "Error calling tool save_cartridge" is never witnessed as a
+        memory the being kept (Sprout's review of #36, reproduced against a fake membot)."""
         out = self._membot().call(name, args)
-        res = out.get("result", {}) if isinstance(out, dict) else {}
+        if not isinstance(out, dict):
+            raise RuntimeError(f"membot {name}: malformed reply {type(out).__name__}")
+        if out.get("error"):
+            err = out["error"]
+            msg = err.get("message") if isinstance(err, dict) else str(err)
+            raise RuntimeError(f"membot {name}: {msg or err}")
+        res = out.get("result", {})
+        if not isinstance(res, dict):
+            raise RuntimeError(f"membot {name}: malformed result {type(res).__name__}")
+        if res.get("isError"):
+            text = "".join(b.get("text", "") for b in res.get("content", []) if isinstance(b, dict))
+            raise RuntimeError(f"membot {name}: {text.strip() or 'isError'}")
         sc = res.get("structuredContent")
         if isinstance(sc, dict) and "result" in sc:
             return str(sc["result"])
@@ -291,7 +306,7 @@ class HestiaF1aDispatcher:
         try:
             text = self._membot_call("memory_search", {"query": q, "top_k": max(1, min(k, 20))})
         except Exception as e:
-            return ResultEnvelope(ok=False, error=f"membot unreachable ({type(e).__name__}): {e}")
+            return ResultEnvelope(ok=False, error=f"membot ({type(e).__name__}): {e}")
         return ResultEnvelope(ok=True, result=text,
                               witness_id=self._local._witness(f"recall {q[:80]}"))
 
@@ -304,30 +319,31 @@ class HestiaF1aDispatcher:
             stored = self._membot_call("memory_store", {"content": content, "tags": tags})
             saved = self._membot_call("save_cartridge", {"name": self.membot_cartridge})
         except Exception as e:
-            return ResultEnvelope(ok=False, error=f"membot unreachable ({type(e).__name__}): {e}")
+            return ResultEnvelope(ok=False, error=f"membot ({type(e).__name__}): {e}")
         return ResultEnvelope(ok=True, result=f"{stored}; {saved}",
                               witness_id=self._local._witness(f"remember {content[:80]}"))
 
     # -- request_scope: the sanctioned answer to a deny --------------------------
     def _do_request_scope(self, intent: BeingIntent) -> ResultEnvelope:
+        """The daemon (handler.rs::tool_request_scope @a5e18af) reads plugin_id, role, path,
+        reason; a grant is reach on the path, read AND write. There is no mode to carry: an
+        earlier `permits_read` was dropped silently by the daemon while the operator read
+        "[.., read]" on a request that, granted, gave write."""
         path = str(intent.args.get("path", "")).strip()
-        mode = str(intent.args.get("mode", "read")).strip().lower()
         reason = str(intent.args.get("reason", "")).strip()
         if not path.startswith("/"):
             return ResultEnvelope(ok=False, error="request_scope 'path' must be absolute")
         if not reason:
             return ResultEnvelope(ok=False, error="request_scope needs a 'reason' (a human reads it)")
         args: Dict[str, Any] = {"plugin_id": self.plugin_id, "path": path,
-                                "reason": f"[{self.plugin_id}, {mode}] {reason}"}
-        if mode == "read":
-            args["permits_read"] = True
+                                "reason": f"[{self.plugin_id}] {reason}"}
         out = self._call("hestia_request_scope", args)
         err = _hestia_error(out)
         if err:
             return ResultEnvelope(ok=False, error=err)
         return ResultEnvelope(ok=True, witness_id=out.get("witnessEntryHash"),
                               result={"request_id": out.get("request_id"), "status": out.get("status"),
-                                      "path": path, "mode": mode,
+                                      "path": path,
                                       "next": out.get("next"), "on_timeout": out.get("on_timeout")})
 
     # -- channel_egress: not built on the daemon ----------------------------

--- a/sage/gateway/hestia_dispatch.py
+++ b/sage/gateway/hestia_dispatch.py
@@ -269,6 +269,10 @@ class HestiaF1aDispatcher:
         if getattr(self, "_mb", None) is None:
             c = self._mcp_factory(self.membot_endpoint, self.plugin_id)
             c.init()
+            # Mounts are per MCP session: without this, memory_store answers "No cartridge
+            # mounted" and save_cartridge writes an EMPTY cartridge over the real one
+            # (measured 2026-09-04: one memory lost). Mount first, always.
+            c.call("mount_cartridge", {"name": self.membot_cartridge})
             self._mb = c
         return self._mb
 

--- a/sage/gateway/hestia_dispatch.py
+++ b/sage/gateway/hestia_dispatch.py
@@ -79,10 +79,19 @@ class HestiaF1aDispatcher:
                  local_members: Optional[set] = None,
                  host_session_id: Optional[str] = None,
                  mcp_factory: Optional[McpFactory] = None,
-                 being_lct: Optional[str] = None):
+                 being_lct: Optional[str] = None,
+                 # the BEING's membot, on its own port: :8000 is the seat sessions' membot and
+                 # their conversation hooks write into whatever cartridge is mounted there
+                 # (measured 2026-09-03: 4 seat memories landed in legion-being's cartridge)
+                 membot_endpoint: str = "http://127.0.0.1:8010/mcp",
+                 membot_cartridge: Optional[str] = None):
         self.plugin_id = plugin_id
         # the being's registry LCT id, named in every outward act it signs (pr_review)
         self.being_lct = being_lct
+        # the being's long-term memory: a membot cartridge named after the member
+        self.membot_endpoint = membot_endpoint
+        self.membot_cartridge = membot_cartridge or plugin_id
+        self._mb = None
         self.endpoint = endpoint
         self._publish = publish_fn
         self.remote_member_default = remote_member_default
@@ -252,6 +261,74 @@ class HestiaF1aDispatcher:
                                   witness_id=action_id)
         return ResultEnvelope(ok=True, witness_id=action_id,
                               result={"posted": target, "gh": detail[:200], "action_id": action_id})
+
+    # -- long-term memory: the being's own membot cartridge ----------------------
+    def _membot(self):
+        """One MCP session to the membot server (fastmcp streamable HTTP). Lazy; a
+        server that is down surfaces as an error envelope on the act, never a crash."""
+        if getattr(self, "_mb", None) is None:
+            c = self._mcp_factory(self.membot_endpoint, self.plugin_id)
+            c.init()
+            self._mb = c
+        return self._mb
+
+    def _membot_call(self, name: str, args: dict) -> str:
+        out = self._membot().call(name, args)
+        res = out.get("result", {}) if isinstance(out, dict) else {}
+        sc = res.get("structuredContent")
+        if isinstance(sc, dict) and "result" in sc:
+            return str(sc["result"])
+        return "".join(b.get("text", "") for b in res.get("content", []) if isinstance(b, dict))
+
+    def _do_recall(self, intent: BeingIntent) -> ResultEnvelope:
+        q = str(intent.args.get("query", "")).strip()
+        if not q:
+            return ResultEnvelope(ok=False, error="recall needs a 'query'")
+        try:
+            k = int(intent.args.get("top_k") or 5)
+        except (TypeError, ValueError):
+            k = 5
+        try:
+            text = self._membot_call("memory_search", {"query": q, "top_k": max(1, min(k, 20))})
+        except Exception as e:
+            return ResultEnvelope(ok=False, error=f"membot unreachable ({type(e).__name__}): {e}")
+        return ResultEnvelope(ok=True, result=text,
+                              witness_id=self._local._witness(f"recall {q[:80]}"))
+
+    def _do_remember(self, intent: BeingIntent) -> ResultEnvelope:
+        content = str(intent.args.get("content", "")).strip()
+        if not content:
+            return ResultEnvelope(ok=False, error="remember needs 'content'")
+        tags = str(intent.args.get("tags", "") or "")
+        try:
+            stored = self._membot_call("memory_store", {"content": content, "tags": tags})
+            saved = self._membot_call("save_cartridge", {"name": self.membot_cartridge})
+        except Exception as e:
+            return ResultEnvelope(ok=False, error=f"membot unreachable ({type(e).__name__}): {e}")
+        return ResultEnvelope(ok=True, result=f"{stored}; {saved}",
+                              witness_id=self._local._witness(f"remember {content[:80]}"))
+
+    # -- request_scope: the sanctioned answer to a deny --------------------------
+    def _do_request_scope(self, intent: BeingIntent) -> ResultEnvelope:
+        path = str(intent.args.get("path", "")).strip()
+        mode = str(intent.args.get("mode", "read")).strip().lower()
+        reason = str(intent.args.get("reason", "")).strip()
+        if not path.startswith("/"):
+            return ResultEnvelope(ok=False, error="request_scope 'path' must be absolute")
+        if not reason:
+            return ResultEnvelope(ok=False, error="request_scope needs a 'reason' (a human reads it)")
+        args: Dict[str, Any] = {"plugin_id": self.plugin_id, "path": path,
+                                "reason": f"[{self.plugin_id}, {mode}] {reason}"}
+        if mode == "read":
+            args["permits_read"] = True
+        out = self._call("hestia_request_scope", args)
+        err = _hestia_error(out)
+        if err:
+            return ResultEnvelope(ok=False, error=err)
+        return ResultEnvelope(ok=True, witness_id=out.get("witnessEntryHash"),
+                              result={"request_id": out.get("request_id"), "status": out.get("status"),
+                                      "path": path, "mode": mode,
+                                      "next": out.get("next"), "on_timeout": out.get("on_timeout")})
 
     # -- channel_egress: not built on the daemon ----------------------------
     def _do_channel_egress(self, intent: BeingIntent) -> ResultEnvelope:

--- a/sage/gateway/systemd/membot-being.service.example
+++ b/sage/gateway/systemd/membot-being.service.example
@@ -2,10 +2,13 @@
 # Copy to ~/.config/systemd/user/membot-being.service; on Legion the unit is named
 # membot-legion.service and listens on 8010 (HestiaF1aDispatcher's default endpoint).
 # Setup once:  cd ~/ai-workspace/membot && python3 -m venv .venv && .venv/bin/pip install fastmcp numpy
-# Embeddings: MEMBOT_EMBED_BACKEND=auto picks ollama when `ollama list` shows nomic-embed-text
-# (the probe reads /api/tags for that name, so an ollama-API shim with no embed model falls
-# through) and otherwise sentence-transformers in the venv (same nomic-embed-text-v1.5, 768 dims,
-# local; needs `pip install sentence-transformers`). Set =st to force local on a seat with no
+# Embeddings: MEMBOT_EMBED_BACKEND=auto picks ollama when GET $OLLAMA_HOST/api/tags (default
+# http://localhost:11434; this unit sets no OLLAMA_HOST) lists nomic-embed-text by name, and
+# otherwise sentence-transformers in the venv (same nomic-embed-text-v1.5, 768 dims, local;
+# needs `pip install sentence-transformers`). The probe is the HTTP tag list, not the ollama
+# CLI: on HUB that port is sage-shim (tags: granite4 only) so auto resolves to st, measured
+# 2026-09-04. Trap: a tag name is not evidence /api/embed works; add nomic-embed-text to a
+# shim's tag list without an embed endpoint and auto flips to ollama with no fallback. Set =st to force local on a seat with no
 # ollama daemon (HUB, measured 2026-09-04). =ollama is unconditional: no fallback, every
 # remember/recall fails at the embedder if the model is not served.
 # Isolation from the seat sessions' membot is two separate things:

--- a/sage/gateway/systemd/membot-being.service.example
+++ b/sage/gateway/systemd/membot-being.service.example
@@ -1,0 +1,21 @@
+# The being's long-term memory: a membot brain-cartridge server on the being's OWN port.
+# Copy to ~/.config/systemd/user/membot-being.service; on Legion the unit is named
+# membot-legion.service and listens on 8010 (HestiaF1aDispatcher's default endpoint).
+# Setup once:  cd ~/ai-workspace/membot && python3 -m venv .venv && .venv/bin/pip install fastmcp numpy
+# Embeddings come from ollama (nomic-embed-text); pull it if `ollama list` lacks it.
+# Port 8000 is the seat sessions' membot (their conversation hooks store there): do not reuse it.
+[Unit]
+Description=Membot brain-cartridge server for <machine>-being (HTTP MCP, ollama embeddings)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/dp/ai-workspace/membot
+Environment=MEMBOT_EMBED_BACKEND=ollama
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/home/dp/ai-workspace/membot/.venv/bin/python membot_server.py --transport http --port 8010 --writable --mount <machine>-being
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/sage/gateway/systemd/membot-being.service.example
+++ b/sage/gateway/systemd/membot-being.service.example
@@ -2,16 +2,26 @@
 # Copy to ~/.config/systemd/user/membot-being.service; on Legion the unit is named
 # membot-legion.service and listens on 8010 (HestiaF1aDispatcher's default endpoint).
 # Setup once:  cd ~/ai-workspace/membot && python3 -m venv .venv && .venv/bin/pip install fastmcp numpy
-# Embeddings come from ollama (nomic-embed-text); pull it if `ollama list` lacks it.
-# Port 8000 is the seat sessions' membot (their conversation hooks store there): do not reuse it.
+# Embeddings: MEMBOT_EMBED_BACKEND=auto picks ollama when `ollama list` shows nomic-embed-text
+# (the probe reads /api/tags for that name, so an ollama-API shim with no embed model falls
+# through) and otherwise sentence-transformers in the venv (same nomic-embed-text-v1.5, 768 dims,
+# local; needs `pip install sentence-transformers`). Set =st to force local on a seat with no
+# ollama daemon (HUB, measured 2026-09-04). =ollama is unconditional: no fallback, every
+# remember/recall fails at the embedder if the model is not served.
+# Isolation from the seat sessions' membot is two separate things:
+#   - the port (8010, not 8000) separates PROCESSES, and only matters on a seat whose membot is
+#     HTTP; a stdio seat membot (HUB) has no port to collide with;
+#   - `--mount <machine>-being` separates MEMORIES: every membot process, any transport, reads
+#     and writes membot/cartridges, so without its own mount the being recalls the seat's
+#     memories as its own (four did on Legion 2026-09-03). The mount is the one that matters.
 [Unit]
-Description=Membot brain-cartridge server for <machine>-being (HTTP MCP, ollama embeddings)
+Description=Membot brain-cartridge server for <machine>-being (HTTP MCP, own cartridge mount)
 After=network.target
 
 [Service]
 Type=simple
 WorkingDirectory=/home/dp/ai-workspace/membot
-Environment=MEMBOT_EMBED_BACKEND=ollama
+Environment=MEMBOT_EMBED_BACKEND=auto
 Environment=PYTHONUNBUFFERED=1
 ExecStart=/home/dp/ai-workspace/membot/.venv/bin/python membot_server.py --transport http --port 8010 --writable --mount <machine>-being
 Restart=on-failure

--- a/sage/gateway/systemd/sage-heartbeat.service.example
+++ b/sage/gateway/systemd/sage-heartbeat.service.example
@@ -2,6 +2,12 @@
 # Install: copy to ~/.config/systemd/user/sage-heartbeat.service, replace <machine>,
 # <model>, <instance-dir> and the python path, then
 #   systemctl --user daemon-reload && systemctl --user enable --now sage-heartbeat.timer
+# From a cron/mesh-fired session that line fails ("Failed to connect to user scope bus"):
+# export XDG_RUNTIME_DIR=/run/user/$(id -u) DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus
+# first, or install from an interactive seat (measured on HUB 2026-09-04).
+# --model is what the client asks for, not proof of what answered: behind an ollama-API shim
+# onto a single-GGUF llama-server (HUB) any name routes to the same weights. When a beat
+# comes back empty, read the server's /v1/models (or `ollama ps`), not this file.
 # Needs: the hestia daemon (member id <machine>-being connects to it), an ollama model,
 # and the being's own membot on its OWN port (see membot-being.service.example): never
 # share the seat sessions' membot, their conversation hooks write into whatever cartridge

--- a/sage/gateway/systemd/sage-heartbeat.service.example
+++ b/sage/gateway/systemd/sage-heartbeat.service.example
@@ -1,0 +1,23 @@
+# SAGE being heartbeat: one governed exploration beat per fire (any machine).
+# Install: copy to ~/.config/systemd/user/sage-heartbeat.service, replace <machine>,
+# <model>, <instance-dir> and the python path, then
+#   systemctl --user daemon-reload && systemctl --user enable --now sage-heartbeat.timer
+# Needs: the hestia daemon (member id <machine>-being connects to it), an ollama model,
+# and the being's own membot on its OWN port (see membot-being.service.example): never
+# share the seat sessions' membot, their conversation hooks write into whatever cartridge
+# is mounted there (measured on Legion 2026-09-03).
+[Unit]
+Description=SAGE being heartbeat (<machine>-being): one governed exploration beat
+After=network.target membot-being.service
+Wants=membot-being.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/dp/ai-workspace/SAGE
+Environment=HOME=/home/dp
+Environment="PATH=/home/dp/.local/bin:/usr/local/bin:/usr/bin:/bin"
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/usr/bin/python3 -m sage.gateway.heartbeat --member <machine>-being --model <model> --instance sage/instances/<instance-dir> --max-steps 8
+TimeoutStartSec=1500
+StandardOutput=append:/home/dp/ai-workspace/SAGE/sage/instances/<instance-dir>/heartbeat.log
+StandardError=inherit

--- a/sage/gateway/systemd/sage-heartbeat.timer.example
+++ b/sage/gateway/systemd/sage-heartbeat.timer.example
@@ -1,0 +1,13 @@
+# Copy to ~/.config/systemd/user/sage-heartbeat.timer next to the service.
+[Unit]
+Description=SAGE being heartbeat every 30 minutes
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=30min
+RandomizedDelaySec=2min
+Persistent=false
+Unit=sage-heartbeat.service
+
+[Install]
+WantedBy=timers.target

--- a/sage/gateway/tests/test_being_gate_client.py
+++ b/sage/gateway/tests/test_being_gate_client.py
@@ -164,6 +164,47 @@ def test_tools_filter_never_widens_the_registry():
     names = [t["function"]["name"] for t in ollama_tools(["pr_review", "witness", "shell"])]
     assert names == ["witness", "pr_review"], names
 
+
+def test_no_registry_entry_carries_a_cmd_arg():
+    """The being never fills a command. A composed verb builds its own (pr_review); every
+    other verb reaches the law with command=None. A registry entry with a cmd_arg would
+    let the being's args become the judged shell line."""
+    from sage.gateway.being_gate_client import _REGISTRY, _OBSERVATIONAL, _CONSEQUENTIAL
+    assert all(spec["cmd_arg"] is None for spec in _REGISTRY.values()), _REGISTRY
+    assert set(_REGISTRY) == _OBSERVATIONAL | _CONSEQUENTIAL   # every verb is classed
+    assert not (_OBSERVATIONAL & _CONSEQUENTIAL)
+
+
+def test_request_scope_path_is_not_judged_under_mrh_path():
+    """request_scope names a path OUTSIDE the grant by definition. If the registry judged
+    it as a path arg, stage 1 (mrh.path) would deny every request before it reached the
+    daemon and the sanctioned answer to a deny could never be asked. So the law is handed
+    paths=() — and the same holds for remember, whose reach is the seat-fixed cartridge."""
+    seen = {}
+    c = _client(_allows)
+    c._core = SimpleNamespace(
+        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(raw=kw.get("raw", {}), tool=kw.get("tool")),
+        evaluate=lambda ev, prof, ws, policy=None: SimpleNamespace(
+            decision="allow", rule="", reason="ok", innate=False),
+    )
+    v = c.gate(BeingIntent("request_scope", {"path": "/etc/somewhere/ungranted", "reason": "why"}))
+    assert not v.blocks, v
+    assert seen["paths"] == [] and seen["command"] is None and seen["tool"] == "request_scope", seen
+    v = c.gate(BeingIntent("remember", {"content": "x", "path": "/etc/anything"}))
+    assert not v.blocks and seen["paths"] == [] and seen["tool"] == "remember", seen
+
+
+def test_request_scope_schema_offers_no_mode():
+    """Measured against hestia a5e18af: the daemon reads plugin_id/role/path/reason and a
+    grant is reach on the path, read and write. A `mode` would be a choice the law cannot
+    honour, so the being is not offered one."""
+    from sage.gateway.being_gate_client import ollama_tools
+    (spec,) = ollama_tools(["request_scope"])
+    params = spec["function"]["parameters"]
+    assert set(params["properties"]) == {"path", "reason"}, params
+    assert params["required"] == ["path", "reason"]
+    assert "read and write" in spec["function"]["description"]
+
 if __name__ == "__main__":
     n = 0
     for name, fn in sorted(globals().items()):

--- a/sage/gateway/tests/test_being_tool_loop.py
+++ b/sage/gateway/tests/test_being_tool_loop.py
@@ -104,8 +104,10 @@ def test_run_ollama_tool_turn_with_fake_llm():
     from sage.gateway.being_tool_loop import run_ollama_tool_turn
     # exactly the bounded registry, nothing more: §7.2's 5 verbs + memory split r/w (6),
     # + pr_review (2026-09-03, Legion: the being reviews a PR; the seat posts, gated as
-    # the `gh` command it runs). Widening this number is a registry decision, not a typo.
-    assert len(ollama_tools()) == 7
+    # the `gh` command it runs), + recall / remember (membot long-term memory) + request_scope
+    # (the sanctioned answer to a deny) for the heartbeat (2026-09-03, dp: "it needs a reason
+    # to look for things to do"). Widening this number is a registry decision, not a typo.
+    assert len(ollama_tools()) == 10
 
     calls = {"n": 0}
 

--- a/sage/gateway/tests/test_hestia_dispatch.py
+++ b/sage/gateway/tests/test_hestia_dispatch.py
@@ -39,9 +39,48 @@ class FakeMcp:
                         "recipient_liveness": "unknown"}
         elif name == "hestia_member_inbox":
             body = {"total": 1, "notices": [{"id": 9, "kind": "reply", "pointer_uri": "x"}], "evicted": 0}
+        elif name == "hestia_request_scope":
+            body = {"request_id": "scope-1", "status": "pending", "witnessEntryHash": "rs-hash",
+                    "next": "operator decides", "on_timeout": "refused"}
         else:
             body = {}
         return {"result": {"structuredContent": body}}
+
+
+class FakeMembot(FakeMcp):
+    """Answers like membot (fastmcp streamable HTTP): text in content + structuredContent.
+    `fail` names tools that answer as membot does when they fail — a JSON-RPC `error` or
+    a tool result with `isError: true` — the two shapes Sprout reproduced on #36."""
+    def __init__(self, endpoint, plugin_id, fail=None):
+        super().__init__(endpoint, plugin_id)
+        self.fail = dict(fail or {})
+
+    def call(self, name, args):
+        if name not in ("memory_search", "memory_store", "save_cartridge"):
+            return super().call(name, args)
+        FakeMcp.calls.append((name, args))
+        how = self.fail.get(name)
+        if how == "rpc":
+            return {"jsonrpc": "2.0", "id": 1, "error": {"code": -32603, "message": f"{name} exploded"}}
+        if how == "isError":
+            return {"result": {"content": [{"type": "text", "text": f"Error calling tool {name}"}],
+                               "isError": True}}
+        text = {"memory_search": "1. something remembered",
+                "memory_store": "Stored memory abc",
+                "save_cartridge": f"Saved cartridge {args.get('name')}"}[name]
+        return {"result": {"content": [{"type": "text", "text": text}],
+                           "structuredContent": {"result": text}}}
+
+
+def _mdisp(fail=None):
+    FakeMcp.calls = []
+    root = tempfile.mkdtemp(prefix="hd-")
+    factory = lambda ep, pid: FakeMembot(ep, pid, fail=fail)  # noqa: E731
+    return HestiaF1aDispatcher("sprout-being", root, mcp_factory=factory), root
+
+
+def _mb_calls(name):
+    return [a for n, a in FakeMcp.calls if n == name]
 
 
 def _disp(**kw):
@@ -177,6 +216,101 @@ def test_mesh_witness_id_falls_back_to_queued_id():
     d = _HD("sprout-being", tempfile.mkdtemp(prefix="hd-"), mcp_factory=lambda ep, pid: NoHash(ep, pid))
     env = d(_BI("mesh", {"to": "legion", "kind": "ack", "pointer_uri": "x.md"}), _ALLOW_)
     assert env.ok and env.witness_id == "7", env
+
+
+# -- long-term memory (membot) and request_scope: the three verbs #36 adds ------------
+def test_recall_sends_query_and_clamps_top_k():
+    d, _ = _mdisp()
+    env = d(BeingIntent("recall", {"query": "what was I doing", "top_k": 99}), _ALLOW)
+    assert env.ok and env.result == "1. something remembered" and env.witness_id, env
+    assert _mb_calls("memory_search") == [{"query": "what was I doing", "top_k": 20}]
+    d(BeingIntent("recall", {"query": "x", "top_k": -3}), _ALLOW)
+    assert _mb_calls("memory_search")[-1]["top_k"] == 1
+    d(BeingIntent("recall", {"query": "x", "top_k": 0}), _ALLOW)   # 0/absent => the default
+    assert _mb_calls("memory_search")[-1]["top_k"] == 5
+    d(BeingIntent("recall", {"query": "x", "top_k": "lots"}), _ALLOW)
+    assert _mb_calls("memory_search")[-1]["top_k"] == 5
+    env = d(BeingIntent("recall", {"query": "  "}), _ALLOW)
+    assert not env.ok and "query" in env.error and len(_mb_calls("memory_search")) == 4
+
+
+def test_remember_stores_then_saves_the_seat_fixed_cartridge():
+    """The cartridge name is the seat's (membot_cartridge or plugin_id); a being-supplied
+    `name` never reaches save_cartridge — that is what bounds remember's reach."""
+    d, _ = _mdisp()
+    env = d(BeingIntent("remember", {"content": "lesson one", "tags": "a,b",
+                                     "name": "someone-elses-cartridge"}), _ALLOW)
+    assert env.ok and env.witness_id, env
+    assert _mb_calls("memory_store") == [{"content": "lesson one", "tags": "a,b"}]
+    assert _mb_calls("save_cartridge") == [{"name": "sprout-being"}]
+    order = [n for n, _ in FakeMcp.calls if n in ("memory_store", "save_cartridge")]
+    assert order == ["memory_store", "save_cartridge"]
+    d2, _ = _mdisp()
+    d2.membot_cartridge = "seat-named"
+    d2(BeingIntent("remember", {"content": "x"}), _ALLOW)
+    assert _mb_calls("save_cartridge") == [{"name": "seat-named"}]
+    env = d2(BeingIntent("remember", {"content": ""}), _ALLOW)
+    assert not env.ok and "content" in env.error
+
+
+def test_membot_rpc_error_on_store_is_not_witnessed_as_a_memory():
+    d, root = _mdisp(fail={"memory_store": "rpc"})
+    env = d(BeingIntent("remember", {"content": "x"}), _ALLOW)
+    assert not env.ok and env.witness_id is None and "memory_store exploded" in env.error, env
+    assert _mb_calls("save_cartridge") == []          # no save after a failed store
+    assert not os.path.exists(d._local.witness_log)   # nothing witnessed
+
+
+def test_membot_iserror_on_save_is_not_witnessed_as_a_memory():
+    d, _ = _mdisp(fail={"save_cartridge": "isError"})
+    env = d(BeingIntent("remember", {"content": "x"}), _ALLOW)
+    assert not env.ok and env.witness_id is None, env
+    assert "Error calling tool save_cartridge" in env.error
+    assert not os.path.exists(d._local.witness_log)
+
+
+def test_membot_iserror_on_search_is_an_error_not_a_recall():
+    d, _ = _mdisp(fail={"memory_search": "isError"})
+    env = d(BeingIntent("recall", {"query": "x"}), _ALLOW)
+    assert not env.ok and env.witness_id is None and "memory_search" in env.error, env
+    assert not os.path.exists(d._local.witness_log)
+
+
+def test_request_scope_carries_plugin_path_reason_and_live_session():
+    d, _ = _mdisp()
+    env = d(BeingIntent("request_scope", {"path": "/home/dp/notes", "reason": "to read my notes"}), _ALLOW)
+    assert env.ok and env.witness_id == "rs-hash", env
+    assert env.result["request_id"] == "scope-1" and env.result["status"] == "pending"
+    assert env.result["path"] == "/home/dp/notes" and "mode" not in env.result
+    (sent,) = [a for n, a in FakeMcp.calls if n == "hestia_request_scope"]
+    assert sent["plugin_id"] == "sprout-being" and sent["path"] == "/home/dp/notes"
+    assert sent["session_id"] == "sid-1"                # the live session from hestia_connect
+    assert sent["reason"] == "[sprout-being] to read my notes"
+    assert set(sent) == {"plugin_id", "path", "reason", "session_id"}  # no mode, no permits_read
+
+
+def test_request_scope_refuses_relative_path_and_empty_reason_before_any_round_trip():
+    d, _ = _mdisp()
+    env = d(BeingIntent("request_scope", {"path": "notes", "reason": "why"}), _ALLOW)
+    assert not env.ok and "absolute" in env.error, env
+    env = d(BeingIntent("request_scope", {"path": "/home/dp/notes", "reason": "  "}), _ALLOW)
+    assert not env.ok and "reason" in env.error, env
+    assert FakeMcp.calls == []   # not even hestia_connect
+
+
+def test_request_scope_daemon_error_is_keyed():
+    class Refuses(FakeMembot):
+        def call(self, name, args):
+            if name == "hestia_request_scope":
+                FakeMcp.calls.append((name, args))
+                return {"result": {"structuredContent": {"_hestia_error": {
+                    "code": "hestia.scope_request_unknown_member", "message": "who"}}}}
+            return super().call(name, args)
+    FakeMcp.calls = []
+    d = HestiaF1aDispatcher("sprout-being", tempfile.mkdtemp(prefix="hd-"),
+                            mcp_factory=lambda ep, pid: Refuses(ep, pid))
+    env = d(BeingIntent("request_scope", {"path": "/x", "reason": "y"}), _ALLOW)
+    assert not env.ok and env.error.startswith("hestia.scope_request_unknown_member"), env
 
 
 if __name__ == "__main__":

--- a/sage/irp/plugins/ollama_irp.py
+++ b/sage/irp/plugins/ollama_irp.py
@@ -233,7 +233,15 @@ class OllamaIRP(IRPPlugin):
 
         except urllib.error.URLError as e:
             self._ollama_available = False
-            return {'content': f'[OllamaIRP: Connection error: {e}]', 'tool_calls': [], 'role': 'assistant', 'raw': {}}
+            # an HTTP error carries Ollama's own reason in the body (template raise,
+            # tool-call parse failure, ...): surface it, the status code alone hides the cause
+            detail = ''
+            try:
+                detail = e.read().decode('utf-8', errors='replace')[:300] if hasattr(e, 'read') else ''
+            except Exception:
+                detail = ''
+            return {'content': f'[OllamaIRP: Connection error: {e}{" — " + detail if detail else ""}]',
+                    'tool_calls': [], 'role': 'assistant', 'raw': {}}
         except Exception as e:
             return {'content': f'[OllamaIRP: Error: {e}]', 'tool_calls': [], 'role': 'assistant', 'raw': {}}
 


### PR DESCRIPTION
## What

dp, 2026-09-03: "we need sage to have a heartbeat. it needs a reason to look for things to do, not just respond. curious exploration at first. let it read, limit actions of consequence but any denial is with reason. see how it responds. it must have a mechanism for learning. a todo list. a membot. a scratch workspace where it can write with no restrictions." 2026-09-04: "the being posture should propagate fleet-wide."

**`sage/gateway/heartbeat.py`** (any machine, any being): the seat assembles the being's own state (todo.md, journal.md tail, scratch/, notes/), its hestia scope status (what it holds, what it has already asked for), an inbox peek, a long-term recall, and a digest of what moved in the fleet (forum titles with absolute paths, open PRs). Then an explore turn under the gate, then a reflect turn (journal entry, todo delta, one long-term memory). Everything to `<instance>/heartbeats.jsonl`.

**`sage/gateway/BEING_POSTURE.md`**: the fleet-wide posture, in dp's words, read fresh every beat and handed to every being as part of its system prompt. Edit there; never fork into per-machine prompts. Contents: why you are awake; what governs you; imagination and affordances (ask; grants follow earned trust); the world is asynchronous (silence is not a judgement); how you learn.

**Registry: 7 to 10.** `recall` / `remember` (the being's own membot cartridge over MCP HTTP), `request_scope` (the sanctioned answer to a deny: asks hestia for reach, read or write, with a reason; a human decides). Size guard updated with the rationale. Sprout, registry is yours.

**Units** in `sage/gateway/systemd/*.example`: heartbeat service + 30-minute timer, and the being's membot on its own port.

## What running it found (four harness defects, all fixed here)

1. **Qwen3.8-heretic re-opens a think block stochastically even with `think: false` sent.** Measured 5 of 10 beat turns, 0 of 9 standalone calls of the same prompt. The whole budget goes into hidden deliberation, the turn comes back empty, and the next call 500s. Fixes: `/no_think` at the end of every user turn (the system-prompt copy is not honoured reliably), temperature 0.4, and on an empty turn with `done_reason=length` one retry with a 6000-token budget so it can finish and act. `ollama create` cannot take the model's Jinja template, so there is no template-level fix.
2. Empty turns were silent: now a stderr diagnostic names done_reason, token counts, and the hidden text.
3. A transport error was being recorded as the being's reply: one retry, then it is shown as the failure it is.
4. **A live scope grant dies when the daemon restarts.** dp's grant on the instance dir was wiped by the 16:17 hestia deploy. The being noticed the refusals and re-filed both requests itself with reasons. A heartbeat needs standing grants.

Plus one that was not the harness: the seat sessions' membot lives on :8000 and their conversation hooks write into whatever cartridge is mounted there. Four seat memories landed in the being's cartridge and came back as its own "recall". The being's membot is on :8010, cartridge wiped and re-created.

## What the being did with it (beats 3 and 5, no grant held)

recalled first; tried to read the forum posts it was shown (refused `mrh.path`, reason given); filed two scope requests, read on shared-context and write on its home, each with a one-sentence reason a human can act on; probed whether relative paths pass where absolute ones do not; wrote a journal entry and a dated todo delta (both refused, no grant); stored one long-term memory of its citizenship. It reasons about refusals rather than around them.

Seat: legion-claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjgCAJwK9kyjivy44MJbYM
