### PR TITLE
M0: bind check governance, execution, and evidence

### DIFF
--- a/sage/gateway/being_gate_client.py
+++ b/sage/gateway/being_gate_client.py
@@ -121,6 +121,37 @@ def _takes_ctx(fn) -> bool:
         return False
 
 
+def check_argv(args: dict, ctx: Optional[dict] = None) -> List[str]:
+    """The canonical argv for ``check`` after validating its bounded target."""
+    import re
+    import os
+    worktree = (ctx or {}).get("worktree")
+    if not worktree:
+        raise ValueError(
+            "check needs a worktree of your own: there is nothing to run tests in, and a "
+            "relative path would be judged against a tree you do not hold (PRD M1)")
+    worktree = os.path.realpath(os.path.expanduser(str(worktree)))
+    target = str(args.get("target", "")).strip()
+    node = None
+    if target in CHECK_TARGETS:
+        suite = target
+    else:
+        # A single node id INSIDE a declared suite: "gateway::test_name". Nothing else.
+        suite, sep, node = target.partition("::")
+        if not sep or suite not in CHECK_TARGETS:
+            raise ValueError(
+                f"check 'target' must be one of {sorted(CHECK_TARGETS)} or "
+                f"'<suite>::<test_name>'; got {target!r}")
+        if not re.fullmatch(r"[A-Za-z0-9_]+", node):
+            raise ValueError(f"check test name must be a bare identifier; got {node!r}")
+    path = os.path.join(worktree, CHECK_TARGETS[suite])
+    argv = ["python3", "-m", "pytest", "-q", "-c", "/dev/null",
+            f"--rootdir={worktree}", path]
+    if node is not None:
+        argv.extend(("-k", node))
+    return argv
+
+
 def check_command(args: dict, ctx: Optional[dict] = None) -> str:
     """The shell command the seat runs for a `check` intent, built from validated args.
 
@@ -138,27 +169,8 @@ def check_command(args: dict, ctx: Optional[dict] = None) -> str:
     actually touch; anything else is the `_safe_path` defect again, one layer over. No
     worktree means no check: fail closed, and say which affordance is missing.
     """
