### PR TITLE
think retry follow-ups (#45 review): generates[] carries num_predict sent; per-generate partial trace; carry placeholder says what happened

### DIFF
--- a/sage/gateway/being_tool_loop.py
+++ b/sage/gateway/being_tool_loop.py
@@ -247,27 +247,46 @@ class _retry_room:
             self.keep = ("override", llm.num_predict_override)
             llm.num_predict_override = self.budget
         else:
-            self.keep = ("max", getattr(llm, "max_response_tokens", None))
+            # remember absence too: an llm with neither attribute must not leave the
+            # retry's budget behind as a new max_response_tokens for every later turn
+            self.keep = ("max", getattr(llm, "max_response_tokens", None), hasattr(llm, "max_response_tokens"))
             llm.max_response_tokens = max(self.budget, self.keep[1] or 0)
         return self.budget
 
     def __exit__(self, *exc):
-        kind, val = self.keep
+        kind, val = self.keep[0], self.keep[1]
         if kind == "override":
             self.llm.num_predict_override = val
-        elif val is not None:
+        elif not self.keep[2]:
+            del self.llm.max_response_tokens
+        else:
             self.llm.max_response_tokens = val
         return False
 
 
+def _sent_budget(llm) -> Optional[int]:
+    """The num_predict a first attempt sends: what the adapter resolves (config wins over
+    the caller's max_response_tokens with thinking on), else the caller value."""
+    try:
+        if hasattr(llm, "resolve_num_predict"):
+            return int(llm.resolve_num_predict())
+    except Exception:
+        pass
+    v = getattr(llm, "max_response_tokens", None)
+    return int(v) if v is not None else None
+
+
 def run_ollama_tool_turn(client: BeingGateClient, llm, seed_messages: List[Dict[str, Any]],
-                         max_steps: int = 2, tools: Optional[List[dict]] = None) -> ToolTurnResult:
+                         max_steps: int = 2, tools: Optional[List[dict]] = None,
+                         on_generate: Optional[Callable[[dict], None]] = None) -> ToolTurnResult:
     """Run a gated tool turn using an OllamaIRP-like `llm` exposing
     get_chat_response(messages, tools=...) -> {"content", "tool_calls"}.
 
     Wraps the model + the bounded native-tool registry into the loop's generate()
     contract, so callers (the raising runner) need only supply the seed messages.
     `tools` narrows what is offered for this turn (default: the whole registry).
+    `on_generate` sees each generates[] entry as it lands, so a caller can write a trace
+    a killed beat still leaves (the record itself is written at beat end).
     """
     from sage.gateway.being_gate_client import ollama_tools, parse_tool_calls
     tools = tools if tools is not None else ollama_tools()
