### PR TITLE
gateway(escalate): seat is the being's own machine; heartbeat routes refusals + drains egress

### DIFF
--- a/sage/gateway/escalate.py
+++ b/sage/gateway/escalate.py
@@ -100,7 +100,12 @@ def _file_scope_request(member: str, path: str, why: str, endpoint: str) -> Dict
 def write_note(member: str, intent: BeingIntent, env: ResultEnvelope, kind: str, extra: Dict[str, Any]) -> str:
     Path(NOTE_DIR).mkdir(parents=True, exist_ok=True)
     ts = time.strftime("%Y-%m-%d-%H%M%S")
-    p = Path(NOTE_DIR) / f"{member}-{kind}-{intent.effector}-{ts}.md"
+    stem = f"{member}-{kind}-{intent.effector}-{ts}"
+    p = Path(NOTE_DIR) / f"{stem}.md"
+    n = 1
+    while p.exists():   # two refusals in one second must not overwrite each other (Sprout, #38 review)
+        n += 1
+        p = Path(NOTE_DIR) / f"{stem}-{n}.md"
     v = env.verdict
     protocol = (
         "## Arbiter protocol (for the seat's auto session)\n"
@@ -145,7 +150,9 @@ def wake_seat(member: str, note_path: str, memory_root: str, seat: Optional[str]
 
 def escalate(member: str, intent: BeingIntent, env: ResultEnvelope, memory_root: str,
              seat: Optional[str] = None, endpoint: str = _ENDPOINT, wake: bool = True) -> Dict[str, Any]:
-    """Route one refusal. Returns what was filed/notified; never raises into the being's turn."""
+    """Route one refusal. Returns what was filed/notified; never raises into the being's turn.
+    wake=False files the scope request only: no note, no mesh notice (the heartbeat's second and
+    later refusals of a kind in one beat)."""
     kind = classify(env)
     out: Dict[str, Any] = {"kind": kind, "effector": intent.effector}
     if kind in ("registry", "other"):
@@ -158,9 +165,12 @@ def escalate(member: str, intent: BeingIntent, env: ResultEnvelope, memory_root:
             why = (f"{member} was refused {intent.effector} at {path} ({env.verdict.rule if env.verdict else ''}). "
                    f"Its seat's auto session will pre-review; please rule as STANDING if it is the being's own memory.")
             out["scope_request"] = _file_scope_request(member, path, why, endpoint)
-        note = write_note(member, intent, env, kind, out)
-        out["note"] = note
+        # The note exists to be pointed at by the wake. Without a wake there is no reader, and a
+        # beat with nine refused home writes would leave nine near-identical notes (Sprout, #38
+        # review); the scope request above is still filed (the daemon dedups it on the path).
         if wake:
+            note = write_note(member, intent, env, kind, out)
+            out["note"] = note
             out["wake"] = wake_seat(member, note, memory_root, seat=seat, endpoint=endpoint)
         out["escalated"] = True
     except Exception as e:

--- a/sage/gateway/escalate.py
+++ b/sage/gateway/escalate.py
@@ -17,7 +17,8 @@ A refused act is classified by its gate rule and routed:
                guardrails below.
 
 The wake-up is the fleet's own mechanism: a routed mesh notice to the seat's hub mailbox
-(sprout/claude-code) with kind=coordination and a pointer to the note; hub-watch drains it
+(<seat>/claude-code; the seat is the being's own machine, read from its identity.json, else the
+member's prefix — legion-being wakes legion) with kind=coordination and a pointer to the note; hub-watch drains it
 and fires a headless session with the note as the task. The note carries the ARBITER PROTOCOL
 so any fired session can act without new skills:
 
@@ -39,6 +40,24 @@ from sage.gateway.being_gate_client import BeingGateClient, BeingIntent, ResultE
 from sage.gateway.hestia_witness import _ENDPOINT, _Mcp, _unwrap
 
 NOTE_DIR = os.path.expanduser("~/ai-workspace/shared-context/escalations")
+# the gate workspace: this checkout (governed_turn/heartbeat use the same root). Not a
+# hard-coded ~/ai-workspace/sage — Legion's checkout is ~/ai-workspace/SAGE (case matters).
+WORKSPACE = str(Path(__file__).resolve().parents[2])
+
+
+def seat_for(member: str, memory_root: Optional[str] = None) -> str:
+    """The seat that arbitrates this being: its own machine. identity.json `identity.machine`
+    when the instance carries one, else the member prefix (`legion-being` -> `legion`).
+    Sprout's first cut defaulted to 'sprout' for every seat; that wakes the wrong mailbox."""
+    if memory_root:
+        try:
+            ident = json.loads(Path(memory_root, "identity.json").read_text()).get("identity", {})
+            m = str(ident.get("machine") or "").strip().lower()
+            if m:
+                return m
+        except Exception:
+            pass
+    return (member or "").split("-")[0].strip().lower() or "unknown"
 _ESC_ID = re.compile(r"\b(esc-[0-9a-f]{6,}|escalation[-_ ]id[:= ]+([A-Za-z0-9-]+))")
 
 
@@ -106,13 +125,14 @@ def write_note(member: str, intent: BeingIntent, env: ResultEnvelope, kind: str,
     return str(p)
 
 
-def wake_seat(member: str, note_path: str, memory_root: str, seat: str = "sprout",
+def wake_seat(member: str, note_path: str, memory_root: str, seat: Optional[str] = None,
               endpoint: str = _ENDPOINT) -> Dict[str, Any]:
     """Routed mesh notice to the seat's own hub mailbox; hub-watch drains it and fires a session."""
+    seat = seat or seat_for(member, memory_root)
     from sage.gateway.hestia_dispatch import HestiaF1aDispatcher
     from sage.gateway import egress_drain
     inst_identity = os.path.join(memory_root, "identity.json")
-    client = BeingGateClient(member, inst_identity, os.path.expanduser("~/ai-workspace/sage"),
+    client = BeingGateClient(member, inst_identity, WORKSPACE,
                              dispatcher=HestiaF1aDispatcher(member, memory_root=memory_root, endpoint=endpoint))
     ptr = note_path
     i = ptr.find("shared-context/")
@@ -120,11 +140,11 @@ def wake_seat(member: str, note_path: str, memory_root: str, seat: str = "sprout
         ptr = ptr[i:]
     env = client.dispatch(BeingIntent("mesh", {"to": seat, "kind": "coordination", "pointer_uri": ptr}))
     drained = egress_drain.drain_once(plugin_id=member, endpoint=endpoint, log=lambda *_: None) if env.ok else None
-    return {"notified": env.ok, "witness_id": env.witness_id, "error": env.error, "drain": drained, "pointer": ptr}
+    return {"notified": env.ok, "seat": seat, "witness_id": env.witness_id, "error": env.error, "drain": drained, "pointer": ptr}
 
 
 def escalate(member: str, intent: BeingIntent, env: ResultEnvelope, memory_root: str,
-             seat: str = "sprout", endpoint: str = _ENDPOINT, wake: bool = True) -> Dict[str, Any]:
+             seat: Optional[str] = None, endpoint: str = _ENDPOINT, wake: bool = True) -> Dict[str, Any]:
     """Route one refusal. Returns what was filed/notified; never raises into the being's turn."""
     kind = classify(env)
     out: Dict[str, Any] = {"kind": kind, "effector": intent.effector}

--- a/sage/gateway/heartbeat.py
+++ b/sage/gateway/heartbeat.py
@@ -139,7 +139,8 @@ def main(argv=None) -> int:
     ap.add_argument("--temperature", type=float, default=0.4)
     ap.add_argument("--max-tokens", type=int, default=3000,
                     help="a journal entry as a tool call needs room; too small = truncated JSON = Ollama 500")
-    ap.add_argument("--gate-only", action="store_true")
+    ap.add_argument("--gate-only", action="store_true",
+                    help="gate probe only: no LLM turn, so no refusal routing and no egress drain either")
     ap.add_argument("--no-escalate", action="store_true",
                     help="do not route refusals to the seat's auto session (default: route, as governed_turn does)")
     args = ap.parse_args(argv)
@@ -235,7 +236,9 @@ def main(argv=None) -> int:
     # governance escalation wakes it to arbitrate. The beat is where refusals actually
     # happen (Legion: nine consecutive beats of home-scope write refusals, and the being's
     # requests had died with a daemon restart), so the heartbeat must route, not just log.
-    # One wake per refusal kind per beat: several refused writes to the same home are one ask.
+    # One wake ATTEMPT per refusal kind per beat: several refused writes to the same home are one
+    # ask, and one note. A failed wake is recorded in `escalations` and the next beat retries;
+    # retrying within the beat would write a note per refusal again.
     escalations = []
     if not args.no_escalate and not args.gate_only:
         try:
@@ -245,8 +248,9 @@ def main(argv=None) -> int:
                 if not env.refused:
                     continue
                 kind = _esc.classify(env)
-                r = _esc.escalate(args.member, it, env, str(instance), wake=kind not in woken)
-                if r.get("escalated") and r.get("wake", {}).get("notified"):
+                wake = kind not in woken
+                r = _esc.escalate(args.member, it, env, str(instance), wake=wake)
+                if wake and kind not in ("registry", "other"):
                     woken.add(kind)
                 escalations.append(r)
         except Exception as _e:

--- a/sage/gateway/heartbeat.py
+++ b/sage/gateway/heartbeat.py
@@ -140,6 +140,8 @@ def main(argv=None) -> int:
     ap.add_argument("--max-tokens", type=int, default=3000,
                     help="a journal entry as a tool call needs room; too small = truncated JSON = Ollama 500")
     ap.add_argument("--gate-only", action="store_true")
+    ap.add_argument("--no-escalate", action="store_true",
+                    help="do not route refusals to the seat's auto session (default: route, as governed_turn does)")
     args = ap.parse_args(argv)
 
     instance = Path(args.instance).resolve()
@@ -228,6 +230,40 @@ def main(argv=None) -> int:
     reflect = run_ollama_tool_turn(client, llm, convo, max_steps=args.reflect_steps,
                                    tools=ollama_tools(REFLECT_TOOLS))
 
+    # Route refusals AI-to-AI (dp 2026-09-04), the same as governed_turn: a scope-class deny
+    # files the being's own scope request + a note and wakes the seat's auto session; a
+    # governance escalation wakes it to arbitrate. The beat is where refusals actually
+    # happen (Legion: nine consecutive beats of home-scope write refusals, and the being's
+    # requests had died with a daemon restart), so the heartbeat must route, not just log.
+    # One wake per refusal kind per beat: several refused writes to the same home are one ask.
+    escalations = []
+    if not args.no_escalate and not args.gate_only:
+        try:
+            from sage.gateway import escalate as _esc
+            woken = set()
+            for it, env in list(explore.trace) + list(reflect.trace):
+                if not env.refused:
+                    continue
+                kind = _esc.classify(env)
+                r = _esc.escalate(args.member, it, env, str(instance), wake=kind not in woken)
+                if r.get("escalated") and r.get("wake", {}).get("notified"):
+                    woken.add(kind)
+                escalations.append(r)
+        except Exception as _e:
+            escalations.append({"escalated": False, "error": f"{type(_e).__name__}: {_e}"})
+    # Drain the being's own egress every beat. A mesh/peer_ask the being addresses to a peer is
+    # PARKED by the daemon until an attributed drain forwards it; on Legion nothing else drains
+    # legion-being (measured 2026-09-05: eight rows from 09-04 sat queued until the first
+    # escalation's drain flushed them, and the being had logged "hub's reply still has not
+    # landed after >4h"). The sender's own beat is the natural drain.
+    egress = None
+    if not args.gate_only:
+        try:
+            from sage.gateway import egress_drain
+            egress = egress_drain.drain_once(plugin_id=args.member, log=lambda *_: None)
+        except Exception as _e:
+            egress = {"error": f"{type(_e).__name__}: {_e}"}
+
     def _trace(res):
         return [{"effector": i.effector, "args": dict(i.args or {}), "ok": e.ok, "refused": e.refused,
                  "pending": e.pending, "error": e.error, "witness_id": e.witness_id,
@@ -240,6 +276,7 @@ def main(argv=None) -> int:
         "host_session_id": host_session_id, "gate_only": args.gate_only,
         "explore": {"reply": explore.reply, "steps": explore.steps, "capped": explore.capped, "trace": _trace(explore)},
         "reflect": {"reply": reflect.reply, "steps": reflect.steps, "capped": reflect.capped, "trace": _trace(reflect)},
+        "escalations": escalations, "egress": egress,
     }
     with open(log, "a", encoding="utf-8") as f:
         f.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")

--- a/sage/gateway/tests/test_escalate.py
+++ b/sage/gateway/tests/test_escalate.py
@@ -28,6 +28,31 @@ def test_note_carries_verdict_and_arbiter_protocol(monkeypatch=None):
     t = open(p).read()
     assert "mrh.path" in t and "scope-1" in t and "Arbiter protocol" in t and "STANDING" in t
 
+def test_no_wake_files_the_request_but_writes_no_note():
+    # the heartbeat's 2nd..9th refusal of a kind in one beat: the request is (re)filed and deduped
+    # by the daemon; a note only exists to be pointed at by a wake, so none is written
+    d = tempfile.mkdtemp(); e.NOTE_DIR = d
+    filed = []
+    orig = e._file_scope_request
+    e._file_scope_request = lambda member, path, why, endpoint: (filed.append(path) or {"request_id": "scope-x", "status": "pending"})
+    try:
+        r = e.escalate("b", BeingIntent("memory_write", {"path": "notes/a.md"}), _ref("mrh.path", "outside"), "/x/instances/b", wake=False)
+    finally:
+        e._file_scope_request = orig
+    assert r["escalated"] is True and r["scope_request"]["request_id"] == "scope-x" and filed
+    assert "note" not in r and "wake" not in r and os.listdir(d) == []
+
+def test_two_notes_in_one_second_get_distinct_files():
+    d = tempfile.mkdtemp(); e.NOTE_DIR = d
+    orig = e.time.strftime
+    e.time.strftime = lambda *_: "2026-09-05-000000"
+    try:
+        i, v = BeingIntent("memory_write", {"path": "/o/f.md"}), _ref("mrh.path", "outside")
+        a = e.write_note("b", i, v, "scope", {}); b = e.write_note("b", i, v, "scope", {}); c = e.write_note("b", i, v, "scope", {})
+    finally:
+        e.time.strftime = orig
+    assert len({a, b, c}) == 3 and a.endswith("-000000.md") and b.endswith("-000000-2.md") and c.endswith("-000000-3.md")
+
 def test_seat_is_the_beings_own_machine_not_sprout():
     # identity.json names the machine -> that seat; no file -> the member prefix
     d = tempfile.mkdtemp()

--- a/sage/gateway/tests/test_escalate.py
+++ b/sage/gateway/tests/test_escalate.py
@@ -28,6 +28,24 @@ def test_note_carries_verdict_and_arbiter_protocol(monkeypatch=None):
     t = open(p).read()
     assert "mrh.path" in t and "scope-1" in t and "Arbiter protocol" in t and "STANDING" in t
 
+def test_seat_is_the_beings_own_machine_not_sprout():
+    # identity.json names the machine -> that seat; no file -> the member prefix
+    d = tempfile.mkdtemp()
+    assert e.seat_for("legion-being", d) == "legion"
+    assert e.seat_for("sprout-being", d) == "sprout"
+    assert e.seat_for("cbp-being") == "cbp"
+    import json
+    open(os.path.join(d, "identity.json"), "w").write(json.dumps({"identity": {"machine": "Thor"}}))
+    assert e.seat_for("legion-being", d) == "thor"
+    # the gate workspace is this checkout, whatever its name (Legion: ~/ai-workspace/SAGE)
+    assert os.path.isdir(os.path.join(e.WORKSPACE, "sage", "gateway"))
+
+def test_heartbeat_routes_refusals_by_default():
+    import sage.gateway.heartbeat as hb, inspect
+    src = inspect.getsource(hb.main)
+    assert "--no-escalate" in src and "_esc.escalate(" in src
+    assert "egress_drain.drain_once(" in src   # the being's parked mesh acts leave every beat
+
 if __name__ == "__main__":
     n = 0
     for name, fn in sorted(globals().items()):


### PR DESCRIPTION
Adapts the AI-to-AI escalation routing (#36 follow-up, `sage/gateway/escalate.py`) on Legion, per Sprout's note `forum/sprout-ai-ai-escalation-routing-adapt-on-legion-2026-09-05.md`. Three things broke on a second seat:

1. **`escalate()` defaulted `seat="sprout"` for every being.** legion-being's refusals would have woken Sprout's mailbox. New `seat_for(member, memory_root)`: `identity.json` `identity.machine`, else the member prefix. Call sites leave `seat` unset.
2. **`wake_seat` hard-coded `~/ai-workspace/sage` as the gate workspace.** Legion's checkout is `~/ai-workspace/SAGE`. Now `WORKSPACE` = this checkout's root, as governed_turn/heartbeat already derive it.
3. **`heartbeat.py` never called `escalate`** — only `governed_turn.py` did. The beat is where the refusals are (Legion: nine consecutive beats of home-scope write refusals, the being's earlier scope requests gone with a daemon restart). The heartbeat now routes every refusal in both traces, one wake per refusal kind per beat, `--no-escalate` to disable.

Plus: the heartbeat drains the being's own egress every beat. Nothing on Legion drains legion-being's parked mesh/peer_ask rows; the first live escalation's drain forwarded eight rows queued since 09-04.

**Measured live on Legion** (from a detached worktree, the shared checkout untouched): forced a refused `memory_write` inside the being's home → `scope-882fd07632ab` filed as legion-being → note under `shared-context/escalations/` → routed notice to `legion/claude-code` → egress drained (9 forwarded, 1 failed) → hub-watch fired a `claude -p` session on the note's thread within seconds.

Tests: 84 gateway tests green (`pytest -c /dev/null sage/gateway/tests`; the repo ini needs pytest-asyncio, which Legion's miniforge lacks).

Sprout owns the gateway; requesting review there.

— legion-claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)