-    import re
-    import os
-    worktree = (ctx or {}).get("worktree")
-    if not worktree:
-        raise ValueError(
-            "check needs a worktree of your own: there is nothing to run tests in, and a "
-            "relative path would be judged against a tree you do not hold (PRD M1)")
-    target = str(args.get("target", "")).strip()
-    if target in CHECK_TARGETS:
-        path = os.path.join(worktree, CHECK_TARGETS[target])
-    else:
-        # A single node id INSIDE a declared suite: "gateway::test_name". Nothing else.
-        suite, sep, node = target.partition("::")
-        if not sep or suite not in CHECK_TARGETS:
-            raise ValueError(
-                f"check 'target' must be one of {sorted(CHECK_TARGETS)} or "
-                f"'<suite>::<test_name>'; got {target!r}")
-        if not re.fullmatch(r"[A-Za-z0-9_]+", node):
-            raise ValueError(f"check test name must be a bare identifier; got {node!r}")
-        path = f"{os.path.join(worktree, CHECK_TARGETS[suite])} -k {node}"
-    return f"python3 -m pytest -q -c /dev/null --rootdir={worktree} {path}"
+    import shlex
+    return shlex.join(check_argv(args, ctx))
 
 
 _REGISTRY = {
@@ -253,8 +265,9 @@ _TOOL_SCHEMAS = {
     # the daemon reads plugin_id/role/path/reason only, and a grant is a `path:<p>` entry
     # in in_scope that rules mrh.path for reads and writes alike. Offering a mode would be
     # a choice the law cannot honour.
-    "request_scope": ("Ask the operator for reach you do not have, after a refusal. A grant "
-                      "is reach on that path, read and write alike. Say why. A human decides; "
+    "request_scope": ("Ask the operator for reach you do not have, after a refusal. SAGE "
+                      "can read an external granted path, but keeps external writes disabled "
+                      "until being-code execution has its own principal. Say why. A human decides; "
                       "no answer within the window is a refusal. A live grant dies with the "
                       "daemon; only a standing grant persists.",
                       {"path": "absolute path you want reach to",
@@ -336,6 +349,9 @@ class GatewayVerdict:
     # 2026-09-05 that a shared-context read grant "cannot be used at all" because the local
     # dispatcher confined memory_read to the instance dir before hestia's gate was consulted.
     granted: tuple = ()
+    # For a composed effector, this is the exact command the law judged. Dispatch executes
+    # this value rather than independently rebuilding a lookalike command.
+    command: Optional[str] = None
 
     @property
     def blocks(self) -> bool:
@@ -385,7 +401,8 @@ class BeingGateClient:
         self.member_id = member_id
         self.workspace = workspace
         # the being's own worktree; composed commands name paths inside it
-        self.worktree = worktree
+        self.worktree = (os.path.realpath(os.path.expanduser(str(worktree)))
+                         if worktree else None)
         # The being's memory root: the instance dir that holds its identity. Relative
         # memory paths the being emits are rooted here (see _normalize).
         self.memory_root = os.path.dirname(os.path.abspath(os.path.expanduser(identity_path)))
@@ -470,9 +487,15 @@ class BeingGateClient:
             # turns that into a deny (gate.raised), never a silent pass. The being never
             # fills a command; the registry never carries a cmd_arg for a composed verb.
             command = compose(intent.args, ctx) if _takes_ctx(compose) else compose(intent.args)
+        raw = {"effector": intent.effector, **intent.args}
+        if command is not None:
+            # Society safety consumes raw/tool_input rather than NormalizedEvent.command.
+            # Carry the composed act there too; otherwise stage 1 and stage 2 judge
+            # different objects.
+            raw["command"] = command
         return self._core.NormalizedEvent(
             tool=spec["tool"], paths=paths, command=command,
-            cwd=self.workspace, raw={"effector": intent.effector, **intent.args},
+            cwd=self.workspace, raw=raw,
         )
 
     # -- gate one intent (intent -> verdict), fail-closed --------------------
@@ -492,7 +515,13 @@ class BeingGateClient:
                                     default_role="role:constellation:member",
                                     host_agent=getattr(self, "_host_agent", "sage-raising"),
                                     client_name=f"sage-{self.member_id}-gate")
-                ge = sg.GateEvent(tool=tool, tool_input=dict(intent.args), cwd=self.workspace,
+                tool_input = dict(intent.args)
+                if getattr(ev, "command", None) is not None:
+                    # The single gate derives NormalizedEvent.command from tool_input. Merely
+                    # calling _normalize above validates the compose but does not make the
+                    # gate judge it; the composed command must cross this seam explicitly.
+                    tool_input["command"] = ev.command
+                ge = sg.GateEvent(tool=tool, tool_input=tool_input, cwd=self.workspace,
                                   session_id=getattr(self, "host_session_id", None),
                                   raw={"effector": intent.effector, **intent.args})
                 d = sg.decide(ge, gp)
@@ -500,7 +529,8 @@ class BeingGateClient:
                 dec = d.decision if (available and d.decision in ("allow", "warn", "deny")) else "deny"
                 rule = d.rule or ("" if available else "gate.no_verdict")
                 return GatewayVerdict(dec, rule, getattr(d, "reason", "") or ("ok" if dec != "deny" else ""),
-                                      innate=False, stage="single-gate")
+                                      innate=False, stage="single-gate",
+                                      command=getattr(ev, "command", None))
             except Exception as e:  # a gate that raises is a refused act, never an ungoverned one
                 return GatewayVerdict("deny", "gate.raised", innate=True, stage="single-gate",
                                       reason=f"{type(e).__name__}: {e}")
@@ -567,7 +597,7 @@ class BeingGateClient:
                                           reason=f"society-safety failed ({type(e).__name__}); consequential act denied")
                 # observational: local law already allowed, soft-pass
         return GatewayVerdict(v.decision, v.rule, v.reason or "ok", v.innate, stage="local-law",
-                              granted=granted)
+                              granted=granted, command=getattr(ev, "command", None))
 
     # -- the F1a seam: gate, then dispatch, then consume the result ----------
     def dispatch(self, intent: BeingIntent) -> ResultEnvelope:

--- a/sage/gateway/governed_turn.py
+++ b/sage/gateway/governed_turn.py
@@ -165,20 +165,33 @@ def build_client(member: str, instance: Path, model: str, workspace: str,
     publish_fn = None
     if forum_dir and os.path.isdir(forum_dir):
         publish_fn = make_forum_publisher(forum_dir, member)
+    cfg = instance_config(instance)
+    declared_embodiment = cfg.get("active_embodiment") or {}
+    embodiment = {
+        # The model argument is what this process actually asked the runner to load. Keep
+        # it even when an older instance lacks the canonical declaration, and say whether
+        # the declaration agrees instead of silently substituting one for the other.
+        "running_tag": model,
+        "declared_running_tag": declared_embodiment.get("running_tag"),
+        "declaration_as_of": declared_embodiment.get("as_of"),
+        "source": declared_embodiment.get("source"),
+        "matches_declaration": (declared_embodiment.get("running_tag") == model
+                                if declared_embodiment.get("running_tag") else None),
+    }
     # gate_only: the law still judges every intent; an allowed one comes back
     # `pending` instead of executing. For seeing verdicts before anything leaves.
     dispatcher = None if gate_only else HestiaF1aDispatcher(
         member, memory_root=str(instance), publish_fn=publish_fn,
         host_session_id=host_session_id, being_lct=being_lct_for(member, workspace),
-        peer_aliases=instance_config(instance).get("peer_aliases") or None,
+        peer_aliases=cfg.get("peer_aliases") or None,
         # The being's own git worktree, for `check` and (M1) for editing code. Read from
         # instance.json so it is a per-being fact beside the being, not a launcher flag.
-        worktree=instance_config(instance).get("worktree") or None)
+        worktree=cfg.get("worktree") or None, embodiment=embodiment)
     client = BeingGateClient(member_id=member,
                              identity_path=str(instance / "identity.json"),
                              workspace=workspace, dispatcher=dispatcher,
                              host_session_id=host_session_id,
-                             worktree=instance_config(instance).get("worktree") or None)
+                             worktree=cfg.get("worktree") or None)
     # Reasoning models (empero Qwen3.8 distills etc.) only emit structured tool calls
     # with `think` on — off, they narrate a bracketed placeholder instead of acting
     # (measured on Sprout 2026-08-28 and again on the first governed turn, 2026-09-03:

--- a/sage/gateway/heartbeat.py
+++ b/sage/gateway/heartbeat.py
@@ -58,7 +58,7 @@ AFFORDANCES = """## What you have this beat
 - Long-term memory: recall (search) and remember (store). Use recall early; remember what a future you would want.
 - check: RUN a test suite in your own worktree and read the result ('gateway', 'irp', or '<suite>::<test_name>'). This is how you find out whether something you believe about your own code is true instead of asserting it. A FAILING test is a real answer, not a problem.
 - witness: record something you noticed or did in the shared chain.
-- request_scope: after a refusal, ask the operator for reach on a path (a grant is read and write alike) and say why. A human decides, asynchronously.
+- request_scope: after a refusal, ask the operator for reach on a path. SAGE can read an external granted path, but keeps external writes disabled until being-code execution has its own principal. Say why. A human decides, asynchronously.
 - appeal: after a refusal you believe was wrong, appeal it with the deny hash shown on the refusal and a reason. A peer or the operator rules; either way it is witnessed. Not for a refusal you agree with.
 - peer_ask / mesh: reach other beings and seats. These are acts of consequence: they are judged, and may be refused with a reason.
 

--- a/sage/gateway/hestia_dispatch.py
+++ b/sage/gateway/hestia_dispatch.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
 from sage.gateway.being_gate_client import BeingIntent, GatewayVerdict, ResultEnvelope
@@ -89,9 +90,14 @@ class HestiaF1aDispatcher:
                  peer_aliases: Optional[Dict[str, str]] = None,
                  # the being's OWN git worktree: where `check` runs and where it may
                  # edit code. Never the shared checkout (PRD M1).
-                 worktree: Optional[str] = None):
+                 worktree: Optional[str] = None,
+                 embodiment: Optional[dict] = None):
         self.plugin_id = plugin_id
-        self.worktree = worktree
+        self.worktree = (os.path.realpath(os.path.expanduser(str(worktree)))
+                         if worktree else None)
+        # Runtime provenance supplied by the launcher. This is deliberately a compact
+        # public identity for the active substrate, not host/infrastructure inventory.
+        self.embodiment = dict(embodiment or {})
         # the being's names for peers -> hub roster names (e.g. legion-being -> legion-sage,
         # the name legion-being joined under on 2026-09-05); env SAGE_PEER_ALIASES="a=b,c=d"
         self.peer_aliases = dict(peer_aliases or {})
@@ -413,9 +419,9 @@ class HestiaF1aDispatcher:
 
     def _do_request_scope(self, intent: BeingIntent) -> ResultEnvelope:
         """The daemon (handler.rs::tool_request_scope @a5e18af) reads plugin_id, role, path,
-        reason; a grant is reach on the path, read AND write. There is no mode to carry: an
-        earlier `permits_read` was dropped silently by the daemon while the operator read
-        "[.., read]" on a request that, granted, gave write."""
+        reason; its law grant has no read/write mode. SAGE deliberately executes external
+        roots read-only until being-authored code has a principal isolated from the seat,
+        so the being-facing contract must describe that narrower effective affordance."""
         path = str(intent.args.get("path", "")).strip()
         reason = str(intent.args.get("reason", "")).strip()
         if not path.startswith("/"):
@@ -431,7 +437,7 @@ class HestiaF1aDispatcher:
             r = _os.path.realpath(str(root))
             if rp == r or rp.startswith(r + "/"):
                 return ResultEnvelope(ok=True, result={"status": "already_granted", "path": path, "within": r,
-                                                       "next": "you already hold reach here; read or write it directly"})
+                                                       "next": "you already hold read reach here; external writes stay disabled until principal isolation"})
         args: Dict[str, Any] = {"plugin_id": self.plugin_id, "path": path,
                                 "reason": f"[{self.plugin_id}] {reason}"}
         out = self._call("hestia_request_scope", args)
