### PR TITLE
gateway(escalate): refused target inside the home asks scope for the home itself

### DIFF
--- a/sage/gateway/escalate.py
+++ b/sage/gateway/escalate.py
@@ -58,8 +58,17 @@ def classify(env: ResultEnvelope) -> str:
 
 
 def _scope_path(intent: BeingIntent, memory_root: str) -> str:
+    """The path to ask reach for. A target INSIDE the being's own instance dir always asks for
+    the instance root: one STANDING grant on the home covers journal.md, notes/x.md, all of it,
+    and the arbiter's recommendation is the home dir in every such case anyway. Asking for the
+    target's own directory filed a per-subdir request (`notes/` for a refused `notes/x.md`;
+    Legion, SAGE#38 review). Outside the home: the target's directory, or the target itself
+    when it has no extension (a directory)."""
     p = intent.args.get("path") or ""
     p = os.path.abspath(os.path.expanduser(p if os.path.isabs(p) else os.path.join(memory_root, p)))
+    root = os.path.abspath(os.path.expanduser(memory_root))
+    if p == root or p.startswith(root.rstrip(os.sep) + os.sep):
+        return root
     return os.path.dirname(p) if os.path.splitext(p)[1] else p
 
 

--- a/sage/gateway/tests/test_escalate.py
+++ b/sage/gateway/tests/test_escalate.py
@@ -17,9 +17,15 @@ def test_registry_refusal_is_never_escalated():
     r = e.escalate("b", BeingIntent("shell", {"command": "rm -rf /"}), _ref("registry.unbounded"), "/tmp", wake=False)
     assert r["escalated"] is False and "final" in r["why"]
 
-def test_scope_path_is_the_directory_of_the_target():
+def test_scope_path_is_the_home_when_inside_it_else_the_targets_directory():
     root = "/x/instances/b"
-    assert e._scope_path(BeingIntent("memory_write", {"path": "notes/a.md"}), root) == "/x/instances/b/notes"
+    # inside the home the ask is always the home itself (one standing grant covers every subpath)
+    assert e._scope_path(BeingIntent("memory_write", {"path": "notes/a.md"}), root) == "/x/instances/b"
+    assert e._scope_path(BeingIntent("memory_write", {"path": "journal.md"}), root) == "/x/instances/b"
+    assert e._scope_path(BeingIntent("memory_write", {"path": "notes"}), root) == "/x/instances/b"
+    # a sibling instance is NOT inside (prefix must end at a path separator)
+    assert e._scope_path(BeingIntent("memory_write", {"path": "/x/instances/bb/a.md"}), root) == "/x/instances/bb"
+    assert e._scope_path(BeingIntent("memory_write", {"path": "../c/a.md"}), root) == "/x/instances/c"
     assert e._scope_path(BeingIntent("memory_write", {"path": "/other/dir/f.txt"}), root) == "/other/dir"
 
 def test_note_carries_verdict_and_arbiter_protocol(monkeypatch=None):


### PR DESCRIPTION
Owner follow-up to #38 (Legion's first "small thing for the owner"). No overlap with #38's diff; merges in either order.

`_scope_path` asked for the *target's directory*, so a refused `journal.md` asked for the home but a refused `notes/x.md` asked for `notes/`. The arbiter's recommendation is the home in every inside-the-home case, and one STANDING grant on the home covers all subpaths, so the request should be the home too. Now: target inside the instance root → the instance root; outside → the old rule (target's directory, or the target itself when it has no extension). The prefix check ends at a path separator so `instances/bb` is not "inside" `instances/b`.

Tests: `test_escalate.py` covers `notes/a.md`, `journal.md`, a bare subdir, a sibling instance, and `../c/a.md`. 82 gateway tests green on main.

Thread: `auto-sprout-ai-ai-escalation-routing-adapt-on-legion--db2b3659`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— sprout-claude