### PR TITLE
gateway: scope consumer counts refusals and names the ruler; arbiter notes wired to hestia scope arbitrate (#952)

### DIFF
--- a/sage/gateway/ESCALATION_ARBITER.md
+++ b/sage/gateway/ESCALATION_ARBITER.md
@@ -7,7 +7,7 @@ The being's refusals are routed by `sage/gateway/escalate.py`: a note lands in
 | refusal | what the seat does | who rules |
 |---|---|---|
 | `registry.*` | nothing — the verb does not exist, by design | — |
-| `mrh.*` (scope) | pre-review against the protocol; if it holds, rule it: CLI `hestia scope arbitrate <request_id> --grant\|--deny --reason '…' --as claude-code` (signs with the seat's registry key, calls MCP `hestia_scope_arbitrate {request_id, granted, reason, session_id, arbiter_signature}`; a grant is always **standing**). Refused by name if you are the asker or hold no delegation covering the path+member: then recommend and leave it for dp | the seat, under an **operator delegation** `scope.decide:<prefix>@<member>` (hestia #952/#962; first live ruling Legion 2026-09-05, delegation 66d05620) — else **dp** |
+| `mrh.*` (scope) | pre-review against the protocol; if it holds, rule it: CLI `hestia scope arbitrate <request_id> --grant\|--deny --reason '…' --as claude-code` (signs with the seat's registry key, calls MCP `hestia_scope_arbitrate {request_id, granted, reason, session_id, arbiter_signature}`; a grant is always **standing**). Refused by name if you are the asker or hold no delegation covering the path+member: then recommend and leave it for dp | the seat, under an **operator delegation** `scope.decide:<member>:/abs/prefix` (hestia #952/#962; first live ruling Legion 2026-09-05, delegation 66d05620) — else **dp** |
 | governance escalation (id in the deny) | `hestia_gate_pending_escalations` (pass your session) → if `you_may_rule` and the protocol holds, rule it: MCP `hestia_gate_arbitrate_escalation {escalation_id, approve: true|false, reason}` or CLI `hestia gate approve|deny <id> --as claude-code --reason '…'` | the seat, as a NOT-SAME peer — **no delegation needed** (measured 2026-09-05: f169ff9c45725a1f, decided_via peer_member) |
 | `society.*` | a law verdict; if plainly wrong, appeal on the being's behalf and corroborate — never override | arbiter of the appeal (NOT-SAME) |
 
@@ -27,7 +27,7 @@ WITH a session (`asker_basis: session`), else only the sovereign may rule it (#1
 Opening one requires `tool_name`, `marker`, and `act` (a text description of the attempted act).
 Scope rulings (hestia #952, PR #962): a NOT-SAME seat may rule a member's pending scope request
 ONLY under an operator delegation naming the action — `hestia delegate grant $(hestia delegate
-agent-id claude-code) --action 'scope.decide:/abs/prefix@<member>' --expires <h>`, minted by dp.
+agent-id claude-code) --action 'scope.decide:<member>:/abs/prefix' --expires <h>`, minted by dp.
 The ruling must be signed by the seat's registry key (`hestia scope arbitrate` does this from the
 vault); an unsigned, self-ruled, or undelegated ruling is refused by name. A delegated grant is
 STANDING; revocation and anything outside the delegated prefix stay operator-only. Until #962 is

--- a/sage/gateway/ESCALATION_ARBITER.md
+++ b/sage/gateway/ESCALATION_ARBITER.md
@@ -7,7 +7,7 @@ The being's refusals are routed by `sage/gateway/escalate.py`: a note lands in
 | refusal | what the seat does | who rules |
 |---|---|---|
 | `registry.*` | nothing — the verb does not exist, by design | — |
-| `mrh.*` (scope) | pre-review; recommend GRANT **as standing** when the path is the being's own memory; corroborate in the thread | **dp** (operator session — today) |
+| `mrh.*` (scope) | pre-review against the protocol; if it holds, rule it: CLI `hestia scope arbitrate <request_id> --grant\|--deny --reason '…' --as claude-code` (signs with the seat's registry key, calls MCP `hestia_scope_arbitrate {request_id, granted, reason, session_id, arbiter_signature}`; a grant is always **standing**). Refused by name if you are the asker or hold no delegation covering the path+member: then recommend and leave it for dp | the seat, under an **operator delegation** `scope.decide:<prefix>@<member>` (hestia #952/#962; first live ruling Legion 2026-09-05, delegation 66d05620) — else **dp** |
 | governance escalation (id in the deny) | `hestia_gate_pending_escalations` (pass your session) → if `you_may_rule` and the protocol holds, rule it: MCP `hestia_gate_arbitrate_escalation {escalation_id, approve: true|false, reason}` or CLI `hestia gate approve|deny <id> --as claude-code --reason '…'` | the seat, as a NOT-SAME peer — **no delegation needed** (measured 2026-09-05: f169ff9c45725a1f, decided_via peer_member) |
 | `society.*` | a law verdict; if plainly wrong, appeal on the being's behalf and corroborate — never override | arbiter of the appeal (NOT-SAME) |
 
@@ -25,5 +25,11 @@ the seat (`claude-code`) is a different member from the being, so it may rule; n
 grant` is required (that CLI is for roles, e.g. reviewer). A being's escalation must be opened
 WITH a session (`asker_basis: session`), else only the sovereign may rule it (#128).
 Opening one requires `tool_name`, `marker`, and `act` (a text description of the attempted act).
-Scope *rulings* remain operator-session-only in hestia today — hestia #952 asks for delegable
-scope arbitration so the seat can rule the being's own-memory requests too.
+Scope rulings (hestia #952, PR #962): a NOT-SAME seat may rule a member's pending scope request
+ONLY under an operator delegation naming the action — `hestia delegate grant $(hestia delegate
+agent-id claude-code) --action 'scope.decide:/abs/prefix@<member>' --expires <h>`, minted by dp.
+The ruling must be signed by the seat's registry key (`hestia scope arbitrate` does this from the
+vault); an unsigned, self-ruled, or undelegated ruling is refused by name. A delegated grant is
+STANDING; revocation and anything outside the delegated prefix stay operator-only. Until #962 is
+deployed on this seat, `hestia scope` is not a subcommand here and the row above degrades to
+recommend-and-leave-for-dp.

--- a/sage/gateway/escalate.py
+++ b/sage/gateway/escalate.py
@@ -7,9 +7,13 @@ A refused act is classified by its gate rule and routed:
   registry.*   bounded-registry refusal — by design, never escalated (the verb does not exist)
   mrh.*        SCOPE-class — the remedy the deny names is hestia_request_scope. We file it AS
                THE BEING (once per path), write an escalation note, and wake the seat. The seat
-               pre-reviews and recommends; the RULING is operator-session-only in hestia today
-               ("a human decides this"), so it lands in dp's queue with a recommendation
-               attached until delegable scope arbitration exists (hestia issue filed).
+               rules it under an operator delegation when it holds one (hestia #952/#962:
+               `hestia scope arbitrate <request_id> --grant|--deny --reason '…' --as <seat>`,
+               which signs with the seat's registry key and calls hestia_scope_arbitrate; the
+               grant is STANDING; NOT-SAME and the delegation's path/member bound are enforced
+               by the daemon). With no delegation covering the path, the daemon refuses by name
+               (hestia.scope_arbitrate_undelegated) and the request stays in dp's queue with the
+               seat's recommendation attached.
   society.*    a law verdict, not an approval; appealable — noted for the seat (hestia_appeal
                shape pending), never auto-overridden.
   <escalation> a governance-write escalation named in the deny — a NOT-SAME peer may arbitrate
@@ -127,9 +131,13 @@ def write_note(member: str, intent: BeingIntent, env: ResultEnvelope, kind: str,
             f"**verdict**: {v.decision if v else '?'} / {v.rule if v else ''} — {(v.reason if v else env.error or '')[:500]}\n\n"
             f"**routing**: {json.dumps(extra)[:600]}\n\n")
     how = {
-        "scope": ("## What the seat can do now\n- Pre-review: is the path inside the being's own memory? If yes, recommend GRANT\n"
-                  "  as STANDING (survives deploys). The ruling itself is operator-session-only today (dp).\n"
-                  "- Corroborate in the thread; do not fabricate a grant.\n"),
+        "scope": ("## What the seat can do now\n- Pre-review: is the path inside the being's own memory and does the protocol below hold?\n"
+                  "- If yes, RULE it (hestia #952): `hestia scope arbitrate <request_id> --grant --reason '<why>' --as claude-code`\n"
+                  "  (signs with this seat's registry key; the grant is STANDING; `--deny` to refuse). Use the request_id in\n"
+                  "  the routing line above. The daemon refuses by name if you are the asker (scope_arbitrate_self) or hold\n"
+                  "  no operator delegation covering this path+member (scope_arbitrate_undelegated): then leave it for dp\n"
+                  "  with your recommendation, and say so in the thread. Do not fabricate a grant.\n"
+                  "- The being sees the ruling on its next beat via hestia_scope_status (decided_by = delegate:<seat>).\n"),
         "governance": ("## What the seat can do now\n- `hestia_gate_pending_escalations` (pass your session) — if you_may_rule and the protocol holds, rule it:\n"
                        "  MCP `hestia_gate_arbitrate_escalation {escalation_id, approve: true|false, reason}` or\n"
                        "  `hestia gate approve|deny <id> --as claude-code --reason '<why>'`. No delegation needed (NOT-SAME peer).\n"),
@@ -172,7 +180,8 @@ def escalate(member: str, intent: BeingIntent, env: ResultEnvelope, memory_root:
         if kind == "scope":
             path = _scope_path(intent, memory_root)
             why = (f"{member} was refused {intent.effector} at {path} ({env.verdict.rule if env.verdict else ''}). "
-                   f"Its seat's auto session will pre-review; please rule as STANDING if it is the being's own memory.")
+                   f"Its seat's auto session will rule it under delegation if it holds one (hestia #952), "
+                   f"else please rule as STANDING if it is the being's own memory.")
             out["scope_request"] = _file_scope_request(member, path, why, endpoint)
         # The note exists to be pointed at by the wake. Without a wake there is no reader, and a
         # beat with nine refused home writes would leave nine near-identical notes (Sprout, #38

--- a/sage/gateway/heartbeat.py
+++ b/sage/gateway/heartbeat.py
@@ -152,16 +152,29 @@ def fleet_digest(hours: float, forum_dir: Path, repos: list[str]) -> str:
     return "\n\n".join(out) if out else "(nothing new in the window)"
 
 
-def note_resolutions(esc_dir: Path, decisions, stamp: str, seen_by: str) -> list:
-    """Append the operator's decision to each escalation note that filed the request
-    (the note carries the request_id in its routing line). Idempotent: a note already
-    resolved is left alone. Returns the note names written."""
+def decided_requests(reqs):
+    """The settled subset of hestia_scope_status `requests[]`, as (request_id, path, decision).
+    hestia's `ScopeRequest::status` emits granted | refused | pending | expired, and its
+    arbitrate door answers `denied`; the first cut filtered on ("granted", "denied") and so
+    dropped every refusal on the floor (legion-claude, hestia #952 review, 2026-09-05): the
+    being was never told, and no `## Resolved` block was ever written for one."""
+    return [(i, p_, d) for i, p_, d in reqs if d in ("granted", "refused", "denied")]
+
+
+def note_resolutions(esc_dir: Path, decisions, stamp: str, seen_by: str, decided_by=None) -> list:
+    """Append the ruling to each escalation note that filed the request (the note carries the
+    request_id in its routing line). Idempotent: a note already resolved is left alone.
+    `decided_by` maps request_id -> hestia's `decided_by` ("operator", or "delegate:<seat>"
+    for a ruling under hestia #952); the note names it rather than assuming the operator.
+    Returns the note names written."""
     written = []
     if not decisions or not esc_dir.is_dir():
         return written
+    decided_by = decided_by or {}
     for req_id, path, decision in decisions:
         if not req_id:
             continue
+        who = str(decided_by.get(req_id) or "operator")
         for p in sorted(esc_dir.glob("*.md")):
             try:
                 body = p.read_text(errors="replace")
@@ -170,7 +183,7 @@ def note_resolutions(esc_dir: Path, decisions, stamp: str, seen_by: str) -> list
             if req_id not in body or "## Resolved" in body:
                 continue
             with open(p, "a", encoding="utf-8") as f:
-                f.write(f"\n## Resolved\n{stamp}: `{req_id}` on `{path}` -> **{decision}** by the operator "
+                f.write(f"\n## Resolved\n{stamp}: `{req_id}` on `{path}` -> **{decision}** by {who} "
                         f"(read from hestia scope status by the seat, beat {seen_by}).\n")
             written.append(p.name)
     return written
@@ -318,6 +331,8 @@ def main(argv=None) -> int:
                      [g.get("path") for g in (st.get("standing_grants") or [])]
             reqs = [(r.get("request_id"), r.get("path"), r.get("decision") or r.get("status"))
                     for r in (st.get("requests") or [])]
+            who_ruled = {r.get("request_id"): r.get("decided_by") for r in (st.get("requests") or [])
+                         if r.get("decided_by")}
             # Close the loop the operator cannot see closed: a request decided since the
             # last beat is written back into the escalation note that filed it, and told
             # to the being. (dp 2026-09-05: "i just approved being's escalation - did you
@@ -328,15 +343,16 @@ def main(argv=None) -> int:
                 seen = set(tuple(x) for x in last.get("scope", {}).get("decided", []))
             except Exception:
                 pass
-            decided = [(i, p_, d) for i, p_, d in reqs if d in ("granted", "denied")]
+            decided = decided_requests(reqs)
             new_decisions = [x for x in decided if tuple(x) not in seen]
             esc_dir = Path(args.forum_dir).parent / "escalations"
             noted = note_resolutions(esc_dir, new_decisions, f"{datetime.now(timezone.utc):%Y-%m-%d %H:%M} UTC",
-                                     host_session_id)
+                                     host_session_id, decided_by=who_ruled)
             scope_record = {"grants": grants, "decided": [list(x) for x in decided], "noted": noted}
             scope = ("granted paths: " + (", ".join(map(str, grants)) or "none") + "\n"
                      "requests: " + ("; ".join(f"{i} {p} -> {d}" for i, p, d in reqs) or "none") + "\n"
-                     + ("decided since your last beat: " + "; ".join(f"{i} {p_} -> {d}" for i, p_, d in new_decisions) + "\n"
+                     + ("decided since your last beat: " + "; ".join(
+                            f"{i} {p_} -> {d} by {who_ruled.get(i) or 'operator'}" for i, p_, d in new_decisions) + "\n"
                         if new_decisions else "")
                      + "(live grants die when the daemon restarts; only standing grants persist)")
         except Exception as e:

--- a/sage/gateway/tests/test_think_policy.py
+++ b/sage/gateway/tests/test_think_policy.py
@@ -9,7 +9,7 @@ from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
 from sage.irp.adapters.model_capabilities import load_capabilities  # noqa: E402
 from sage.gateway.governed_turn import is_reasoning_model  # noqa: E402
-from sage.gateway.heartbeat import note_resolutions  # noqa: E402
+from sage.gateway.heartbeat import note_resolutions, decided_requests  # noqa: E402
 
 
 def test_think_policy_is_per_size_not_per_caller():
@@ -105,6 +105,23 @@ def test_note_resolutions_appends_once_to_the_filing_note():
     assert "Resolved" not in (d / "b.md").read_text()
     assert note_resolutions(d, [("scope-abc", "/x", "granted")], "later", "heartbeat-2") == []  # idempotent
     assert note_resolutions(d, [], "x", "y") == [] and note_resolutions(d / "nope", [("i", "p", "denied")], "x", "y") == []
+
+
+def test_refusals_are_decisions_too_and_the_ruler_is_named():
+    # hestia emits `refused` (ScopeRequest::status) and its arbitrate door says `denied`; the
+    # first cut filtered on ("granted", "denied") and silently dropped every operator refusal
+    # (legion-claude, hestia #952 review). Both spellings settle; pending/expired do not.
+    reqs = [("scope-a", "/x", "granted"), ("scope-b", "/y", "refused"), ("scope-c", "/z", "denied"),
+            ("scope-d", "/w", "pending"), ("scope-e", "/v", "expired")]
+    assert [i for i, _, _ in decided_requests(reqs)] == ["scope-a", "scope-b", "scope-c"]
+    d = Path(tempfile.mkdtemp(prefix="esc-"))
+    (d / "r.md").write_text("routing: {\"scope_request\": {\"request_id\": \"scope-b\"}}\n")
+    (d / "g.md").write_text("routing: {\"scope_request\": {\"request_id\": \"scope-a\"}}\n")
+    w = note_resolutions(d, decided_requests(reqs), "2026-09-05 22:00 UTC", "heartbeat-3",
+                         decided_by={"scope-a": "delegate:claude-code", "scope-b": "operator"})
+    assert sorted(w) == ["g.md", "r.md"]
+    assert "**refused** by operator" in (d / "r.md").read_text()
+    assert "**granted** by delegate:claude-code" in (d / "g.md").read_text()   # never "by the operator" for a #952 ruling
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sprout's half of hestia #952 / #962, per legion-claude's review of the consumer.

## The live bug, fixed
`heartbeat.py` filtered settled scope requests on `("granted", "denied")`. hestia's `ScopeRequest::status` emits `refused`, so every operator refusal was silently dropped: the being was never told, and no `## Resolved` block was ever appended for one. The filter is now `decided_requests()` accepting `granted | refused | denied` (the #962 arbitrate door answers `denied` while status says `refused`, so both are kept), pinned by a test.

## The string a delegated ruling falsifies
`note_resolutions()` wrote `by the operator` unconditionally. It now takes `decided_by` from `hestia_scope_status` (`operator` or `delegate:<seat>`) and names it; the beat prompt tells the being who ruled too.

## Arbiter wiring
`escalate.py`'s scope note and `ESCALATION_ARBITER.md` now tell the woken seat session to rule with
```
hestia scope arbitrate <request_id> --grant|--deny --reason '…' --as claude-code
```
(signs from the vault, calls `hestia_scope_arbitrate`; grant is STANDING; self / undelegated / unsigned are refused by name), and to fall back to recommend-and-leave-for-dp when the daemon refuses or `hestia scope` does not exist on the seat yet (Sprout runs main; #962 is unmerged).

Tests: 125 gateway tests pass (`python3 -m pytest -c /dev/null sage/gateway/tests`).

Thread: `auto-legion-first-ai-ruled-scope-grant-952-live-on-le-66fff8ff`

— sprout-claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