@@ -453,31 +459,55 @@ class HestiaF1aDispatcher:
         which is the opposite of what this organ is for — so `passed` carries the verdict
         and `ok` carries only whether the check ran.
         """
+        import hashlib
         import shlex
         import subprocess
-        from sage.gateway.being_gate_client import check_command
+        from sage.gateway.being_gate_client import check_argv, check_command
         if not self.worktree or not os.path.isdir(self.worktree):
             return ResultEnvelope(ok=False, pending=True,
                                   note="check needs a worktree of your own; none is configured "
                                        "on this seat (PRD M1)")
-        # Rebuild the SAME command the gate judged — same function, same context. Composing
-        # it differently here would mean the law ruled on one command and the seat ran
-        # another, which is the whole failure this organ exists to make impossible.
+        # Execute the command carried by the verdict, not a separately built lookalike.
+        # Recomposition below is an invariant check; it is not the execution authority.
         try:
-            cmd = check_command(intent.args, {"worktree": self.worktree})
+            expected = check_command(intent.args, {"worktree": self.worktree})
+            argv = check_argv(intent.args, {"worktree": self.worktree})
         except ValueError as e:
             return ResultEnvelope(ok=False, error=str(e))
+        cmd = getattr(getattr(self, "_verdict", None), "command", None)
+        if not cmd:
+            return ResultEnvelope(ok=False, error="check refused: the allow verdict did not bind "
+                                  "the composed command")
+        if cmd != expected or shlex.split(cmd) != argv:
+            return ResultEnvelope(ok=False, error="check refused: the command judged by the law "
+                                  "does not equal the command this dispatcher would execute")
         target = str(intent.args.get("target", "")).strip()
+
+        tree_before, status_before = self._worktree_revision()
+        if not tree_before.get("head") or status_before is None:
+            return ResultEnvelope(ok=False, error="check refused: the worktree revision could "
+                                  "not be established")
+        if tree_before["dirty"]:
+            return ResultEnvelope(ok=False, error="check refused: the worktree has uncommitted "
+                                  "changes, so HEAD does not identify the bytes that would run")
+        try:
+            source_before = self._test_source_identity(target, tree_before["head"])
+        except Exception as e:
+            return ResultEnvelope(ok=False, error=f"check refused: test-source identity could "
+                                  f"not be established ({type(e).__name__}: {e})")
+
         begin = self._call("hestia_begin_action", {"tool_name": "check", "target": target})
         err = _hestia_error(begin)
         if err:
             return ResultEnvelope(ok=False, error=err)
         action_id = begin.get("actionId")
         try:
-            proc = subprocess.run(shlex.split(cmd), cwd=self.worktree, text=True,
+            proc = subprocess.run(argv, cwd=self.worktree,
                                   capture_output=True, timeout=600)
             passed = proc.returncode == 0
-            out = ((proc.stdout or "") + (proc.stderr or "")).strip()
+            output_bytes = (proc.stdout or b"") + (proc.stderr or b"")
+            output_sha256 = hashlib.sha256(output_bytes).hexdigest()
+            out = output_bytes.decode("utf-8", errors="replace").strip()
             # The tail is where pytest puts the verdict and the failure detail; the head is
             # progress dots. Truncate from the FRONT so a failure is never the part cut.
             if len(out) > 3000:
@@ -493,11 +523,95 @@ class HestiaF1aDispatcher:
         if not ran:
             return ResultEnvelope(ok=False, error=f"check could not run: {detail[:400]}",
                                   witness_id=action_id)
+
+        tree_after, _status_after = self._worktree_revision()
+        try:
+            source_after = self._test_source_identity(target, tree_after.get("head"))
+        except Exception:
+            source_after = None
+        stable = tree_after == tree_before and source_after == source_before
         return ResultEnvelope(ok=True, witness_id=action_id,
                               result={"target": target, "passed": passed,
                                       "verdict": "PASS" if passed else "FAIL",
                                       "output": detail, "worktree": self.worktree,
+                                      "evidence": {
+                                          "tree": tree_before,
+                                          "command": cmd,
+                                          "argv": argv,
+                                          "test_source": source_before,
+                                          "exit_status": proc.returncode,
+                                          "output_sha256": output_sha256,
+                                          "output_bytes": len(output_bytes),
+                                          "class": "independent",
+                                          "embodiment": self.embodiment,
+                                          "stable": stable,
+                                          "state": ("pinned" if stable else
+                                                    "tree_changed_during_check"),
+                                      },
                                       "action_id": action_id})
+
+    def _git(self, *args: str) -> Optional[str]:
+        """Run one read-only git query in the check worktree."""
+        import subprocess
+        try:
+            proc = subprocess.run(("git", *args), cwd=self.worktree, text=True,
+                                  capture_output=True, timeout=15)
+            return proc.stdout.strip() if proc.returncode == 0 else None
+        except Exception:
+            return None
+
+    def _worktree_revision(self) -> tuple[dict, Optional[str]]:
+        """Return the exact committed revision and whether other bytes are present."""
+        head = self._git("rev-parse", "HEAD")
+        status = self._git("status", "--porcelain", "--untracked-files=all")
+        top = self._git("rev-parse", "--show-toplevel")
+        canonical_top = os.path.realpath(top) if top else None
+        if canonical_top != self.worktree:
+            head, status = None, None
+        return ({"head": head, "short": (head or "")[:9] or None,
+                 "dirty": None if status is None else bool(status)}, status)
+
+    def _test_source_identity(self, target: str, head: Optional[str]) -> dict:
+        """Digest the selected acceptance bar, separately from the production tree SHA.
+
+        The bar is every tracked file below the declared suite plus each tracked
+        ``conftest.py`` pytest loads on the path from the worktree root to that suite.
+        Paths and byte lengths are framed into the digest so concatenation is unambiguous.
+        """
+        import hashlib
+        from sage.gateway.being_gate_client import CHECK_TARGETS
+
+        if not head:
+            raise ValueError("missing HEAD")
+        suite = target.partition("::")[0]
+        rel_root = CHECK_TARGETS[suite].rstrip("/")
+        listed = self._git("ls-tree", "-r", "--name-only", head, "--", rel_root)
+        if listed is None:
+            raise ValueError("git could not enumerate the test source")
+        paths = [p for p in listed.splitlines() if p]
+
+        parent = Path(rel_root)
+        for ancestor in (Path("."), *parent.parents, parent):
+            candidate = (ancestor / "conftest.py").as_posix()
+            if candidate.startswith("./"):
+                candidate = candidate[2:]
+            if candidate and self._git("cat-file", "-e", f"{head}:{candidate}") is not None:
+                paths.append(candidate)
+
+        paths = sorted(set(paths))
+        if not paths:
+            raise ValueError("the selected suite has no tracked test source")
+        digest = hashlib.sha256()
+        for rel in paths:
+            data = (Path(self.worktree) / rel).read_bytes()
+            name = rel.encode("utf-8")
+            digest.update(len(name).to_bytes(8, "big")); digest.update(name)
+            digest.update(len(data).to_bytes(8, "big")); digest.update(data)
+        git_tree = self._git("rev-parse", f"{head}:{rel_root}")
+        if not git_tree:
+            raise ValueError("git could not identify the test-source tree")
+        return {"sha256": digest.hexdigest(), "git_tree": git_tree,
+                "root": rel_root, "files": len(paths)}
 
     # -- channel_egress: not built on the daemon ----------------------------
     def _do_channel_egress(self, intent: BeingIntent) -> ResultEnvelope:

--- a/sage/gateway/tests/test_being_gate_client.py
+++ b/sage/gateway/tests/test_being_gate_client.py
@@ -23,7 +23,7 @@ def _client(mech):
     c._profile = object()
     c._mech = mech
     c._core = SimpleNamespace(
-        NormalizedEvent=lambda **kw: SimpleNamespace(raw=kw.get("raw", {}), tool=kw.get("tool")),
+        NormalizedEvent=lambda **kw: SimpleNamespace(**kw),
         evaluate=lambda ev, prof, ws, policy=None: SimpleNamespace(
             decision="allow", rule="", reason="ok", innate=False),
     )
@@ -114,7 +114,7 @@ def test_relative_memory_path_is_judged_at_the_being_memory_root():
     c = _client(_allows)
     c.memory_root = "/tmp/being-home"
     c._core = SimpleNamespace(
-        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(raw=kw.get("raw", {}), tool=kw.get("tool")),
+        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(**kw),
         evaluate=lambda ev, prof, ws, policy=None: SimpleNamespace(
             decision="allow", rule="", reason="ok", innate=False),
     )
@@ -131,7 +131,7 @@ def test_pr_review_is_judged_as_the_gh_command_the_seat_runs():
     seen = {}
     c = _client(_allows)
     c._core = SimpleNamespace(
-        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(raw=kw.get("raw", {}), tool=kw.get("tool")),
+        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(**kw),
         evaluate=lambda ev, prof, ws, policy=None: SimpleNamespace(
             decision="allow", rule="", reason="ok", innate=False),
     )
@@ -198,6 +198,22 @@ def test_single_gate_decides_and_client_does_not_resequence():
     assert prof["member_id"] == "test-being" and prof["host_agent"] == "test-harness"
 
 
+def test_single_gate_judges_and_returns_the_composed_check_command():
+    """Validation is not governance: the composed command must be inside GateEvent or the
+    single gate sees only the being's friendly target label."""
+    import shlex
+    from sage.gateway.being_gate_client import check_command
+    c, calls = _sg_client("allow")
+    c.worktree = "/tmp/being worktree"
+    v = c.gate(BeingIntent("check", {"target": "gateway::test_thing"}))
+    expected = check_command({"target": "gateway::test_thing"},
+                             {"worktree": "/tmp/being worktree"})
+    assert calls[0][0]["tool_input"]["command"] == expected
+    assert v.command == expected
+    assert shlex.split(expected)[-2:] == ["-k", "test_thing"]
+    assert shlex.split(expected)[-3] == "/tmp/being worktree/sage/gateway/tests/"
+
+
 def test_single_gate_deny_and_no_verdict_map_fail_closed():
     assert _sg_client("deny", "mrh.path")[0].gate(WRITE).rule == "mrh.path"
     v = _sg_client("allow", available=False)[0].gate(WRITE)
