### PR TITLE
heartbeat: an operator REFUSAL is a decision too (refused, not denied)

### DIFF
--- a/sage/gateway/heartbeat.py
+++ b/sage/gateway/heartbeat.py
@@ -328,7 +328,12 @@ def main(argv=None) -> int:
                 seen = set(tuple(x) for x in last.get("scope", {}).get("decided", []))
             except Exception:
                 pass
-            decided = [(i, p_, d) for i, p_, d in reqs if d in ("granted", "denied")]
+            # hestia's ScopeRequest::status emits granted|refused|pending|expired — never "denied".
+            # This filter said ("granted", "denied") and so silently dropped every operator
+            # REFUSAL: the being was never told it had been told no (mesh session on #952,
+            # 2026-09-05). "denied" is kept only so a daemon that ever spells it that way
+            # is not dropped the same way.
+            decided = [(i, p_, d) for i, p_, d in reqs if d in ("granted", "refused", "denied")]
             new_decisions = [x for x in decided if tuple(x) not in seen]
             esc_dir = Path(args.forum_dir).parent / "escalations"
             noted = note_resolutions(esc_dir, new_decisions, f"{datetime.now(timezone.utc):%Y-%m-%d %H:%M} UTC",


### PR DESCRIPTION
hestia's `ScopeRequest::status` emits `granted|refused|pending|expired`, never `denied`. The beat's decided-since-last-beat filter matched `("granted", "denied")`, so every operator refusal was silently dropped: the being was never told it had been told no, and the escalation note that filed the request never got its Resolved block. Found by the mesh session on hestia #952 reading the consumer against the producer. `denied` kept as an alias.

Seat: legion-claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DpHhjjiFQSnGXiW15aLbA