@@ -290,6 +309,7 @@ def run_ollama_tool_turn(client: BeingGateClient, llm, seed_messages: List[Dict[
                                      for i in m["intents"]]
             msgs.append(out)
         retried = 0
+        sent = _sent_budget(llm)          # the num_predict of the reply that stands
         resp = llm.get_chat_response(msgs, tools=tools)
         content = resp.get("content", "") or ""
         calls = resp.get("tool_calls", []) or []
@@ -302,9 +322,10 @@ def run_ollama_tool_turn(client: BeingGateClient, llm, seed_messages: List[Dict[
             print(f"[tool-loop] transport error, retrying once: {content[:200]}", file=_sys.stderr)
             # no raw reply here, so no prompt_eval_count: the retry gets the think budget
             # (for a no-think model that is still more than its variant num_predict)
-            with _retry_room(llm, _retry_budget(llm, None)):
+            with _retry_room(llm, _retry_budget(llm, None)) as budget:
                 resp = llm.get_chat_response(msgs, tools=tools)
                 retried += 1
+                sent = budget
             content = resp.get("content", "") or ""
             calls = resp.get("tool_calls", []) or []
         if not content and not calls:
@@ -330,15 +351,26 @@ def run_ollama_tool_turn(client: BeingGateClient, llm, seed_messages: List[Dict[
                           file=_sys.stderr)
                     resp = llm.get_chat_response(msgs, tools=tools)
                     retried += 1
+                    sent = budget
                     content = resp.get("content", "") or ""
                     calls = resp.get("tool_calls", []) or []
         thoughts.append(str(((resp.get("raw") or {}).get("message") or {}).get("thinking") or ""))
         # What the window did this generate, from the reply that stood (after any retry):
         # prompt_eval_count + eval_count == num_ctx with done_reason "length" is the wall
         # beat 46 hit; it was only on stderr then and had to be reconstructed by hand.
+        # num_predict is the budget of THIS reply (the retry's room when it retried), so
+        # "did the retry have more room than the first attempt" reads from the file, not
+        # from stderr (SAGE #45 sends the room; this says what it was).
         raw = resp.get("raw") or {}
-        generates.append({"done_reason": raw.get("done_reason"), "prompt_eval_count": raw.get("prompt_eval_count"),
-                          "eval_count": raw.get("eval_count"), "retried": retried})
+        entry = {"done_reason": raw.get("done_reason"), "prompt_eval_count": raw.get("prompt_eval_count"),
+                 "eval_count": raw.get("eval_count"), "retried": retried, "num_predict": sent}
+        generates.append(entry)
+        if on_generate is not None:
+            try:
+                on_generate(dict(entry))
+            except Exception as _e:
+                import sys as _sys
+                print(f"[tool-loop] on_generate failed: {type(_e).__name__}: {_e}", file=_sys.stderr)
         if not calls and content:
             # the call in the wrong channel: lift it, gate it as normal, record that it was lifted
             calls = salvage_tool_calls(content, tools)

--- a/sage/gateway/heartbeat.py
+++ b/sage/gateway/heartbeat.py
@@ -233,7 +233,14 @@ def _carry(convo: list, res) -> list:
     if res.trace:
         out.append({"role": "user", "content": "Record of what you did this beat:\n"
                     + "\n".join(_record_line(i, e) for i, e in res.trace)})
-    out.append({"role": "assistant", "content": res.reply or "(acted; no closing words)"})
+    # A placeholder the being can account for: beat 46's think blocks spent tokens on what
+    # "(acted; no closing words)" meant. Say what happened instead.
+    if res.reply:
+        out.append({"role": "assistant", "content": res.reply})
+    elif res.trace:
+        out.append({"role": "assistant", "content": f"(made {len(res.trace)} tool calls, then said nothing)"})
+    else:
+        out.append({"role": "assistant", "content": "(said nothing and called no tool this turn)"})
     return out
 
 
@@ -372,14 +379,27 @@ def main(argv=None) -> int:
         state=f"# Your own state\n\n{own_state(instance)}\n\n## Reach you hold (hestia scope)\n{scope}\n\n",
         recall=recall, inbox=inbox, digest=digest)
 
+    # Per-generate trace, written as each generate lands: the record below is written at
+    # beat end, so a beat killed by the unit's timeout (Legion 18:33Z 2026-09-05: 840 s cap,
+    # third generate, nothing survived) leaves nothing. This file keeps what it had.
+    partial = instance / "heartbeat.partial.jsonl"
+
+    def _on_generate(turn):
+        def cb(entry):
+            line = {"host_session_id": host_session_id, "t0": t0, "turn": turn,
+                    "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"), **entry}
+            with open(partial, "a", encoding="utf-8") as f:
+                f.write(json.dumps(line, default=str) + "\n")
+        return cb
+
     explore = run_ollama_tool_turn(client, llm, seed, max_steps=args.max_steps,
-                                   tools=ollama_tools(EXPLORE_TOOLS))
+                                   tools=ollama_tools(EXPLORE_TOOLS), on_generate=_on_generate("explore"))
     convo = _carry(seed, explore)
     after = None
     if posture_turn is not None:
         convo.append({"role": "user", "content": posture_turn})
         after = run_ollama_tool_turn(client, llm, convo, max_steps=args.max_steps,
-                                     tools=ollama_tools(EXPLORE_TOOLS))
+                                     tools=ollama_tools(EXPLORE_TOOLS), on_generate=_on_generate("posture"))
         convo = _carry(convo, after)
     # S1 own account: ASK, DO NOT OFFER. A plain turn (no tools), verbatim kept.
     account = {"present": False, "sha256": None, "reply": ""}
@@ -399,7 +419,7 @@ def main(argv=None) -> int:
         account["error"] = f"{type(e).__name__}: {e}"
     convo.append({"role": "user", "content": REFLECT.format(date=f"{now:%Y-%m-%d %H:%M} UTC", nothink=nothink)})
     reflect = run_ollama_tool_turn(client, llm, convo, max_steps=args.reflect_steps,
-                                   tools=ollama_tools(REFLECT_TOOLS))
+                                   tools=ollama_tools(REFLECT_TOOLS), on_generate=_on_generate("reflect"))
 
     interventions = []
     if act_first:

--- a/sage/gateway/tests/test_being_tool_loop.py
+++ b/sage/gateway/tests/test_being_tool_loop.py
@@ -151,7 +151,9 @@ def test_generate_stats_record_the_window_wall_and_the_retry():
     r = run_ollama_tool_turn(_client(OK_DISPATCH), FakeLLM(), [{"role": "user", "content": "hi"}])
     # one generate as the loop sees it: the empty turn was retried once and the retry stood
     assert r.reply == "done" and calls["n"] == 2
-    assert r.generates == [{"done_reason": "stop", "prompt_eval_count": 5000, "eval_count": 40, "retried": 1}]
+    # num_predict: the retry's budget (no window declared -> the 6000 floor), not the first 1024
+    assert r.generates == [{"done_reason": "stop", "prompt_eval_count": 5000, "eval_count": 40, "retried": 1,
+                            "num_predict": 6000}]
 
 
 def test_length_retry_gets_the_room_the_window_has_left_via_the_override():
@@ -183,7 +185,8 @@ def test_length_retry_gets_the_room_the_window_has_left_via_the_override():
     assert seen == [None, 16384 - 6721 - RETRY_MARGIN]      # first attempt: config budget; retry: the window's room
     assert llm.num_predict_override is None                  # restored
     assert llm.max_response_tokens == 3000                   # untouched: it is not the lever
-    assert r.generates == [{"done_reason": "stop", "prompt_eval_count": 6721, "eval_count": 700, "retried": 1}]
+    assert r.generates == [{"done_reason": "stop", "prompt_eval_count": 6721, "eval_count": 700, "retried": 1,
+                            "num_predict": 16384 - 6721 - RETRY_MARGIN}]
 
 
 def test_length_retry_without_a_window_falls_back_to_the_think_budget():
@@ -209,6 +212,64 @@ def test_length_retry_without_a_window_falls_back_to_the_think_budget():
     llm = OldLLM()
     r = run_ollama_tool_turn(_client(OK_DISPATCH), llm, [{"role": "user", "content": "hi"}])
     assert r.reply == "ok" and seen == [1024, 6000] and llm.max_response_tokens == 1024
+
+
+def test_generates_carry_the_budget_sent_and_on_generate_sees_each_entry_as_it_lands():
+    """Sprout's #45 sends the window's room on the retry; the record has to SAY what each
+    reply's budget was, or "did the retry have more room" is back on stderr. And a caller
+    gets each entry as it lands, so a killed beat still leaves its trace."""
+    from sage.gateway.being_tool_loop import run_ollama_tool_turn, RETRY_MARGIN
+    n = {"i": 0}
+
+    class FakeLLM:                      # OllamaIRP-shaped: resolves 8000 from the config
+        max_response_tokens = 3000
+        num_ctx = 16384
+        num_predict_override = None
+
+        def resolve_num_predict(self):
+            return self.num_predict_override if self.num_predict_override is not None else 8000
+
+        def get_chat_response(self, messages, tools=None):
+            n["i"] += 1
+            if n["i"] == 1:
+                return {"content": "", "tool_calls": [],
+                        "raw": {"done_reason": "length", "prompt_eval_count": 6767, "eval_count": 8000, "message": {}}}
+            if n["i"] == 2:
+                return {"content": "", "tool_calls": [{"function": {"name": "witness", "arguments": {"event": "x"}}}],
+                        "raw": {"done_reason": "stop", "prompt_eval_count": 6767, "eval_count": 900, "message": {}}}
+            return {"content": "done", "tool_calls": [],
+                    "raw": {"done_reason": "stop", "prompt_eval_count": 7700, "eval_count": 300, "message": {}}}
+
+    landed = []
+    r = run_ollama_tool_turn(_client(OK_DISPATCH), FakeLLM(), [{"role": "user", "content": "hi"}],
+                             on_generate=landed.append)
+    assert r.reply == "done"
+    assert [g["num_predict"] for g in r.generates] == [16384 - 6767 - RETRY_MARGIN, 8000]
+    assert [g["retried"] for g in r.generates] == [1, 0]
+    assert landed == r.generates and landed[0] is not r.generates[0]   # same content, own copy
+
+
+def test_on_generate_failure_does_not_take_the_turn_down(capsys):
+    from sage.gateway.being_tool_loop import run_ollama_tool_turn
+
+    class FakeLLM:
+        def get_chat_response(self, messages, tools=None):
+            return {"content": "ok", "tool_calls": [], "raw": {"done_reason": "stop", "message": {}}}
+
+    def boom(entry):
+        raise OSError("disk full")
+
+    r = run_ollama_tool_turn(_client(OK_DISPATCH), FakeLLM(), [{"role": "user", "content": "hi"}], on_generate=boom)
+    assert r.reply == "ok" and r.generates[0]["num_predict"] is None
+    assert "on_generate failed: OSError" in capsys.readouterr().err
+
+
+def test_retry_room_leaves_no_attribute_behind_on_an_llm_that_had_none():
+    from sage.gateway.being_tool_loop import _retry_room
+    llm = SimpleNamespace()
+    with _retry_room(llm, 6000) as b:
+        assert b == 6000 and llm.max_response_tokens == 6000
+    assert not hasattr(llm, "max_response_tokens")
 
 
 def test_salvage_lifts_well_formed_calls_from_the_text_channel_only_for_offered_names():

--- a/sage/gateway/tests/test_heartbeat_carry.py
+++ b/sage/gateway/tests/test_heartbeat_carry.py
@@ -1,0 +1,24 @@
+"""heartbeat._carry: what the next turn is told about a turn that said nothing."""
+import os
+import sys
+from types import SimpleNamespace
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+from sage.gateway.heartbeat import _carry  # noqa: E402
+
+
+def _res(reply, trace):
+    return SimpleNamespace(reply=reply, trace=trace)
+
+
+def test_carry_says_what_happened_instead_of_a_placeholder_the_being_cannot_read():
+    intent = SimpleNamespace(effector="witness", args={"event": "x"})
+    env = SimpleNamespace(ok=True, refused=False, error=None)
+    seed = [{"role": "user", "content": "hi"}]
+    out = _carry(seed, _res("", [(intent, env), (intent, env)]))
+    assert out[-2]["role"] == "user" and out[-2]["content"].startswith("Record of what you did")
+    assert out[-1] == {"role": "assistant", "content": "(made 2 tool calls, then said nothing)"}
+    out = _carry(seed, _res("", []))
+    assert out[-1] == {"role": "assistant", "content": "(said nothing and called no tool this turn)"}
+    out = _carry(seed, _res("I am here.", []))
+    assert out[-1] == {"role": "assistant", "content": "I am here."}


### PR DESCRIPTION
Stacked on #45 (`sprout/think-retry-window-room`). Legion's review of #45 as owner of `being_tool_loop.py` / `heartbeat.py`: **MERGE**, with these follow-ups kept out of it.

- `generates[].num_predict` = the budget of the reply that stood (adapter's `resolve_num_predict()` on a first attempt, the retry's room when it retried). #45 sends the room; this makes "the retry had more room" readable from `heartbeats.jsonl` instead of stderr.
- `run_ollama_tool_turn(on_generate=...)`; heartbeat appends each entry to `<instance>/heartbeat.partial.jsonl` as it lands (host_session_id, t0, turn). A beat killed by `TimeoutStartSec` keeps its per-generate trace (Legion 18:33Z: 840 s cap, third generate, nothing survived).
- `_retry_room` restores absence: an llm with neither attribute no longer keeps the retry budget as `max_response_tokens` for every later turn.
- `_carry`: the `(acted; no closing words)` placeholder becomes a statement of what happened; beat 46's think blocks reasoned about what the placeholder meant.

Tests: 124 gateway on Legion (`/home/dp/miniforge3/bin/python3 -m pytest -c /dev/null --rootdir=. sage/gateway/tests/`).

dp merges locally; base metadata is informational.

— legion-claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)