@@ -229,7 +245,7 @@ def test_request_scope_path_is_not_judged_under_mrh_path():
     seen = {}
     c = _client(_allows)
     c._core = SimpleNamespace(
-        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(raw=kw.get("raw", {}), tool=kw.get("tool")),
+        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(**kw),
         evaluate=lambda ev, prof, ws, policy=None: SimpleNamespace(
             decision="allow", rule="", reason="ok", innate=False),
     )
@@ -249,7 +265,8 @@ def test_request_scope_schema_offers_no_mode():
     params = spec["function"]["parameters"]
     assert set(params["properties"]) == {"path", "reason"}, params
     assert params["required"] == ["path", "reason"]
-    assert "read and write" in spec["function"]["description"]
+    assert "external writes disabled" in spec["function"]["description"]
+    assert "read and write alike" not in spec["function"]["description"]
 
 def test_registry_offers_appeal_as_an_observational_effector():
     from sage.gateway.being_gate_client import _REGISTRY, _OBSERVATIONAL, ollama_tools
@@ -308,19 +325,26 @@ def test_check_is_judged_as_the_pytest_command_the_seat_runs():
     c = _client(_allows)
     c.worktree = "/tmp/being-wt"
     c._core = SimpleNamespace(
-        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(raw=kw.get("raw", {}), tool=kw.get("tool")),
+        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(**kw),
         evaluate=lambda ev, prof, ws, policy=None: SimpleNamespace(
             decision="allow", rule="", reason="ok", innate=False),
     )
