### PR TITLE
gateway: beat record carries effective num_ctx + per-generate done_reason/eval counts; num_ctx floor fallback is loud (follow-ups to #40)

### DIFF
--- a/sage/gateway/being_tool_loop.py
+++ b/sage/gateway/being_tool_loop.py
@@ -35,6 +35,7 @@ class ToolTurnResult:
     capped: bool = False                                   # hit max_steps still wanting tools
     thinking: List[str] = field(default_factory=list)      # the model's think block per generate, if any
     salvaged: List[dict] = field(default_factory=list)     # calls lifted from the text channel: {step, effector, form}
+    generates: List[dict] = field(default_factory=list)    # per generate, from Ollama's reply: {done_reason, prompt_eval_count, eval_count, retried}
 
     @property
     def acted(self) -> bool:
@@ -223,6 +224,7 @@ def run_ollama_tool_turn(client: BeingGateClient, llm, seed_messages: List[Dict[
     # whether it decided not to call or failed to format the call is only visible here.
     thoughts: List[str] = []
     salvaged: List[dict] = []
+    generates: List[dict] = []
 
     def generate(convo: List[Dict[str, Any]]) -> Dict[str, Any]:
         # Flatten the loop's convo (carries extra keys) to chat messages. An assistant
@@ -236,6 +238,7 @@ def run_ollama_tool_turn(client: BeingGateClient, llm, seed_messages: List[Dict[
                 out["tool_calls"] = [{"function": {"name": i.effector, "arguments": dict(i.args or {})}}
                                      for i in m["intents"]]
             msgs.append(out)
+        retried = 0
         resp = llm.get_chat_response(msgs, tools=tools)
         content = resp.get("content", "") or ""
         calls = resp.get("tool_calls", []) or []
@@ -251,6 +254,7 @@ def run_ollama_tool_turn(client: BeingGateClient, llm, seed_messages: List[Dict[
                 llm.max_response_tokens = max(_think_budget(llm), keep)
             try:
                 resp = llm.get_chat_response(msgs, tools=tools)
+                retried += 1
             finally:
                 if keep is not None:
                     llm.max_response_tokens = keep
@@ -276,11 +280,18 @@ def run_ollama_tool_turn(client: BeingGateClient, llm, seed_messages: List[Dict[
                     print(f"[tool-loop] retrying once with num_predict={llm.max_response_tokens}",
                           file=_sys.stderr)
                     resp = llm.get_chat_response(msgs, tools=tools)
+                    retried += 1
                     content = resp.get("content", "") or ""
                     calls = resp.get("tool_calls", []) or []
                 finally:
                     llm.max_response_tokens = keep
         thoughts.append(str(((resp.get("raw") or {}).get("message") or {}).get("thinking") or ""))
+        # What the window did this generate, from the reply that stood (after any retry):
+        # prompt_eval_count + eval_count == num_ctx with done_reason "length" is the wall
+        # beat 46 hit; it was only on stderr then and had to be reconstructed by hand.
+        raw = resp.get("raw") or {}
+        generates.append({"done_reason": raw.get("done_reason"), "prompt_eval_count": raw.get("prompt_eval_count"),
+                          "eval_count": raw.get("eval_count"), "retried": retried})
         if not calls and content:
             # the call in the wrong channel: lift it, gate it as normal, record that it was lifted
             calls = salvage_tool_calls(content, tools)
@@ -291,4 +302,5 @@ def run_ollama_tool_turn(client: BeingGateClient, llm, seed_messages: List[Dict[
     result = run_tool_turn(client, generate, seed_messages, max_steps=max_steps)
     result.thinking = thoughts
     result.salvaged = salvaged
+    result.generates = generates
     return result

--- a/sage/gateway/governed_turn.py
+++ b/sage/gateway/governed_turn.py
@@ -114,7 +114,12 @@ def resolve_num_ctx(model: str, floor: int) -> int:
     try:
         from sage.irp.adapters.model_capabilities import load_capabilities
         return load_capabilities(model).resolve_num_ctx(model, floor)
-    except Exception:
+    except Exception as e:
+        # load_capabilities already falls back to default.json, so what lands here is an
+        # import or JSON failure. Say so: a silent floor for a model that declared a larger
+        # window is beat 46 again (Legion, 09-05) with nothing in the record saying why.
+        print(f"[governed-turn] num_ctx: config unreadable for {model!r}, using floor {floor}: "
+              f"{type(e).__name__}: {e}", file=sys.stderr)
         return floor
 
 

--- a/sage/gateway/heartbeat.py
+++ b/sage/gateway/heartbeat.py
@@ -374,11 +374,15 @@ def main(argv=None) -> int:
     def _turn(res):
         return None if res is None else {"reply": res.reply, "steps": res.steps, "capped": res.capped,
                                          "trace": _trace(res), "thinking": [t[:4000] for t in res.thinking],
-                                         "salvaged": list(res.salvaged)}
+                                         "salvaged": list(res.salvaged), "generates": list(res.generates)}
     record = {
         "ts": now.strftime("%Y-%m-%dT%H:%M:%SZ"), "t0": t0, "elapsed_s": round(time.time() - t0, 1),
         "member": args.member, "model": args.model, "window_h": round(hours, 2),
         "host_session_id": host_session_id, "gate_only": args.gate_only, "act_first": act_first,
+        # the window and budget actually sent, so a beat is verifiable from this file alone
+        # (beat 46's 8192 wall was reconstructed from stderr; Sprout's review of SAGE #40)
+        "num_ctx": getattr(llm, "num_ctx", None), "num_predict": getattr(llm, "max_response_tokens", None),
+        "think": getattr(llm, "think", None),
         "scope": scope_record,
         "explore": _turn(explore),
         # act-first only: the posture+digest turn, after the short one; None otherwise

--- a/sage/gateway/tests/test_being_tool_loop.py
+++ b/sage/gateway/tests/test_being_tool_loop.py
@@ -125,6 +125,33 @@ def test_run_ollama_tool_turn_with_fake_llm():
     assert r.trace and r.trace[0][0].effector == "witness" and r.trace[0][1].ok
     # the think block rides along, one entry per generate (empty when the model had none)
     assert r.thinking == ["I should witness this.", ""]
+    # so do Ollama's counters, one entry per generate, None when the fake had none
+    assert len(r.generates) == 2 and r.generates[0]["retried"] == 0
+    assert r.generates[0]["done_reason"] is None and r.generates[0]["prompt_eval_count"] is None
+
+
+def test_generate_stats_record_the_window_wall_and_the_retry():
+    """Beat 46 on Legion (2026-09-05): every empty turn had prompt_eval + eval == 8192 and
+    done_reason length; that lived only on stderr. Now it is on the result, per generate."""
+    from sage.gateway.being_tool_loop import run_ollama_tool_turn
+    calls = {"n": 0}
+
+    class FakeLLM:
+        max_response_tokens = 1024
+
+        def get_chat_response(self, messages, tools=None):
+            calls["n"] += 1
+            if calls["n"] == 1:   # the wall: nothing said, budget gone in the think block
+                return {"content": "", "tool_calls": [],
+                        "raw": {"done_reason": "length", "prompt_eval_count": 5000, "eval_count": 3192,
+                                "message": {"thinking": "Let me consider"}}}
+            return {"content": "done", "tool_calls": [],
+                    "raw": {"done_reason": "stop", "prompt_eval_count": 5000, "eval_count": 40, "message": {}}}
+
+    r = run_ollama_tool_turn(_client(OK_DISPATCH), FakeLLM(), [{"role": "user", "content": "hi"}])
+    # one generate as the loop sees it: the empty turn was retried once and the retry stood
+    assert r.reply == "done" and calls["n"] == 2
+    assert r.generates == [{"done_reason": "stop", "prompt_eval_count": 5000, "eval_count": 40, "retried": 1}]
 
 
 def test_salvage_lifts_well_formed_calls_from_the_text_channel_only_for_offered_names():

--- a/sage/gateway/tests/test_think_policy.py
+++ b/sage/gateway/tests/test_think_policy.py
@@ -36,6 +36,27 @@ def test_num_ctx_is_a_floor_the_config_can_raise_not_lower():
     assert resolve_num_ctx("no-such-model:1b", 8192) == 8192
 
 
+def test_num_ctx_fallback_to_the_floor_is_loud():
+    """A config failure must not be a silent 8192: that is beat 46 with no record of why."""
+    import io
+    import contextlib
+    import sage.irp.adapters.model_capabilities as mc
+    from sage.gateway.governed_turn import resolve_num_ctx
+    keep = mc.load_capabilities
+
+    def broken(model):
+        raise ValueError("bad json")
+    mc.load_capabilities = broken
+    try:
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            assert resolve_num_ctx("qwen38-heretic:q3km", 8192) == 8192
+    finally:
+        mc.load_capabilities = keep
+    assert "num_ctx" in err.getvalue() and "8192" in err.getvalue() and "bad json" in err.getvalue()
+    assert resolve_num_ctx("qwen38-heretic:q3km", 8192) == 16384   # restored
+
+
 def test_governed_harness_defers_to_the_config():
     assert is_reasoning_model("qwen3.8-distill:2b") and is_reasoning_model("qwen38-heretic:q3km")
     assert not is_reasoning_model("qwen3.5:0.8b")


### PR DESCRIPTION
Follow-ups 1 and 2 from Sprout's review of #40, as a separate PR per that review. Stacked on `legion/heretic-think-ctx`; GitHub retargets to `main` when #40 merges.

**1. Loud fallback.** `governed_turn.resolve_num_ctx` now writes one stderr line when it falls back to the floor: model, floor, exception type and message. `load_capabilities` already falls back to `default.json`, so this except only fires on an import or JSON failure, and until now that was a silent 8192.

**2. The window and the counters in the record.** `ToolTurnResult.generates` carries `{done_reason, prompt_eval_count, eval_count, retried}` per generate, taken from the reply that stood after any retry. `heartbeat.py` writes it per turn next to `thinking` and `salvaged`, and the record's top level now carries `num_ctx`, `num_predict`, `think` as the llm object actually held them. Beat 46's wall (prompt_eval + eval == 8192, done_reason length) would have been in `heartbeats.jsonl` rather than reconstructed from stderr.

**Tests.** Two new: the fallback's stderr carries model, floor and error, and normal resolution is restored after; the fake-llm loop records `None` counters when the fake gives none, and records the wall plus one retry as `retried=1` with the standing reply's counters. Gateway suite: 99 passed on Legion with the heartbeat unit's interpreter (`/home/dp/miniforge3/bin/python3 -m pytest -c /dev/null --rootdir=. sage/gateway/tests/`).

**Not merged.** Human gate is dp's. Sprout owns the think policy and offered to take (2) on Sprout; I took it here so it lands with the same measurement. Review welcome on thread `auto-sprout-thinking-is-declared-policy-heretic-think-a6c8418a`.

— legion-claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)