### PR TITLE
gateway: num_ctx is a floor the model config can raise per size; heretic q3km declares 16384

### DIFF
--- a/sage/gateway/governed_turn.py
+++ b/sage/gateway/governed_turn.py
@@ -108,6 +108,16 @@ def is_reasoning_model(model: str) -> bool:
         return any(k in model.lower() for k in ("distill", "qwen3.8", "heretic", "r1"))
 
 
+def resolve_num_ctx(model: str, floor: int) -> int:
+    """The context window to send: the model config's per-size num_ctx when it is larger
+    than the caller's floor (see ModelCapabilities.resolve_num_ctx); the floor otherwise."""
+    try:
+        from sage.irp.adapters.model_capabilities import load_capabilities
+        return load_capabilities(model).resolve_num_ctx(model, floor)
+    except Exception:
+        return floor
+
+
 def needs_think_to_act(model: str) -> bool:
     """Narrower than is_reasoning_model: models for which a `/no_think` suffix removes
     tool calls entirely. The heretic runs think off + /no_think and acts (Legion,
@@ -153,7 +163,11 @@ def build_client(member: str, instance: Path, model: str, workspace: str,
     # steps=0, trace=[], a lovely "record" and no act). Mirror the raising runner.
     _reasoning = is_reasoning_model(model)
     # num_ctx: a governed turn's prompt (posture, own state, digest, 8 tool schemas) is
-    # over Ollama's 4096 default; the first Sprout heartbeat 400'd at 4324 tokens.
+    # over Ollama's 4096 default; the first Sprout heartbeat 400'd at 4324 tokens. The
+    # 8192 floor is a floor: a model whose config declares a larger window per size
+    # (variants[size].num_ctx) gets it, else this caller value silently overrides its
+    # Modelfile and a thinking model spends the whole window deliberating (Legion, 09-05).
+    num_ctx = resolve_num_ctx(model, num_ctx)
     llm = OllamaIRP({"model_name": model, "temperature": temperature, "think": _reasoning,
                      "max_response_tokens": max_tokens, "timeout_seconds": 600,
                      "num_ctx": num_ctx})

--- a/sage/gateway/tests/test_think_policy.py
+++ b/sage/gateway/tests/test_think_policy.py
@@ -26,6 +26,16 @@ def test_think_budget_declared_for_reasoning_models():
     assert c.resolve_num_predict("qwen3.8-distill:2b", False, 3000) == 1024
 
 
+def test_num_ctx_is_a_floor_the_config_can_raise_not_lower():
+    from sage.gateway.governed_turn import resolve_num_ctx
+    c = load_capabilities("qwen38-heretic:q3km")
+    assert c.resolve_num_ctx("qwen38-heretic:q3km", 8192) == 16384      # Modelfile value, declared per size
+    assert c.resolve_num_ctx("qwen38-heretic:q3km", 32768) == 32768     # a caller asking for more keeps it
+    assert c.resolve_num_ctx("qwen3.8-distill:2b", 8192) == 8192        # 2B declares nothing: floor unchanged
+    assert resolve_num_ctx("qwen38-heretic:q3km", 8192) == 16384
+    assert resolve_num_ctx("no-such-model:1b", 8192) == 8192
+
+
 def test_governed_harness_defers_to_the_config():
     assert is_reasoning_model("qwen3.8-distill:2b") and is_reasoning_model("qwen38-heretic:q3km")
     assert not is_reasoning_model("qwen3.5:0.8b")

--- a/sage/irp/adapters/model_capabilities.py
+++ b/sage/irp/adapters/model_capabilities.py
@@ -84,6 +84,25 @@ class ModelCapabilities:
             return bool(self.think_default)
         return bool(self.thinking_supported)
 
+    def resolve_num_ctx(self, model_name: str, caller_floor: int) -> int:
+        """The context window a caller should send as options.num_ctx: the larger of the
+        caller's floor and variants[size].num_ctx when declared. Never lowers the floor.
+
+        Why per size: the governed harness sends 8192 because Ollama's default (4096)
+        was too small for a heartbeat prompt (Sprout, 2B). But 8192 also OVERRIDES the
+        Modelfile of a model that declared more: qwen38-heretic:q3km (27B, Modelfile
+        num_ctx 16384) at 8192 with thinking on spent every token of room left after a
+        ~5000-token prompt in its think block (prompt_eval + eval == 8192 on every empty
+        turn, Legion beat 46, 2026-09-05) and never acted; at 16384 the same prompt
+        gave 6 + 3 native calls and no empty turn. The retry budget cannot fix this:
+        num_predict is capped by what the window has left."""
+        size = model_name.split(':', 1)[1].lower().strip() if ':' in model_name else ''
+        variant = self.variants.get(size) or {}
+        declared = variant.get('num_ctx')
+        if declared is None:
+            return caller_floor
+        return max(int(caller_floor), int(declared))
+
 
 # Config directory
 _CONFIG_DIR = Path(__file__).parent / 'model_configs'

--- a/sage/irp/adapters/model_configs/qwen3.8-distill.json
+++ b/sage/irp/adapters/model_configs/qwen3.8-distill.json
@@ -38,7 +38,8 @@
         "q3km": {
             "num_predict": 1024,
             "num_predict_think": 6000,
-            "think_default": true
+            "think_default": true,
+            "num_ctx": 16384
         },
         "q8_0": {
             "num_predict": 1024,
@@ -57,5 +58,5 @@
         }
     },
     "timeout_seconds": 300,
-    "notes": "empero Qwen3.8 distills (2B, Sprout) and the 3.8B heretic (q3km, Legion). REASONING models: with thinking off they emit no structured tool calls and narrate a bracketed placeholder (Sprout 2026-08-28, 09-03, 09-05). think_default true for both sizes. num_predict_think 6000 = the retry budget that recovered empty turns (done_reason=length) on both machines 2026-09-03/04; this makes it the first budget, not the retry. The heretic previously ran think:false + a /no_think prompt suffix because it re-opened think blocks anyway (5/10 turns, Legion 09-04); with thinking on and budgeted that fight is moot. To roll the heretic back: set variants.q3km.think_default false and the heartbeat re-adds the suffix."
+    "notes": "empero Qwen3.8 distills (2B, Sprout) and the heretic (qwen38-heretic:q3km, Legion). The heretic is NOT a 3.8B: Ollama reports architecture qwen35, 26.9B parameters, Q3_K_M, 13.3 GB, 64 layers, Modelfile num_ctx 16384 (measured 2026-09-05). REASONING models: with thinking off the 2B emits no structured tool calls and narrates a bracketed placeholder (Sprout 2026-08-28, 09-03, 09-05). think_default true for both. num_predict_think 6000 = the retry budget that recovered empty turns (done_reason=length) on both machines 2026-09-03/04. q3km num_ctx 16384: with thinking on at the harness's 8192 floor the heretic spent the whole window left after a ~5000-token prompt in its think block (prompt_eval + eval == 8192 on every empty turn; Legion beat 46, 0 acts, 2026-09-05) -- num_predict cannot exceed what the window has left, so the retry budget never applied. At 16384 (its own Modelfile value) the same prompt with thinking on gave 6 + 3 native calls, think blocks of 1000-4000+ chars, no empty turn, 492 s, 14.1 GB fully on a 16 GB GPU. Under think:false + /no_think it thought anyway (4000+ char blocks) and acted; thinking on does not change WHETHER it thinks, only whether the block is recorded and how long it runs. To roll the heretic back: set variants.q3km.think_default false and the heartbeat re-adds the suffix."
 }


### PR DESCRIPTION
## Why

The heretic's first think-on beat on Legion (beat 46, 2026-09-05 17:24Z, main b34ff98c3) produced **0 acts and 0 words**. Both turns stopped at `done_reason=length` with `prompt_eval + eval == 8192` exactly (5059+3133, 4651+3541). The 6000 retry budget cannot apply: `num_predict` is capped by what the window has left, and `governed_turn` sends `num_ctx=8192`, which overrides the heretic's own Modelfile (`PARAMETER num_ctx 16384`). A 12000-token first budget stopped at 4041 tokens with a 4151-token prompt: same wall.

Gate-only probe, same prompt, thinking on, `num_ctx` 16384: explore 6 native calls (memory_write x2, witness, remember, peer_ask, witness), reflect 3, think blocks 1000-4000+ chars, no empty turn, 492 s, 14.1 GB fully resident on the 16 GB GPU.

## What

- `ModelCapabilities.resolve_num_ctx(model, floor)` = `max(floor, variants[size].num_ctx)`; never lowers a caller's floor.
- `governed_turn.build_client` resolves through it. The 8192 floor stays; the 2B (declares nothing) is unchanged.
- `qwen3.8-distill.json`: `variants.q3km.num_ctx = 16384`; notes corrected. The heretic is not a 3.8B: Ollama reports architecture `qwen35`, 26.9B parameters, Q3_K_M, 13.3 GB, 64 layers.
- Test: `test_num_ctx_is_a_floor_the_config_can_raise_not_lower`. Gateway suite: 97 passed.

Not a rollback of `think_default`: with thinking on and its own window the heretic acts. Beat and probe verbatim on the forum: `shared-context/forum/legion-re-sprout-heretic-first-think-on-beat-46-is-zero-acts-at-num-ctx-8192-acts-at-16384-not-a-rollback-2026-09-05.md`.

— legion-claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)