-    c.gate(BeingIntent("check", {"target": "gateway"}))
+    v = c.gate(BeingIntent("check", {"target": "gateway"}))
     # ABSOLUTE, inside the worktree: the law must judge the path the command touches, not
     # the same relative path resolved against the shared checkout (measured 2026-09-07).
     assert seen["command"] == (
         "python3 -m pytest -q -c /dev/null --rootdir=/tmp/being-wt "
         "/tmp/being-wt/sage/gateway/tests/"), seen["command"]
     assert seen["tool"] == "check"
+    assert v.command == seen["command"]
     c.gate(BeingIntent("check", {"target": "gateway::test_thing"}))
     assert seen["command"].endswith("/tmp/being-wt/sage/gateway/tests/ -k test_thing")
+    # Seat-chosen paths with spaces stay one argv item; command and execution identity do
+    # not depend on a whitespace-free checkout name.
+    c.worktree = "/tmp/being worktree"
+    c.gate(BeingIntent("check", {"target": "gateway"}))
+    import shlex
+    assert shlex.split(seen["command"])[-1] == "/tmp/being worktree/sage/gateway/tests/"
     # no worktree is a deny, never a command judged against somebody else's tree
     c.worktree = None
     v = c.gate(BeingIntent("check", {"target": "gateway"}))

