### PR TITLE
inbox drain: notify the drained being, not sprout-being; peer aliases from instance.json

### DIFF
--- a/sage/gateway/being_inbox_drain.py
+++ b/sage/gateway/being_inbox_drain.py
@@ -94,10 +94,16 @@ def persist_notice(instance: Path, n: Dict, relayed_by: str) -> Path:
 
 def drain_once(instance: Path, env_file: str, notify: Optional[Callable[[str, str], Dict]] = None,
                fetch: Optional[Callable[[], List[Dict]]] = None, relayed_by: str = "sprout-claude",
-               workspace: Optional[str] = None) -> Dict:
+               workspace: Optional[str] = None, member: str = "sprout-being") -> Dict:
     """One drain pass. `fetch` (test seam) defaults to the hub read with the being's key;
-    `notify(kind, pointer)` (test seam) defaults to the seat's hestia member_notify to the
-    being. Returns {fetched, persisted, notified, skipped, errors[]}."""
+    `notify(kind, pointer)` (test seam) defaults to the seat's hestia member_notify to
+    `member` — the being whose home `instance` is (its hestia plugin id, e.g. legion-being).
+    Returns {fetched, persisted, notified, skipped, errors[]}.
+
+    Legion 2026-09-05: the first cut hard-coded sprout-being as the notify target and
+    sprout-claude as the courier, so the mirror drain on Legion would have persisted a notice
+    into legion-being's home, marked it seen, and told sprout-being's hestia inbox about it —
+    once, with no retry. The recipient must be the drained being, and the caller says who."""
     instance = Path(instance)
     seen_file = instance / "notes" / "inbox" / ".seen"
     seen = set(seen_file.read_text().split()) if seen_file.exists() else set()
@@ -128,7 +134,8 @@ def drain_once(instance: Path, env_file: str, notify: Optional[Callable[[str, st
             ptr = str(p)
             if workspace and ptr.startswith(str(Path(workspace).resolve()) + "/"):
                 ptr = os.path.relpath(ptr, Path(workspace).resolve().parent)  # sage/instances/...
-            r = (notify or _seat_notify)(map_kind(n.get("kind", "")), ptr)
+            r = notify(map_kind(n.get("kind", "")), ptr) if notify is not None \
+                else _seat_notify(map_kind(n.get("kind", "")), ptr, member=member)
             if r.get("ok"):
                 out["notified"] += 1
             else:

--- a/sage/gateway/governed_turn.py
+++ b/sage/gateway/governed_turn.py
@@ -143,6 +143,18 @@ def acts_under_posture(model: str) -> bool:
     return not any(k in model.lower() for k in ("distill",))
 
 
+def instance_config(instance: Path) -> dict:
+    """The seat's per-instance config (`instance.json`: machine, model, slug ...). Also the
+    home of `peer_aliases` — the being's names for peers -> hub roster names / member ids
+    (sprout-being's hub member is still unnamed, so Legion aliases it to its id). A file
+    beside the being rather than env on a launcher, because Legion's beats have no unit
+    to carry SAGE_PEER_ALIASES (2026-09-05); env still applies on top."""
+    try:
+        return json.loads((Path(instance) / "instance.json").read_text())
+    except Exception:
+        return {}
+
+
 def build_client(member: str, instance: Path, model: str, workspace: str,
                  forum_dir: str | None, host_session_id: str, temperature: float,
                  max_tokens: int, gate_only: bool = False, num_ctx: int = 8192):
@@ -157,7 +169,8 @@ def build_client(member: str, instance: Path, model: str, workspace: str,
     # `pending` instead of executing. For seeing verdicts before anything leaves.
     dispatcher = None if gate_only else HestiaF1aDispatcher(
         member, memory_root=str(instance), publish_fn=publish_fn,
-        host_session_id=host_session_id, being_lct=being_lct_for(member, workspace))
+        host_session_id=host_session_id, being_lct=being_lct_for(member, workspace),
+        peer_aliases=instance_config(instance).get("peer_aliases") or None)
     client = BeingGateClient(member_id=member,
                              identity_path=str(instance / "identity.json"),
                              workspace=workspace, dispatcher=dispatcher,

--- a/sage/gateway/heartbeat.py
+++ b/sage/gateway/heartbeat.py
@@ -294,7 +294,8 @@ def main(argv=None) -> int:
     except Exception:
         pass
     name = ident.get("name") or args.member.split("-")[0]
-    machine = ident.get("machine") or "legion"
+    from sage.gateway.governed_turn import instance_config
+    machine = ident.get("machine") or instance_config(instance).get("machine") or "legion"
 
     from sage.gateway.governed_turn import build_client
     from sage.gateway.being_gate_client import ollama_tools
@@ -312,7 +313,9 @@ def main(argv=None) -> int:
     if not args.no_hub_drain and not args.gate_only and os.path.isfile(being_env):
         try:
             from sage.gateway.being_inbox_drain import drain_once as _hub_drain
-            hub_inbox = _hub_drain(instance, being_env, workspace=workspace)
+            # the notify goes to THIS being (args.member), labelled as this machine's seat
+            hub_inbox = _hub_drain(instance, being_env, workspace=workspace, member=args.member,
+                                   relayed_by=f"{machine}-claude")
         except Exception as _e:
             hub_inbox = {"error": f"{type(_e).__name__}: {_e}"}
     # inbox (peek) and long-term recall, seat-side, so the being starts oriented

--- a/sage/gateway/tests/test_being_inbox_drain.py
+++ b/sage/gateway/tests/test_being_inbox_drain.py
@@ -72,6 +72,24 @@ def test_env_file_expands_shell_variables_and_tilde():
     assert e["CHANNEL_CLIENT"] == os.path.expanduser("~/bin/cc") and e["MY_KEYPAIR"] == os.path.expanduser("~/.web4/k.bin")
 
 
+def test_default_notify_targets_the_drained_being_not_sprout(monkeypatch=None):
+    """Legion 2026-09-05: the mirror drain must tell legion-being's hestia inbox, labelled
+    legion-claude — not sprout-being / sprout-claude, which the first cut hard-coded."""
+    import sage.gateway.being_inbox_drain as m
+    inst = _inst()
+    calls = []
+    orig = m._seat_notify
+    m._seat_notify = lambda kind, pointer, member="sprout-being": (calls.append((kind, pointer, member)) or {"ok": True})
+    try:
+        r = m.drain_once(inst, env_file="unused", fetch=lambda: [{"kind": "reply", "pointer_uri": "p", "from": "2e175714-sprout-being", "pair_id": "n-7"}],
+                         member="legion-being", relayed_by="legion-claude")
+    finally:
+        m._seat_notify = orig
+    assert r["notified"] == 1 and calls == [("reply", calls[0][1], "legion-being")]
+    body = next((inst / "notes" / "inbox").glob("*.md")).read_text()
+    assert "relayed_by: legion-claude" in body and "sprout-claude" not in body
+
+
 if __name__ == "__main__":
     n = 0
     for name, fn in sorted(globals().items()):

--- a/sage/gateway/tests/test_hestia_dispatch.py
+++ b/sage/gateway/tests/test_hestia_dispatch.py
@@ -489,3 +489,16 @@ if __name__ == "__main__":
         if name.startswith("test_") and callable(fn):
             fn(); n += 1; print(f"PASS {name}")
     print(f"\n{n} passed")
+
+
+def test_instance_config_peer_aliases_reach_the_dispatcher(tmp_path=None):
+    import json, tempfile
+    from pathlib import Path
+    from sage.gateway.governed_turn import instance_config
+    inst = Path(tempfile.mkdtemp(prefix="inst-"))
+    (inst / "instance.json").write_text(json.dumps({"machine": "legion", "peer_aliases": {"sprout-being": "2e175714-id"}}))
+    cfg = instance_config(inst)
+    assert cfg["machine"] == "legion" and cfg["peer_aliases"] == {"sprout-being": "2e175714-id"}
+    assert instance_config(inst / "missing") == {}
+    d = HestiaF1aDispatcher("legion-being", memory_root=str(inst), peer_aliases=cfg["peer_aliases"])
+    assert d.peer_aliases["sprout-being"] == "2e175714-id"

--- a/sage/instances/legion-gemma3-12b/instance.json
+++ b/sage/instances/legion-gemma3-12b/instance.json
@@ -10,5 +10,8 @@
   "device_hint": "cpu",
   "has_training_track": false,
   "has_lora": false,
-  "encryption_enabled": false
+  "encryption_enabled": false,
+  "peer_aliases": {
+    "sprout-being": "2e175714-4b01-4063-a997-27a6dade7044"
+  }
 }


### PR DESCRIPTION
Mirror of Sprout's S4 inbound drain on Legion, and the defect that blocked it.

**Defect.** `being_inbox_drain.drain_once` (522a00fbf) hard-codes `_seat_notify(member="sprout-being")` and `relayed_by="sprout-claude"`; the heartbeat passes neither. On Legion, a notice addressed to legion-sage would be persisted into legion-being's home, marked seen in `.seen`, and the hestia notify sent to **sprout-being** (not a member here) with no retry. The being would never learn the file exists.

**Fix.** `drain_once(..., member=)` threads the drained being's plugin id to the notify; the heartbeat passes `args.member` and `f"{machine}-claude"`, with `machine` falling back to `instance.json` before the `"legion"` literal.

**Aliases.** Legion's beats have no unit or launcher to carry `SAGE_PEER_ALIASES`, so `build_client` also reads `peer_aliases` from the instance's `instance.json` (env still applies on top). legion-gemma3-12b aliases `sprout-being` to its unnamed hub member id `2e175714-…`.

Tests: 37 pass (`test_being_inbox_drain.py` 7, `test_hestia_dispatch.py` 30).

Thread: `auto-sprout-s4-being-to-being-plumbing-on-sprout-legi-234b8ae4` · acting_on `434d10a0-c708-45f1-9868-cb70bd81f283`

— legion-claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)