--- a/sage/gateway/tests/test_hestia_dispatch.py
+++ b/sage/gateway/tests/test_hestia_dispatch.py
@@ -2,8 +2,11 @@
 see, so the three measured contract deltas (pointer_uri, kind enum, live session_id) and the
 r1 envelope (hestia.<code> error keys) are pinned without a running daemon."""
 import os
+import re
+import subprocess
 import sys
 import tempfile
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
 from sage.gateway.being_gate_client import BeingIntent, GatewayVerdict  # noqa: E402
@@ -105,6 +108,22 @@ def _disp(**kw):
 
 def _notify_args():
     return [a for n, a in FakeMcp.calls if n == "hestia_member_notify"][-1]
+
+
+def _clean_check_tree(test_body="def test_bar():\n    assert True\n"):
+    """A minimal committed SAGE-shaped tree for exercising the real pytest subprocess."""
+    root = Path(tempfile.mkdtemp(prefix="hd-check-"))
+    tests = root / "sage" / "gateway" / "tests"
+    tests.mkdir(parents=True)
+    (root / ".gitignore").write_text("__pycache__/\n*.pyc\n.pytest_cache/\n")
+    (root / "conftest.py").write_text("# acceptance fixture root\n")
+    (tests / "test_bar.py").write_text(test_body)
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "SAGE test"], cwd=root, check=True)
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-qm", "bar"], cwd=root, check=True)
+    return root
 
 
 def test_mesh_routes_remote_with_pointer_uri_and_session():
@@ -481,6 +500,53 @@ def test_peer_aliases_map_the_beings_name_to_the_hub_roster_name():
         assert d2._address("cbp-being") == "cbp-sage/claude-code"
     finally:
         del os.environ["SAGE_PEER_ALIASES"]
+
+
+def test_check_result_binds_command_tree_bar_output_exit_class_and_embodiment():
+    from sage.gateway.being_gate_client import check_command
+    root = _clean_check_tree()
+    embodiment = {"running_tag": "test:model", "matches_declaration": True}
+    d, _ = _disp(worktree=str(root), embodiment=embodiment)
+    intent = BeingIntent("check", {"target": "gateway::test_bar"})
+    command = check_command(intent.args, {"worktree": str(root)})
+    env = d(intent, GatewayVerdict("allow", command=command))
+    assert env.ok and env.result["passed"] and env.result["verdict"] == "PASS", env
+    evidence = env.result["evidence"]
+    assert evidence["command"] == command
+    assert evidence["argv"][-2:] == ["-k", "test_bar"]
+    assert evidence["exit_status"] == 0
+    assert re.fullmatch(r"[0-9a-f]{64}", evidence["output_sha256"])
+    assert evidence["output_bytes"] > 0
+    assert evidence["tree"]["head"] == subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=root, check=True,
+        text=True, capture_output=True).stdout.strip()
+    assert evidence["tree"]["dirty"] is False
+    assert evidence["test_source"]["files"] == 2  # selected test + loaded root conftest
+    assert re.fullmatch(r"[0-9a-f]{64}", evidence["test_source"]["sha256"])
+    assert evidence["class"] == "independent"
+    assert evidence["embodiment"] == embodiment
+    assert evidence["stable"] and evidence["state"] == "pinned"
+
+
+def test_check_refuses_unbound_command_and_dirty_tree_before_execution():
+    from sage.gateway.being_gate_client import check_command
+    root = _clean_check_tree()
+    d, _ = _disp(worktree=str(root))
+    intent = BeingIntent("check", {"target": "gateway"})
+
+    env = d(intent, GatewayVerdict("allow"))
+    assert not env.ok and "did not bind" in env.error
+
+    command = check_command(intent.args, {"worktree": str(root)})
+    env = d(intent, GatewayVerdict("allow", command=command + " --maxfail=1"))
+    assert not env.ok and "does not equal" in env.error
+
+    (root / "sage" / "gateway" / "tests" / "test_bar.py").write_text(
+        "def test_bar():\n    assert False\n")
+    FakeMcp.calls.clear()
+    env = d(intent, GatewayVerdict("allow", command=command))
+    assert not env.ok and "uncommitted changes" in env.error
+    assert not [name for name, _args in FakeMcp.calls if name == "hestia_begin_action"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked directly on #55 (`legion/m0-check-organ`); one commit, intended to be reviewed or cherry-picked into that PR before it lands.

## Why

The r3 evidence blocker on #55 is real, and the audit found one deeper governance seam while implementing it: on the optional single-gate path, SAGE called `_normalize()` (so invalid composed arguments were rejected) but then passed only the being's raw `{target: ...}` to `GateEvent`. The composed pytest command was therefore validated but not actually presented to that gate for judgment.

## What this changes

- carries the composed command through both the single-gate and society-safety paths;
- returns the exact gate-judged command on `GatewayVerdict`, and makes dispatch execute that authority rather than an independently rebuilt string;
- uses a canonical argv + `shlex.join`, preserving argument identity even when the seat-chosen worktree path contains whitespace;
- refuses checks when the git worktree or clean revision cannot be established;
- emits a self-describing evidence object containing:
  - clean tree HEAD;
  - exact command and argv;
  - deterministic SHA-256 plus git tree identity for the selected test bar (including loaded ancestor `conftest.py` files);
  - raw process exit status;
  - SHA-256 and byte length of the full pre-truncation output;
  - M0 evidence class (`independent`);
  - compact runtime/declaration embodiment provenance;
  - a pre/post stability marker;
- corrects the being-facing scope contract: external grants are readable, while SAGE deliberately keeps external writes disabled until being-code execution has an isolated principal.

A check that starts clean but changes underneath execution still returns the test answer, but marks its evidence `tree_changed_during_check` rather than presenting it as pinned.

## Verification

```text
python3 -m pytest -q -c /dev/null --rootdir=. sage/gateway/tests/
143 passed in 5.30s
```

New adversarial coverage pins missing/mismatched verdict commands, the single-gate composed-command seam, whitespace-safe argv identity, dirty-tree refusal before execution, and the complete evidence shape.

— Codex (OpenAI), outside-seat contribution
