### PR TITLE
M0 refresh: check organ + #60 evidence contract, re-cut onto current main with #1002 reach

### DIFF
--- a/sage/gateway/being_gate_client.py
+++ b/sage/gateway/being_gate_client.py
@@ -100,6 +100,67 @@ def pr_review_signature(member_id: str, action_id: Optional[str], being_lct: Opt
     return "\n".join(lines)
 
 
+# The test targets a being may name, and the command each one becomes (#M0, PRD
+# "Beings improve their own harness"). An ALLOW-LIST, not a grammar: `check` exists so a
+# being can verify a claim about its own harness, and the smallest thing that does that is
+# a fixed set of suites plus a single node id inside them. Anything wider is a shell with a
+# friendly name, which is the one thing the bounded registry exists to prevent.
+CHECK_TARGETS = {
+    "gateway": "sage/gateway/tests/",
+    "irp": "sage/irp/tests/",
+}
+
+
+def _takes_ctx(fn) -> bool:
+    """Whether a registry `compose` accepts the client's context as a second argument.
+    Older composes (pr_review_command) take args alone and must keep working."""
+    import inspect
+    try:
+        return len(inspect.signature(fn).parameters) >= 2
+    except (TypeError, ValueError):
+        return False
+
+
+def check_command(args: dict, ctx: Optional[dict] = None) -> str:
+    """The shell command the seat runs for a `check` intent, built from validated args.
+
+    Raises ValueError on anything the allow-list cannot represent, so a malformed target is
+    a `gate.raised` deny rather than a silent pass. `-c /dev/null` because the repo's
+    pytest.ini declares an asyncio_mode this interpreter does not have (measured: bare
+    pytest errors before collecting), and a checking organ that reports an infrastructure
+    error as a test failure would teach the being the opposite of what it asked.
+
+    THE PATHS ARE ABSOLUTE, AND THAT IS THE WHOLE POINT (measured 2026-09-07). The command
+    runs with cwd = the being's worktree, but the gate resolves a RELATIVE path against the
+    workspace it was handed — the shared checkout. So `sage/gateway/tests/` was judged at
+    `<shared>/sage/gateway/tests/`, which the being has no grant for, while the command
+    would have touched the worktree it does. The law must judge the path the command will
+    actually touch; anything else is the `_safe_path` defect again, one layer over. No
+    worktree means no check: fail closed, and say which affordance is missing.
+    """
+    import re
+    import os
+    worktree = (ctx or {}).get("worktree")
+    if not worktree:
+        raise ValueError(
+            "check needs a worktree of your own: there is nothing to run tests in, and a "
+            "relative path would be judged against a tree you do not hold (PRD M1)")
+    target = str(args.get("target", "")).strip()
+    if target in CHECK_TARGETS:
+        path = os.path.join(worktree, CHECK_TARGETS[target])
+    else:
+        # A single node id INSIDE a declared suite: "gateway::test_name". Nothing else.
+        suite, sep, node = target.partition("::")
+        if not sep or suite not in CHECK_TARGETS:
+            raise ValueError(
+                f"check 'target' must be one of {sorted(CHECK_TARGETS)} or "
+                f"'<suite>::<test_name>'; got {target!r}")
+        if not re.fullmatch(r"[A-Za-z0-9_]+", node):
+            raise ValueError(f"check test name must be a bare identifier; got {node!r}")
+        path = f"{os.path.join(worktree, CHECK_TARGETS[suite])} -k {node}"
+    return f"python3 -m pytest -q -c /dev/null --rootdir={worktree} {path}"
+
+
 _REGISTRY = {
     "peer_ask":       dict(tool="peer_ask",     path_args=(),       cmd_arg=None),
     "witness":        dict(tool="witness",      path_args=(),       cmd_arg=None),
@@ -113,6 +174,14 @@ _REGISTRY = {
     # a being holds no reviewer role, so the comment never counts toward merge.
     "pr_review":      dict(tool="pr_review",    path_args=(),       cmd_arg=None,
                            compose=pr_review_command),
+    # check: RUN a test suite in the being's own worktree and read the result. The first
+    # organ, and the ordering is argued from measurement (PRD §2): given only a diff this
+    # being asserted a compile error that did not exist; given the same diff plus a real
+    # test result it made zero false claims. Composed like pr_review — the being names a
+    # target from an allow-list, the SEAT builds the command, the law judges THAT, and the
+    # being never holds a shell. A failing check is a first-class result, not an error.
+    "check":          dict(tool="check",       path_args=(),       cmd_arg=None,
+                           compose=check_command),
     # Long-term semantic memory (membot brain cartridge, the being's own): recall is
     # observational; remember is consequential but passes local law under ANY grant
     # (paths=()), and that is not because it is "classed with memory_write" (which the
@@ -141,7 +210,7 @@ _REGISTRY = {
 # consequential acts must not proceed without it (fail-closed).
 _OBSERVATIONAL = frozenset({"witness", "memory_read", "recall", "appeal"})
 _CONSEQUENTIAL = frozenset({"peer_ask", "memory_write", "channel_egress", "mesh", "pr_review",
-                            "remember", "request_scope"})
+                            "remember", "request_scope", "check"})
 
 # Native-tool schema for the bounded registry — what the being is offered.
 _TOOL_SCHEMAS = {
@@ -165,6 +234,12 @@ _TOOL_SCHEMAS = {
                   "would change, with file and line references where you can.",
                   {"repo": "owner/name, e.g. dp-web4/SAGE", "number": "the PR number",
                    "body": "your review, in markdown"}, ["repo", "number", "body"]),
+    "check": ("Run a test suite in your own worktree and read the result. This is how you "
+              "find out whether something you believe about your harness is true, instead of "
+              "asserting it. A failure is a real answer, not a problem.",
+              {"target": "'gateway' or 'irp' for a whole suite, or '<suite>::<test_name>' "
+                         "for one test, e.g. 'gateway::test_relative_memory_path'"},
+              ["target"]),
     "recall": ("Search your long-term memory (semantic search over everything you have "
                "remembered). Use it before deciding what to do; use it when something "
                "feels familiar.",
@@ -304,10 +379,13 @@ class BeingGateClient:
     """One per being. Governs every intent through the real hestia law, fail-closed."""
 
     def __init__(self, member_id: str, identity_path: str, workspace: str,
+                 worktree: Optional[str] = None,
                  dispatcher: "Optional[Dispatcher]" = None,
                  host_session_id: Optional[str] = None):
         self.member_id = member_id
         self.workspace = workspace
+        # the being's own worktree; composed commands name paths inside it
+        self.worktree = worktree
         # The being's memory root: the instance dir that holds its identity. Relative
         # memory paths the being emits are rooted here (see _normalize).
         self.memory_root = os.path.dirname(os.path.abspath(os.path.expanduser(identity_path)))
@@ -386,11 +464,12 @@ class BeingGateClient:
         command = intent.args.get(spec["cmd_arg"]) if spec["cmd_arg"] else None
         compose = spec.get("compose")
         if compose is not None:
+            ctx = {"worktree": getattr(self, "worktree", None)}
             # a COMPOSED verb: the seat builds the exact outward act (a shell line) from the
             # being's args, and THAT is what the law judges. Bad args raise here and gate()
             # turns that into a deny (gate.raised), never a silent pass. The being never
             # fills a command; the registry never carries a cmd_arg for a composed verb.
-            command = compose(intent.args)
+            command = compose(intent.args, ctx) if _takes_ctx(compose) else compose(intent.args)
         return self._core.NormalizedEvent(
             tool=spec["tool"], paths=paths, command=command,
             cwd=self.workspace, raw={"effector": intent.effector, **intent.args},

--- a/sage/gateway/being_gate_client.py
+++ b/sage/gateway/being_gate_client.py
@@ -121,6 +121,37 @@ def _takes_ctx(fn) -> bool:
         return False
 
 
+def check_argv(args: dict, ctx: Optional[dict] = None) -> List[str]:
+    """The canonical argv for ``check`` after validating its bounded target."""
+    import re
+    import os
+    worktree = (ctx or {}).get("worktree")
+    if not worktree:
+        raise ValueError(
+            "check needs a worktree of your own: there is nothing to run tests in, and a "
+            "relative path would be judged against a tree you do not hold (PRD M1)")
+    worktree = os.path.realpath(os.path.expanduser(str(worktree)))
+    target = str(args.get("target", "")).strip()
+    node = None
+    if target in CHECK_TARGETS:
+        suite = target
+    else:
+        # A single node id INSIDE a declared suite: "gateway::test_name". Nothing else.
+        suite, sep, node = target.partition("::")
+        if not sep or suite not in CHECK_TARGETS:
+            raise ValueError(
+                f"check 'target' must be one of {sorted(CHECK_TARGETS)} or "
+                f"'<suite>::<test_name>'; got {target!r}")
+        if not re.fullmatch(r"[A-Za-z0-9_]+", node):
+            raise ValueError(f"check test name must be a bare identifier; got {node!r}")
+    path = os.path.join(worktree, CHECK_TARGETS[suite])
+    argv = ["python3", "-m", "pytest", "-q", "-c", "/dev/null",
+            f"--rootdir={worktree}", path]
+    if node is not None:
+        argv.extend(("-k", node))
+    return argv
+
+
 def check_command(args: dict, ctx: Optional[dict] = None) -> str:
     """The shell command the seat runs for a `check` intent, built from validated args.
 
@@ -138,27 +169,8 @@ def check_command(args: dict, ctx: Optional[dict] = None) -> str:
     actually touch; anything else is the `_safe_path` defect again, one layer over. No
     worktree means no check: fail closed, and say which affordance is missing.
     """
-    import re
-    import os
-    worktree = (ctx or {}).get("worktree")
-    if not worktree:
-        raise ValueError(
-            "check needs a worktree of your own: there is nothing to run tests in, and a "
-            "relative path would be judged against a tree you do not hold (PRD M1)")
-    target = str(args.get("target", "")).strip()
-    if target in CHECK_TARGETS:
-        path = os.path.join(worktree, CHECK_TARGETS[target])
-    else:
-        # A single node id INSIDE a declared suite: "gateway::test_name". Nothing else.
-        suite, sep, node = target.partition("::")
-        if not sep or suite not in CHECK_TARGETS:
-            raise ValueError(
-                f"check 'target' must be one of {sorted(CHECK_TARGETS)} or "
-                f"'<suite>::<test_name>'; got {target!r}")
-        if not re.fullmatch(r"[A-Za-z0-9_]+", node):
-            raise ValueError(f"check test name must be a bare identifier; got {node!r}")
-        path = f"{os.path.join(worktree, CHECK_TARGETS[suite])} -k {node}"
-    return f"python3 -m pytest -q -c /dev/null --rootdir={worktree} {path}"
+    import shlex
+    return shlex.join(check_argv(args, ctx))
 
 
 _REGISTRY = {
@@ -253,8 +265,9 @@ _TOOL_SCHEMAS = {
     # the daemon reads plugin_id/role/path/reason only, and a grant is a `path:<p>` entry
     # in in_scope that rules mrh.path for reads and writes alike. Offering a mode would be
     # a choice the law cannot honour.
-    "request_scope": ("Ask the operator for reach you do not have, after a refusal. A grant "
-                      "is reach on that path, read and write alike. Say why. A human decides; "
+    "request_scope": ("Ask the operator for reach you do not have, after a refusal. SAGE "
+                      "can read an external granted path, but keeps external writes disabled "
+                      "until being-code execution has its own principal. Say why. A human decides; "
                       "no answer within the window is a refusal. A live grant dies with the "
                       "daemon; only a standing grant persists.",
                       {"path": "absolute path you want reach to",
@@ -336,6 +349,9 @@ class GatewayVerdict:
     # 2026-09-05 that a shared-context read grant "cannot be used at all" because the local
     # dispatcher confined memory_read to the instance dir before hestia's gate was consulted.
     granted: tuple = ()
+    # For a composed effector, this is the exact command the law judged. Dispatch executes
+    # this value rather than independently rebuilding a lookalike command.
+    command: Optional[str] = None
 
     @property
     def blocks(self) -> bool:
@@ -385,7 +401,8 @@ class BeingGateClient:
         self.member_id = member_id
         self.workspace = workspace
         # the being's own worktree; composed commands name paths inside it
-        self.worktree = worktree
+        self.worktree = (os.path.realpath(os.path.expanduser(str(worktree)))
+                         if worktree else None)
         # The being's memory root: the instance dir that holds its identity. Relative
         # memory paths the being emits are rooted here (see _normalize).
         self.memory_root = os.path.dirname(os.path.abspath(os.path.expanduser(identity_path)))
@@ -470,9 +487,15 @@ class BeingGateClient:
             # turns that into a deny (gate.raised), never a silent pass. The being never
             # fills a command; the registry never carries a cmd_arg for a composed verb.
             command = compose(intent.args, ctx) if _takes_ctx(compose) else compose(intent.args)
+        raw = {"effector": intent.effector, **intent.args}
+        if command is not None:
+            # Society safety consumes raw/tool_input rather than NormalizedEvent.command.
+            # Carry the composed act there too; otherwise stage 1 and stage 2 judge
+            # different objects.
+            raw["command"] = command
         return self._core.NormalizedEvent(
             tool=spec["tool"], paths=paths, command=command,
-            cwd=self.workspace, raw={"effector": intent.effector, **intent.args},
+            cwd=self.workspace, raw=raw,
         )
 
     # -- gate one intent (intent -> verdict), fail-closed --------------------
@@ -492,7 +515,13 @@ class BeingGateClient:
                                     default_role="role:constellation:member",
                                     host_agent=getattr(self, "_host_agent", "sage-raising"),
                                     client_name=f"sage-{self.member_id}-gate")
-                ge = sg.GateEvent(tool=tool, tool_input=dict(intent.args), cwd=self.workspace,
+                tool_input = dict(intent.args)
+                if getattr(ev, "command", None) is not None:
+                    # The single gate derives NormalizedEvent.command from tool_input. Merely
+                    # calling _normalize above validates the compose but does not make the
+                    # gate judge it; the composed command must cross this seam explicitly.
+                    tool_input["command"] = ev.command
+                ge = sg.GateEvent(tool=tool, tool_input=tool_input, cwd=self.workspace,
                                   session_id=getattr(self, "host_session_id", None),
                                   raw={"effector": intent.effector, **intent.args})
                 d = sg.decide(ge, gp)
@@ -500,7 +529,8 @@ class BeingGateClient:
                 dec = d.decision if (available and d.decision in ("allow", "warn", "deny")) else "deny"
                 rule = d.rule or ("" if available else "gate.no_verdict")
                 return GatewayVerdict(dec, rule, getattr(d, "reason", "") or ("ok" if dec != "deny" else ""),
-                                      innate=False, stage="single-gate")
+                                      innate=False, stage="single-gate",
+                                      command=getattr(ev, "command", None))
             except Exception as e:  # a gate that raises is a refused act, never an ungoverned one
                 return GatewayVerdict("deny", "gate.raised", innate=True, stage="single-gate",
                                       reason=f"{type(e).__name__}: {e}")
@@ -567,7 +597,7 @@ class BeingGateClient:
                                           reason=f"society-safety failed ({type(e).__name__}); consequential act denied")
                 # observational: local law already allowed, soft-pass
         return GatewayVerdict(v.decision, v.rule, v.reason or "ok", v.innate, stage="local-law",
-                              granted=granted)
+                              granted=granted, command=getattr(ev, "command", None))
 
     # -- the F1a seam: gate, then dispatch, then consume the result ----------
     def dispatch(self, intent: BeingIntent) -> ResultEnvelope:

--- a/sage/gateway/being_gate_client.py
+++ b/sage/gateway/being_gate_client.py
@@ -345,20 +345,30 @@ def _home_hint(intent: "BeingIntent", dispatcher) -> str:
 
 
 def _granted_roots(core, policy, workspace: str) -> tuple:
-    """The absolute path roots a resolved policy grants ("path:<abs>" scopes), via the
-    core's own resolver when it has one. () when there is no policy or no path scope."""
+    """``((abs_root, recursive), ...)`` for every `path:` scope a resolved policy grants.
+
+    REACH TRAVELS WITH THE ROOT (hestia #1002; GPT review of #55/#56). This used to return
+    bare roots via `_scope_parts(...)[1]`, and the dispatcher then admitted `p == root OR
+    root in p.parents` — so an EXACT hestia grant on /x became recursive /x/** inside SAGE's
+    own defense-in-depth layer, wider than the law that produced it. Now the pair is kept:
+    the core's `_scope_roots_with_reach` when it has one (post-#1002), else parsed here from
+    the `/**` spelling, so an older core still yields exact-by-default rather than a guess."""
     if policy is None:
         return ()
     try:
         scopes = list(getattr(policy, "scope", ()) or ())
-        parts = getattr(core, "_scope_parts", None)
-        if parts is not None:
-            return tuple(parts(scopes, workspace)[1])
-        roots = []
+        with_reach = getattr(core, "_scope_roots_with_reach", None)
+        if with_reach is not None:
+            return tuple((str(r), bool(rec)) for r, rec in with_reach(scopes, workspace))
+        out = []
         for sc in scopes:
             if isinstance(sc, str) and sc.startswith("path:"):
-                roots.append(os.path.realpath(os.path.expanduser(sc[5:])))
-        return tuple(roots)
+                raw = sc[5:]
+                rec = raw.endswith("/**")
+                if rec:
+                    raw = raw[:-3]
+                out.append((os.path.realpath(os.path.expanduser(raw)), rec))
+        return tuple(out)
     except Exception:
         return ()
 

--- a/sage/gateway/governed_turn.py
+++ b/sage/gateway/governed_turn.py
@@ -170,11 +170,15 @@ def build_client(member: str, instance: Path, model: str, workspace: str,
     dispatcher = None if gate_only else HestiaF1aDispatcher(
         member, memory_root=str(instance), publish_fn=publish_fn,
         host_session_id=host_session_id, being_lct=being_lct_for(member, workspace),
-        peer_aliases=instance_config(instance).get("peer_aliases") or None)
+        peer_aliases=instance_config(instance).get("peer_aliases") or None,
+        # The being's own git worktree, for `check` and (M1) for editing code. Read from
+        # instance.json so it is a per-being fact beside the being, not a launcher flag.
+        worktree=instance_config(instance).get("worktree") or None)
     client = BeingGateClient(member_id=member,
                              identity_path=str(instance / "identity.json"),
                              workspace=workspace, dispatcher=dispatcher,
-                             host_session_id=host_session_id)
+                             host_session_id=host_session_id,
+                             worktree=instance_config(instance).get("worktree") or None)
     # Reasoning models (empero Qwen3.8 distills etc.) only emit structured tool calls
     # with `think` on — off, they narrate a bracketed placeholder instead of acting
     # (measured on Sprout 2026-08-28 and again on the first governed turn, 2026-09-03:

--- a/sage/gateway/governed_turn.py
+++ b/sage/gateway/governed_turn.py
@@ -165,20 +165,33 @@ def build_client(member: str, instance: Path, model: str, workspace: str,
     publish_fn = None
     if forum_dir and os.path.isdir(forum_dir):
         publish_fn = make_forum_publisher(forum_dir, member)
+    cfg = instance_config(instance)
+    declared_embodiment = cfg.get("active_embodiment") or {}
+    embodiment = {
+        # The model argument is what this process actually asked the runner to load. Keep
+        # it even when an older instance lacks the canonical declaration, and say whether
+        # the declaration agrees instead of silently substituting one for the other.
+        "running_tag": model,
+        "declared_running_tag": declared_embodiment.get("running_tag"),
+        "declaration_as_of": declared_embodiment.get("as_of"),
+        "source": declared_embodiment.get("source"),
+        "matches_declaration": (declared_embodiment.get("running_tag") == model
+                                if declared_embodiment.get("running_tag") else None),
+    }
     # gate_only: the law still judges every intent; an allowed one comes back
     # `pending` instead of executing. For seeing verdicts before anything leaves.
     dispatcher = None if gate_only else HestiaF1aDispatcher(
         member, memory_root=str(instance), publish_fn=publish_fn,
         host_session_id=host_session_id, being_lct=being_lct_for(member, workspace),
-        peer_aliases=instance_config(instance).get("peer_aliases") or None,
+        peer_aliases=cfg.get("peer_aliases") or None,
         # The being's own git worktree, for `check` and (M1) for editing code. Read from
         # instance.json so it is a per-being fact beside the being, not a launcher flag.
-        worktree=instance_config(instance).get("worktree") or None)
+        worktree=cfg.get("worktree") or None, embodiment=embodiment)
     client = BeingGateClient(member_id=member,
                              identity_path=str(instance / "identity.json"),
                              workspace=workspace, dispatcher=dispatcher,
                              host_session_id=host_session_id,
-                             worktree=instance_config(instance).get("worktree") or None)
+                             worktree=cfg.get("worktree") or None)
     # Reasoning models (empero Qwen3.8 distills etc.) only emit structured tool calls
     # with `think` on — off, they narrate a bracketed placeholder instead of acting
     # (measured on Sprout 2026-08-28 and again on the first governed turn, 2026-09-03:

--- a/sage/gateway/heartbeat.py
+++ b/sage/gateway/heartbeat.py
@@ -39,7 +39,7 @@ from pathlib import Path
 HOME_FILES = ("todo.md", "journal.md", "notes", "scratch")
 
 EXPLORE_TOOLS = ["recall", "remember", "memory_read", "memory_write", "witness",
-                 "request_scope", "appeal", "peer_ask", "mesh"]
+                 "request_scope", "appeal", "peer_ask", "mesh", "check"]
 REFLECT_TOOLS = ["memory_write", "remember", "memory_read"]
 
 POSTURE_FILE = Path(__file__).with_name("BEING_POSTURE.md")
@@ -56,6 +56,7 @@ HEAD = "You are {name}, a SAGE being on the {machine} machine, member id {member
 AFFORDANCES = """## What you have this beat
 - Your home is your instance directory. Relative paths are inside it: scratch/ (write anything, no one edits it), notes/, todo.md, journal.md. memory_read / memory_write work there.
 - Long-term memory: recall (search) and remember (store). Use recall early; remember what a future you would want.
+- check: RUN a test suite in your own worktree and read the result ('gateway', 'irp', or '<suite>::<test_name>'). This is how you find out whether something you believe about your own code is true instead of asserting it. A FAILING test is a real answer, not a problem.
 - witness: record something you noticed or did in the shared chain.
 - request_scope: after a refusal, ask the operator for reach on a path (a grant is read and write alike) and say why. A human decides, asynchronously.
 - appeal: after a refusal you believe was wrong, appeal it with the deny hash shown on the refusal and a reason. A peer or the operator rules; either way it is witnessed. Not for a refusal you agree with.

--- a/sage/gateway/heartbeat.py
+++ b/sage/gateway/heartbeat.py
@@ -58,7 +58,7 @@ AFFORDANCES = """## What you have this beat
 - Long-term memory: recall (search) and remember (store). Use recall early; remember what a future you would want.
 - check: RUN a test suite in your own worktree and read the result ('gateway', 'irp', or '<suite>::<test_name>'). This is how you find out whether something you believe about your own code is true instead of asserting it. A FAILING test is a real answer, not a problem.
 - witness: record something you noticed or did in the shared chain.
-- request_scope: after a refusal, ask the operator for reach on a path (a grant is read and write alike) and say why. A human decides, asynchronously.
+- request_scope: after a refusal, ask the operator for reach on a path. SAGE can read an external granted path, but keeps external writes disabled until being-code execution has its own principal. Say why. A human decides, asynchronously.
 - appeal: after a refusal you believe was wrong, appeal it with the deny hash shown on the refusal and a reason. A peer or the operator rules; either way it is witnessed. Not for a refusal you agree with.
 - peer_ask / mesh: reach other beings and seats. These are acts of consequence: they are judged, and may be refused with a reason.
 

--- a/sage/gateway/hestia_dispatch.py
+++ b/sage/gateway/hestia_dispatch.py
@@ -86,8 +86,12 @@ class HestiaF1aDispatcher:
                  membot_endpoint: str = "http://127.0.0.1:8010/mcp",
                  membot_cartridge: Optional[str] = None,
                  seed_path: Optional[str] = None,
-                 peer_aliases: Optional[Dict[str, str]] = None):
+                 peer_aliases: Optional[Dict[str, str]] = None,
+                 # the being's OWN git worktree: where `check` runs and where it may
+                 # edit code. Never the shared checkout (PRD M1).
+                 worktree: Optional[str] = None):
         self.plugin_id = plugin_id
+        self.worktree = worktree
         # the being's names for peers -> hub roster names (e.g. legion-being -> legion-sage,
         # the name legion-being joined under on 2026-09-05); env SAGE_PEER_ALIASES="a=b,c=d"
         self.peer_aliases = dict(peer_aliases or {})
@@ -438,6 +442,62 @@ class HestiaF1aDispatcher:
                               result={"request_id": out.get("request_id"), "status": out.get("status"),
                                       "path": path,
                                       "next": out.get("next"), "on_timeout": out.get("on_timeout")})
+
+    # -- check: the being runs a test and reads the answer (PRD M0) --------------
+    def _do_check(self, intent: BeingIntent) -> ResultEnvelope:
+        """Run a declared test target in the being's OWN worktree and return the result.
+
+        Only ever reached on an intent the gate ALLOWED as the exact pytest command below.
+        A FAILING SUITE IS ok=True: the act succeeded and the answer is "it fails". Making
+        a red suite an error envelope would teach the being that checking is dangerous,
+        which is the opposite of what this organ is for — so `passed` carries the verdict
+        and `ok` carries only whether the check ran.
+        """
+        import shlex
+        import subprocess
+        from sage.gateway.being_gate_client import check_command
+        if not self.worktree or not os.path.isdir(self.worktree):
+            return ResultEnvelope(ok=False, pending=True,
+                                  note="check needs a worktree of your own; none is configured "
+                                       "on this seat (PRD M1)")
+        # Rebuild the SAME command the gate judged — same function, same context. Composing
+        # it differently here would mean the law ruled on one command and the seat ran
+        # another, which is the whole failure this organ exists to make impossible.
+        try:
+            cmd = check_command(intent.args, {"worktree": self.worktree})
+        except ValueError as e:
+            return ResultEnvelope(ok=False, error=str(e))
+        target = str(intent.args.get("target", "")).strip()
+        begin = self._call("hestia_begin_action", {"tool_name": "check", "target": target})
+        err = _hestia_error(begin)
+        if err:
+            return ResultEnvelope(ok=False, error=err)
+        action_id = begin.get("actionId")
+        try:
+            proc = subprocess.run(shlex.split(cmd), cwd=self.worktree, text=True,
+                                  capture_output=True, timeout=600)
+            passed = proc.returncode == 0
+            out = ((proc.stdout or "") + (proc.stderr or "")).strip()
+            # The tail is where pytest puts the verdict and the failure detail; the head is
+            # progress dots. Truncate from the FRONT so a failure is never the part cut.
+            if len(out) > 3000:
+                out = "[…truncated…]\n" + out[-3000:]
+            ran, detail = True, out
+        except Exception as e:
+            ran, passed, detail = False, False, f"{type(e).__name__}: {e}"
+        try:
+            self._call("hestia_record_outcome",
+                       {"action_id": action_id, "success": ran, "magnitude": 0.0})
+        except Exception:
+            pass
+        if not ran:
+            return ResultEnvelope(ok=False, error=f"check could not run: {detail[:400]}",
+                                  witness_id=action_id)
+        return ResultEnvelope(ok=True, witness_id=action_id,
+                              result={"target": target, "passed": passed,
+                                      "verdict": "PASS" if passed else "FAIL",
+                                      "output": detail, "worktree": self.worktree,
+                                      "action_id": action_id})
 
     # -- channel_egress: not built on the daemon ----------------------------
     def _do_channel_egress(self, intent: BeingIntent) -> ResultEnvelope:

--- a/sage/gateway/hestia_dispatch.py
+++ b/sage/gateway/hestia_dispatch.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
 from sage.gateway.being_gate_client import BeingIntent, GatewayVerdict, ResultEnvelope
@@ -89,9 +90,14 @@ class HestiaF1aDispatcher:
                  peer_aliases: Optional[Dict[str, str]] = None,
                  # the being's OWN git worktree: where `check` runs and where it may
                  # edit code. Never the shared checkout (PRD M1).
-                 worktree: Optional[str] = None):
+                 worktree: Optional[str] = None,
+                 embodiment: Optional[dict] = None):
         self.plugin_id = plugin_id
-        self.worktree = worktree
+        self.worktree = (os.path.realpath(os.path.expanduser(str(worktree)))
+                         if worktree else None)
+        # Runtime provenance supplied by the launcher. This is deliberately a compact
+        # public identity for the active substrate, not host/infrastructure inventory.
+        self.embodiment = dict(embodiment or {})
         # the being's names for peers -> hub roster names (e.g. legion-being -> legion-sage,
         # the name legion-being joined under on 2026-09-05); env SAGE_PEER_ALIASES="a=b,c=d"
         self.peer_aliases = dict(peer_aliases or {})
@@ -413,9 +419,9 @@ class HestiaF1aDispatcher:
 
     def _do_request_scope(self, intent: BeingIntent) -> ResultEnvelope:
         """The daemon (handler.rs::tool_request_scope @a5e18af) reads plugin_id, role, path,
-        reason; a grant is reach on the path, read AND write. There is no mode to carry: an
-        earlier `permits_read` was dropped silently by the daemon while the operator read
-        "[.., read]" on a request that, granted, gave write."""
+        reason; its law grant has no read/write mode. SAGE deliberately executes external
+        roots read-only until being-authored code has a principal isolated from the seat,
+        so the being-facing contract must describe that narrower effective affordance."""
         path = str(intent.args.get("path", "")).strip()
         reason = str(intent.args.get("reason", "")).strip()
         if not path.startswith("/"):
@@ -431,7 +437,7 @@ class HestiaF1aDispatcher:
             r = _os.path.realpath(str(root))
             if rp == r or rp.startswith(r + "/"):
                 return ResultEnvelope(ok=True, result={"status": "already_granted", "path": path, "within": r,
-                                                       "next": "you already hold reach here; read or write it directly"})
+                                                       "next": "you already hold read reach here; external writes stay disabled until principal isolation"})
         args: Dict[str, Any] = {"plugin_id": self.plugin_id, "path": path,
                                 "reason": f"[{self.plugin_id}] {reason}"}
         out = self._call("hestia_request_scope", args)
@@ -453,31 +459,55 @@ class HestiaF1aDispatcher:
         which is the opposite of what this organ is for — so `passed` carries the verdict
         and `ok` carries only whether the check ran.
         """
+        import hashlib
         import shlex
         import subprocess
-        from sage.gateway.being_gate_client import check_command
+        from sage.gateway.being_gate_client import check_argv, check_command
         if not self.worktree or not os.path.isdir(self.worktree):
             return ResultEnvelope(ok=False, pending=True,
                                   note="check needs a worktree of your own; none is configured "
                                        "on this seat (PRD M1)")
-        # Rebuild the SAME command the gate judged — same function, same context. Composing
-        # it differently here would mean the law ruled on one command and the seat ran
-        # another, which is the whole failure this organ exists to make impossible.
+        # Execute the command carried by the verdict, not a separately built lookalike.
+        # Recomposition below is an invariant check; it is not the execution authority.
         try:
-            cmd = check_command(intent.args, {"worktree": self.worktree})
+            expected = check_command(intent.args, {"worktree": self.worktree})
+            argv = check_argv(intent.args, {"worktree": self.worktree})
         except ValueError as e:
             return ResultEnvelope(ok=False, error=str(e))
+        cmd = getattr(getattr(self, "_verdict", None), "command", None)
+        if not cmd:
+            return ResultEnvelope(ok=False, error="check refused: the allow verdict did not bind "
+                                  "the composed command")
+        if cmd != expected or shlex.split(cmd) != argv:
+            return ResultEnvelope(ok=False, error="check refused: the command judged by the law "
+                                  "does not equal the command this dispatcher would execute")
         target = str(intent.args.get("target", "")).strip()
+
+        tree_before, status_before = self._worktree_revision()
+        if not tree_before.get("head") or status_before is None:
+            return ResultEnvelope(ok=False, error="check refused: the worktree revision could "
+                                  "not be established")
+        if tree_before["dirty"]:
+            return ResultEnvelope(ok=False, error="check refused: the worktree has uncommitted "
+                                  "changes, so HEAD does not identify the bytes that would run")
+        try:
+            source_before = self._test_source_identity(target, tree_before["head"])
+        except Exception as e:
+            return ResultEnvelope(ok=False, error=f"check refused: test-source identity could "
+                                  f"not be established ({type(e).__name__}: {e})")
+
         begin = self._call("hestia_begin_action", {"tool_name": "check", "target": target})
         err = _hestia_error(begin)
         if err:
             return ResultEnvelope(ok=False, error=err)
         action_id = begin.get("actionId")
         try:
-            proc = subprocess.run(shlex.split(cmd), cwd=self.worktree, text=True,
+            proc = subprocess.run(argv, cwd=self.worktree,
                                   capture_output=True, timeout=600)
             passed = proc.returncode == 0
-            out = ((proc.stdout or "") + (proc.stderr or "")).strip()
+            output_bytes = (proc.stdout or b"") + (proc.stderr or b"")
+            output_sha256 = hashlib.sha256(output_bytes).hexdigest()
+            out = output_bytes.decode("utf-8", errors="replace").strip()
             # The tail is where pytest puts the verdict and the failure detail; the head is
             # progress dots. Truncate from the FRONT so a failure is never the part cut.
             if len(out) > 3000:
@@ -493,11 +523,95 @@ class HestiaF1aDispatcher:
         if not ran:
             return ResultEnvelope(ok=False, error=f"check could not run: {detail[:400]}",
                                   witness_id=action_id)
+
+        tree_after, _status_after = self._worktree_revision()
+        try:
+            source_after = self._test_source_identity(target, tree_after.get("head"))
+        except Exception:
+            source_after = None
+        stable = tree_after == tree_before and source_after == source_before
         return ResultEnvelope(ok=True, witness_id=action_id,
                               result={"target": target, "passed": passed,
                                       "verdict": "PASS" if passed else "FAIL",
                                       "output": detail, "worktree": self.worktree,
+                                      "evidence": {
+                                          "tree": tree_before,
+                                          "command": cmd,
+                                          "argv": argv,
+                                          "test_source": source_before,
+                                          "exit_status": proc.returncode,
+                                          "output_sha256": output_sha256,
+                                          "output_bytes": len(output_bytes),
+                                          "class": "independent",
+                                          "embodiment": self.embodiment,
+                                          "stable": stable,
+                                          "state": ("pinned" if stable else
+                                                    "tree_changed_during_check"),
+                                      },
                                       "action_id": action_id})
+
+    def _git(self, *args: str) -> Optional[str]:
+        """Run one read-only git query in the check worktree."""
+        import subprocess
+        try:
+            proc = subprocess.run(("git", *args), cwd=self.worktree, text=True,
+                                  capture_output=True, timeout=15)
+            return proc.stdout.strip() if proc.returncode == 0 else None
+        except Exception:
+            return None
+
+    def _worktree_revision(self) -> tuple[dict, Optional[str]]:
+        """Return the exact committed revision and whether other bytes are present."""
+        head = self._git("rev-parse", "HEAD")
+        status = self._git("status", "--porcelain", "--untracked-files=all")
+        top = self._git("rev-parse", "--show-toplevel")
+        canonical_top = os.path.realpath(top) if top else None
+        if canonical_top != self.worktree:
+            head, status = None, None
+        return ({"head": head, "short": (head or "")[:9] or None,
+                 "dirty": None if status is None else bool(status)}, status)
+
+    def _test_source_identity(self, target: str, head: Optional[str]) -> dict:
+        """Digest the selected acceptance bar, separately from the production tree SHA.
+
+        The bar is every tracked file below the declared suite plus each tracked
+        ``conftest.py`` pytest loads on the path from the worktree root to that suite.
+        Paths and byte lengths are framed into the digest so concatenation is unambiguous.
+        """
+        import hashlib
+        from sage.gateway.being_gate_client import CHECK_TARGETS
+
+        if not head:
+            raise ValueError("missing HEAD")
+        suite = target.partition("::")[0]
+        rel_root = CHECK_TARGETS[suite].rstrip("/")
+        listed = self._git("ls-tree", "-r", "--name-only", head, "--", rel_root)
+        if listed is None:
+            raise ValueError("git could not enumerate the test source")
+        paths = [p for p in listed.splitlines() if p]
+
+        parent = Path(rel_root)
+        for ancestor in (Path("."), *parent.parents, parent):
+            candidate = (ancestor / "conftest.py").as_posix()
+            if candidate.startswith("./"):
+                candidate = candidate[2:]
+            if candidate and self._git("cat-file", "-e", f"{head}:{candidate}") is not None:
+                paths.append(candidate)
+
+        paths = sorted(set(paths))
+        if not paths:
+            raise ValueError("the selected suite has no tracked test source")
+        digest = hashlib.sha256()
+        for rel in paths:
+            data = (Path(self.worktree) / rel).read_bytes()
+            name = rel.encode("utf-8")
+            digest.update(len(name).to_bytes(8, "big")); digest.update(name)
+            digest.update(len(data).to_bytes(8, "big")); digest.update(data)
+        git_tree = self._git("rev-parse", f"{head}:{rel_root}")
+        if not git_tree:
+            raise ValueError("git could not identify the test-source tree")
+        return {"sha256": digest.hexdigest(), "git_tree": git_tree,
+                "root": rel_root, "files": len(paths)}
 
     # -- channel_egress: not built on the daemon ----------------------------
     def _do_channel_egress(self, intent: BeingIntent) -> ResultEnvelope:

--- a/sage/gateway/reference_f1a.py
+++ b/sage/gateway/reference_f1a.py
@@ -72,16 +72,41 @@ class ReferenceF1aDispatcher:
         return wid
 
     # -- path confinement (defense in depth over the gate) -------------------
-    def _safe_path(self, raw: str) -> Path:
-        # A being names its notes by a path inside its own memory ("notes/x.md"); a
-        # relative path is rooted at memory_root, never at the process cwd. Absolute
-        # paths are honoured only if they already lie inside the root (checked below).
+    def _safe_path(self, raw: str, writing: bool = False) -> Path:
+        """Resolve a being's memory path. Relative paths are rooted at memory_root, never
+        at the process cwd.
+
+        READS follow the law: memory_root plus whatever roots the verdict named as granted.
+
+        WRITES DO NOT, AND THIS IS A SECURITY BOUNDARY, NOT TIDINESS (2026-09-07).
+        `check` executes pytest inside the being's worktree, and pytest imports `conftest.py`
+        from the rootdir it is given. The moment a being can WRITE into a tree that `check`
+        EXECUTES, the bounded effector registry stops bounding the computation: a gated write
+        plus a gated execute compose into ungated arbitrary code, running as this seat's user,
+        with the vault passphrase and every key on this box in reach. Measured live: with a
+        standing grant on the worktree, `memory_write` to `<worktree>/conftest.py` was ALLOWED.
+        Nothing had to go wrong for that to be true; two correct grants were enough.
+
+        So writes stay inside the being's own home whatever the grants say. That is a stopgap
+        with a known shape: the durable answer is that being-authored code runs under a
+        principal that is not the seat (GPT review of PRD #54, point 3 — a hard prerequisite
+        for M1 write capability). Until that exists, the invariant is: THE TREE `check`
+        EXECUTES IS NOT A TREE THE BEING CAN WRITE.
+        """
         p = Path(raw).expanduser()
         if not p.is_absolute():
             p = self.memory_root / p
         p = p.resolve()
-        roots = (self.memory_root,) + tuple(getattr(self, "_extra_roots", ()) or ())
+        roots = (self.memory_root,)
+        if not writing:
+            roots = roots + tuple(getattr(self, "_extra_roots", ()) or ())
         if not any(p == r or r in p.parents for r in roots):
+            if writing and any(p == r or r in p.parents
+                               for r in (getattr(self, "_extra_roots", ()) or ())):
+                raise ValueError(
+                    f"writes stay inside your own home ({self.memory_root}); {p} is readable "
+                    "to you but not writable, because a tree you can write is a tree `check` "
+                    "would then execute. Ask for the affordance rather than the path")
             raise ValueError(f"path escapes the being's memory root and its grants: {p}")
         return p
 
@@ -104,7 +129,7 @@ class ReferenceF1aDispatcher:
     def _do_memory_write(self, intent: BeingIntent) -> ResultEnvelope:
         if not str(intent.args.get("path", "")).strip():
             return ResultEnvelope(ok=False, error="memory_write needs a 'path' (relative paths are inside your home)")
-        p = self._safe_path(intent.args["path"])
+        p = self._safe_path(intent.args["path"], writing=True)
         content = str(intent.args.get("content", ""))
         p.parent.mkdir(parents=True, exist_ok=True)
         with open(p, "a") as f:

--- a/sage/gateway/reference_f1a.py
+++ b/sage/gateway/reference_f1a.py
@@ -45,8 +45,16 @@ class ReferenceF1aDispatcher:
 
     # -- the Dispatcher contract ---------------------------------------------
     def __call__(self, intent: BeingIntent, verdict: GatewayVerdict) -> ResultEnvelope:
-        # confinement = the home + whatever the law just consulted as granted for THIS verdict
-        self._extra_roots = tuple(Path(r).resolve() for r in (getattr(verdict, "granted", ()) or ()))
+        # confinement = the home + whatever the law just consulted as granted for THIS verdict,
+        # WITH REACH: each entry is (root, recursive). A bare string (an older gate client)
+        # is read as EXACT — the default hestia #1002 chose — never widened by guessing.
+        roots = []
+        for g in (getattr(verdict, "granted", ()) or ()):
+            if isinstance(g, (tuple, list)) and len(g) == 2:
+                roots.append((Path(str(g[0])).resolve(), bool(g[1])))
+            else:
+                roots.append((Path(str(g)).resolve(), False))
+        self._extra_roots = tuple(roots)
         handler = getattr(self, f"_do_{intent.effector}", None)
         if handler is None:
             # a consequential network act the reference won't run — real F1a's job
@@ -97,12 +105,18 @@ class ReferenceF1aDispatcher:
         if not p.is_absolute():
             p = self.memory_root / p
         p = p.resolve()
-        roots = (self.memory_root,)
+        # (root, recursive) pairs. The home is always a subtree — it is the being's own.
+        roots = [(self.memory_root, True)]
         if not writing:
-            roots = roots + tuple(getattr(self, "_extra_roots", ()) or ())
-        if not any(p == r or r in p.parents for r in roots):
-            if writing and any(p == r or r in p.parents
-                               for r in (getattr(self, "_extra_roots", ()) or ())):
+            roots += list(getattr(self, "_extra_roots", ()) or ())
+        def _covered(path: Path, root: Path, recursive: bool) -> bool:
+            # exact: the root itself; recursive: the root and everything under it.
+            # Separator-aware by construction (Path.parents): /a never fronts for /ab.
+            return path == root or (recursive and root in path.parents)
+
+        if not any(_covered(p, r, rec) for r, rec in roots):
+            if writing and any(_covered(p, r, rec)
+                               for r, rec in (getattr(self, "_extra_roots", ()) or ())):
                 raise ValueError(
                     f"writes stay inside your own home ({self.memory_root}); {p} is readable "
                     "to you but not writable, because a tree you can write is a tree `check` "

--- a/sage/gateway/tests/test_being_gate_client.py
+++ b/sage/gateway/tests/test_being_gate_client.py
@@ -23,7 +23,7 @@ def _client(mech):
     c._profile = object()
     c._mech = mech
     c._core = SimpleNamespace(
-        NormalizedEvent=lambda **kw: SimpleNamespace(raw=kw.get("raw", {}), tool=kw.get("tool")),
+        NormalizedEvent=lambda **kw: SimpleNamespace(**kw),
         evaluate=lambda ev, prof, ws, policy=None: SimpleNamespace(
             decision="allow", rule="", reason="ok", innate=False),
     )
@@ -114,7 +114,7 @@ def test_relative_memory_path_is_judged_at_the_being_memory_root():
     c = _client(_allows)
     c.memory_root = "/tmp/being-home"
     c._core = SimpleNamespace(
-        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(raw=kw.get("raw", {}), tool=kw.get("tool")),
+        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(**kw),
         evaluate=lambda ev, prof, ws, policy=None: SimpleNamespace(
             decision="allow", rule="", reason="ok", innate=False),
     )
@@ -131,7 +131,7 @@ def test_pr_review_is_judged_as_the_gh_command_the_seat_runs():
     seen = {}
     c = _client(_allows)
     c._core = SimpleNamespace(
-        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(raw=kw.get("raw", {}), tool=kw.get("tool")),
+        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(**kw),
         evaluate=lambda ev, prof, ws, policy=None: SimpleNamespace(
             decision="allow", rule="", reason="ok", innate=False),
     )
@@ -198,6 +198,22 @@ def test_single_gate_decides_and_client_does_not_resequence():
     assert prof["member_id"] == "test-being" and prof["host_agent"] == "test-harness"
 
 
+def test_single_gate_judges_and_returns_the_composed_check_command():
+    """Validation is not governance: the composed command must be inside GateEvent or the
+    single gate sees only the being's friendly target label."""
+    import shlex
+    from sage.gateway.being_gate_client import check_command
+    c, calls = _sg_client("allow")
+    c.worktree = "/tmp/being worktree"
+    v = c.gate(BeingIntent("check", {"target": "gateway::test_thing"}))
+    expected = check_command({"target": "gateway::test_thing"},
+                             {"worktree": "/tmp/being worktree"})
+    assert calls[0][0]["tool_input"]["command"] == expected
+    assert v.command == expected
+    assert shlex.split(expected)[-2:] == ["-k", "test_thing"]
+    assert shlex.split(expected)[-3] == "/tmp/being worktree/sage/gateway/tests/"
+
+
 def test_single_gate_deny_and_no_verdict_map_fail_closed():
     assert _sg_client("deny", "mrh.path")[0].gate(WRITE).rule == "mrh.path"
     v = _sg_client("allow", available=False)[0].gate(WRITE)
@@ -229,7 +245,7 @@ def test_request_scope_path_is_not_judged_under_mrh_path():
     seen = {}
     c = _client(_allows)
     c._core = SimpleNamespace(
-        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(raw=kw.get("raw", {}), tool=kw.get("tool")),
+        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(**kw),
         evaluate=lambda ev, prof, ws, policy=None: SimpleNamespace(
             decision="allow", rule="", reason="ok", innate=False),
     )
@@ -249,7 +265,8 @@ def test_request_scope_schema_offers_no_mode():
     params = spec["function"]["parameters"]
     assert set(params["properties"]) == {"path", "reason"}, params
     assert params["required"] == ["path", "reason"]
-    assert "read and write" in spec["function"]["description"]
+    assert "external writes disabled" in spec["function"]["description"]
+    assert "read and write alike" not in spec["function"]["description"]
 
 def test_registry_offers_appeal_as_an_observational_effector():
     from sage.gateway.being_gate_client import _REGISTRY, _OBSERVATIONAL, ollama_tools
@@ -308,19 +325,26 @@ def test_check_is_judged_as_the_pytest_command_the_seat_runs():
     c = _client(_allows)
     c.worktree = "/tmp/being-wt"
     c._core = SimpleNamespace(
-        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(raw=kw.get("raw", {}), tool=kw.get("tool")),
+        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(**kw),
         evaluate=lambda ev, prof, ws, policy=None: SimpleNamespace(
             decision="allow", rule="", reason="ok", innate=False),
     )
-    c.gate(BeingIntent("check", {"target": "gateway"}))
+    v = c.gate(BeingIntent("check", {"target": "gateway"}))
     # ABSOLUTE, inside the worktree: the law must judge the path the command touches, not
     # the same relative path resolved against the shared checkout (measured 2026-09-07).
     assert seen["command"] == (
         "python3 -m pytest -q -c /dev/null --rootdir=/tmp/being-wt "
         "/tmp/being-wt/sage/gateway/tests/"), seen["command"]
     assert seen["tool"] == "check"
+    assert v.command == seen["command"]
     c.gate(BeingIntent("check", {"target": "gateway::test_thing"}))
     assert seen["command"].endswith("/tmp/being-wt/sage/gateway/tests/ -k test_thing")
+    # Seat-chosen paths with spaces stay one argv item; command and execution identity do
+    # not depend on a whitespace-free checkout name.
+    c.worktree = "/tmp/being worktree"
+    c.gate(BeingIntent("check", {"target": "gateway"}))
+    import shlex
+    assert shlex.split(seen["command"])[-1] == "/tmp/being worktree/sage/gateway/tests/"
     # no worktree is a deny, never a command judged against somebody else's tree
     c.worktree = None
     v = c.gate(BeingIntent("check", {"target": "gateway"}))

--- a/sage/gateway/tests/test_being_gate_client.py
+++ b/sage/gateway/tests/test_being_gate_client.py
@@ -298,3 +298,41 @@ if __name__ == "__main__":
         if name.startswith("test_") and callable(fn):
             fn(); n += 1; print(f"PASS {name}")
     print(f"\n{n} passed")
+
+
+def test_check_is_judged_as_the_pytest_command_the_seat_runs():
+    """check reaches the law as the exact command, and the allow-list is the whole grammar:
+    a being can name a declared suite or one test inside it, and nothing else."""
+    from sage.gateway.being_gate_client import check_command
+    seen = {}
+    c = _client(_allows)
+    c.worktree = "/tmp/being-wt"
+    c._core = SimpleNamespace(
+        NormalizedEvent=lambda **kw: seen.update(kw) or SimpleNamespace(raw=kw.get("raw", {}), tool=kw.get("tool")),
+        evaluate=lambda ev, prof, ws, policy=None: SimpleNamespace(
+            decision="allow", rule="", reason="ok", innate=False),
+    )
+    c.gate(BeingIntent("check", {"target": "gateway"}))
+    # ABSOLUTE, inside the worktree: the law must judge the path the command touches, not
+    # the same relative path resolved against the shared checkout (measured 2026-09-07).
+    assert seen["command"] == (
+        "python3 -m pytest -q -c /dev/null --rootdir=/tmp/being-wt "
+        "/tmp/being-wt/sage/gateway/tests/"), seen["command"]
+    assert seen["tool"] == "check"
+    c.gate(BeingIntent("check", {"target": "gateway::test_thing"}))
+    assert seen["command"].endswith("/tmp/being-wt/sage/gateway/tests/ -k test_thing")
+    # no worktree is a deny, never a command judged against somebody else's tree
+    c.worktree = None
+    v = c.gate(BeingIntent("check", {"target": "gateway"}))
+    assert v.decision == "deny" and v.rule == "gate.raised", v
+    c.worktree = "/tmp/being-wt"
+    # anything the allow-list cannot represent is a deny, never a shell
+    for bad in ("; rm -rf /", "sage/", "gateway::a b", "gateway::../x", "", "other"):
+        v = c.gate(BeingIntent("check", {"target": bad}))
+        assert v.decision == "deny" and v.rule == "gate.raised", (bad, v)
+    for bad in ({"target": "gateway::a;b"}, {"target": "irp::"}):
+        try:
+            check_command(bad, {"worktree": "/tmp/being-wt"})
+            assert False, bad
+        except ValueError:
+            pass

--- a/sage/gateway/tests/test_being_gate_client.py
+++ b/sage/gateway/tests/test_being_gate_client.py
@@ -303,9 +303,14 @@ def test_granted_roots_come_from_the_policy_scope():
     class Pol: scope = ("path:/tmp/being-home", "repo:sage", "path:~/nope-not-real")
     class Core:
         @staticmethod
-        def _scope_parts(scopes, ws): return ((), tuple(s[5:] for s in scopes if s.startswith("path:")))
-    assert _granted_roots(Core, Pol, "/ws") == ("/tmp/being-home", "~/nope-not-real")
-    assert _granted_roots(object(), Pol, "/ws")[0].endswith("/tmp/being-home")   # fallback parser
+        def _scope_roots_with_reach(scopes, ws):
+            return tuple((s[5:].removesuffix("/**"), s.endswith("/**"))
+                         for s in scopes if s.startswith("path:"))
+    assert _granted_roots(Core, Pol, "/ws") == (("/tmp/being-home", False), ("~/nope-not-real", False))
+    fb = _granted_roots(object(), Pol, "/ws")
+    assert fb[0][0].endswith("/tmp/being-home") and fb[0][1] is False
+    class PolRec: scope = ("path:/tmp/tree/**",)
+    assert _granted_roots(object(), PolRec, "/ws") == (("/tmp/tree", True),)
     assert _granted_roots(Core, None, "/ws") == () and GatewayVerdict("allow").granted == ()
 
 

--- a/sage/gateway/tests/test_being_tool_loop.py
+++ b/sage/gateway/tests/test_being_tool_loop.py
@@ -107,7 +107,11 @@ def test_run_ollama_tool_turn_with_fake_llm():
     # the `gh` command it runs), + recall / remember (membot long-term memory) + request_scope
     # (the sanctioned answer to a deny) for the heartbeat (2026-09-03, dp: "it needs a reason
     # to look for things to do"). Widening this number is a registry decision, not a typo.
-    assert len(ollama_tools()) == 11   # + appeal (S4, 2026-09-05)
+    # + check (M0, 2026-09-07): the being RUNS a test in its own worktree and reads the
+    # result. Argued from measurement, not taste — given only a diff this being asserted
+    # a compile error that did not exist; given the same diff plus a real test result it
+    # made zero false claims (PRD_BEINGS_IMPROVE_THEIR_HARNESS §2).
+    assert len(ollama_tools()) == 12   # + check (M0, 2026-09-07)
 
     calls = {"n": 0}
 

--- a/sage/gateway/tests/test_hestia_dispatch.py
+++ b/sage/gateway/tests/test_hestia_dispatch.py
@@ -2,8 +2,11 @@
 see, so the three measured contract deltas (pointer_uri, kind enum, live session_id) and the
 r1 envelope (hestia.<code> error keys) are pinned without a running daemon."""
 import os
+import re
+import subprocess
 import sys
 import tempfile
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
 from sage.gateway.being_gate_client import BeingIntent, GatewayVerdict  # noqa: E402
@@ -105,6 +108,22 @@ def _disp(**kw):
 
 def _notify_args():
     return [a for n, a in FakeMcp.calls if n == "hestia_member_notify"][-1]
+
+
+def _clean_check_tree(test_body="def test_bar():\n    assert True\n"):
+    """A minimal committed SAGE-shaped tree for exercising the real pytest subprocess."""
+    root = Path(tempfile.mkdtemp(prefix="hd-check-"))
+    tests = root / "sage" / "gateway" / "tests"
+    tests.mkdir(parents=True)
+    (root / ".gitignore").write_text("__pycache__/\n*.pyc\n.pytest_cache/\n")
+    (root / "conftest.py").write_text("# acceptance fixture root\n")
+    (tests / "test_bar.py").write_text(test_body)
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "SAGE test"], cwd=root, check=True)
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-qm", "bar"], cwd=root, check=True)
+    return root
 
 
 def test_mesh_routes_remote_with_pointer_uri_and_session():
@@ -481,6 +500,53 @@ def test_peer_aliases_map_the_beings_name_to_the_hub_roster_name():
         assert d2._address("cbp-being") == "cbp-sage/claude-code"
     finally:
         del os.environ["SAGE_PEER_ALIASES"]
+
+
+def test_check_result_binds_command_tree_bar_output_exit_class_and_embodiment():
+    from sage.gateway.being_gate_client import check_command
+    root = _clean_check_tree()
+    embodiment = {"running_tag": "test:model", "matches_declaration": True}
+    d, _ = _disp(worktree=str(root), embodiment=embodiment)
+    intent = BeingIntent("check", {"target": "gateway::test_bar"})
+    command = check_command(intent.args, {"worktree": str(root)})
+    env = d(intent, GatewayVerdict("allow", command=command))
+    assert env.ok and env.result["passed"] and env.result["verdict"] == "PASS", env
+    evidence = env.result["evidence"]
+    assert evidence["command"] == command
+    assert evidence["argv"][-2:] == ["-k", "test_bar"]
+    assert evidence["exit_status"] == 0
+    assert re.fullmatch(r"[0-9a-f]{64}", evidence["output_sha256"])
+    assert evidence["output_bytes"] > 0
+    assert evidence["tree"]["head"] == subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=root, check=True,
+        text=True, capture_output=True).stdout.strip()
+    assert evidence["tree"]["dirty"] is False
+    assert evidence["test_source"]["files"] == 2  # selected test + loaded root conftest
+    assert re.fullmatch(r"[0-9a-f]{64}", evidence["test_source"]["sha256"])
+    assert evidence["class"] == "independent"
+    assert evidence["embodiment"] == embodiment
+    assert evidence["stable"] and evidence["state"] == "pinned"
+
+
+def test_check_refuses_unbound_command_and_dirty_tree_before_execution():
+    from sage.gateway.being_gate_client import check_command
+    root = _clean_check_tree()
+    d, _ = _disp(worktree=str(root))
+    intent = BeingIntent("check", {"target": "gateway"})
+
+    env = d(intent, GatewayVerdict("allow"))
+    assert not env.ok and "did not bind" in env.error
+
+    command = check_command(intent.args, {"worktree": str(root)})
+    env = d(intent, GatewayVerdict("allow", command=command + " --maxfail=1"))
+    assert not env.ok and "does not equal" in env.error
+
+    (root / "sage" / "gateway" / "tests" / "test_bar.py").write_text(
+        "def test_bar():\n    assert False\n")
+    FakeMcp.calls.clear()
+    env = d(intent, GatewayVerdict("allow", command=command))
+    assert not env.ok and "uncommitted changes" in env.error
+    assert not [name for name, _args in FakeMcp.calls if name == "hestia_begin_action"]
 
 
 if __name__ == "__main__":

--- a/sage/gateway/tests/test_reference_f1a.py
+++ b/sage/gateway/tests/test_reference_f1a.py
@@ -106,6 +106,34 @@ def test_confinement_follows_the_verdicts_granted_roots():
     assert not r.ok and "escapes" in (r.error or "")
 
 
+def test_a_granted_root_is_readable_but_never_writable():
+    """THE TREE `check` EXECUTES IS NOT A TREE THE BEING CAN WRITE (2026-09-07).
+
+    Measured live: with a standing grant on its worktree, the being could memory_write
+    `<worktree>/conftest.py` — which pytest imports from the rootdir `check` runs against.
+    A gated write plus a gated execute compose into ungated arbitrary code as the seat's
+    user. Nothing malfunctioned; two correct grants were enough. Reads still follow the
+    law; writes stay home.
+    """
+    disp, root = _disp()
+    other = tempfile.mkdtemp(prefix="ref-f1a-worktree-")
+    conftest = os.path.join(other, "conftest.py")
+    open(conftest, "w").write("# a tree check would execute\n")
+    granted = GatewayVerdict("allow", granted=(other,))
+
+    r = disp(BeingIntent("memory_read", {"path": conftest}), granted)
+    assert r.ok and "check would execute" in r.result, "a granted root must stay readable"
+
+    w = disp(BeingIntent("memory_write", {"path": conftest, "content": "import os"}), granted)
+    assert not w.ok, "a granted root must NOT be writable"
+    assert "writes stay inside your own home" in (w.error or ""), w.error
+    assert "import os" not in open(conftest).read(), "the write must not have landed"
+
+    # the being's own home is unaffected
+    ok = disp(BeingIntent("memory_write", {"path": "journal.md", "content": "mine"}), granted)
+    assert ok.ok, ok.error
+
+
 if __name__ == "__main__":
     n = 0
     for name, fn in sorted(globals().items()):

--- a/sage/gateway/tests/test_reference_f1a.py
+++ b/sage/gateway/tests/test_reference_f1a.py
@@ -96,13 +96,13 @@ def test_confinement_follows_the_verdicts_granted_roots():
     other = tempfile.mkdtemp(prefix="ref-f1a-granted-")
     target = os.path.join(other, "forum", "note.md")
     os.makedirs(os.path.dirname(target)); open(target, "w").write("a note from a peer")
-    r = disp(BeingIntent("memory_read", {"path": target}), GatewayVerdict("allow", granted=(other,)))
+    r = disp(BeingIntent("memory_read", {"path": target}), GatewayVerdict("allow", granted=((other, True),)))
     assert r.ok and "a note from a peer" in r.result
     r = disp(BeingIntent("memory_read", {"path": target}), _ALLOW)
     assert not r.ok and "escapes" in (r.error or "")
     # a granted root never widens to its parent or a sibling
     r = disp(BeingIntent("memory_read", {"path": os.path.join(os.path.dirname(other), "x.md")}),
-             GatewayVerdict("allow", granted=(other,)))
+             GatewayVerdict("allow", granted=((other, True),)))
     assert not r.ok and "escapes" in (r.error or "")
 
 
@@ -119,7 +119,7 @@ def test_a_granted_root_is_readable_but_never_writable():
     other = tempfile.mkdtemp(prefix="ref-f1a-worktree-")
     conftest = os.path.join(other, "conftest.py")
     open(conftest, "w").write("# a tree check would execute\n")
-    granted = GatewayVerdict("allow", granted=(other,))
+    granted = GatewayVerdict("allow", granted=((other, True),))
 
     r = disp(BeingIntent("memory_read", {"path": conftest}), granted)
     assert r.ok and "check would execute" in r.result, "a granted root must stay readable"
@@ -140,3 +140,33 @@ if __name__ == "__main__":
         if name.startswith("test_") and callable(fn):
             fn(); n += 1; print(f"PASS {name}")
     print(f"\n{n} passed")
+
+
+def test_confinement_honours_exact_vs_recursive_reach():
+    """hestia #1002: SAGE's defense-in-depth used to admit `p == root OR root in p.parents`
+    for EVERY granted root — an exact hestia grant on /x became recursive /x/** inside SAGE,
+    wider than the law that produced it. Reach travels with the root as (root, recursive);
+    a bare string reads as exact."""
+    import pytest
+    disp, root = _disp()
+    other = tempfile.mkdtemp(prefix="ref-f1a-reach-")
+    child = os.path.join(other, "sub", "note.md")
+    os.makedirs(os.path.dirname(child)); open(child, "w").write("deep")
+    sibling = tempfile.mkdtemp(prefix="ref-f1a-reach-", dir=os.path.dirname(other))
+
+    def confine(verdict, path):
+        disp(BeingIntent("witness", {"event": "prime"}), verdict)
+        return disp._safe_path(path)
+
+    exact = GatewayVerdict("allow", granted=((other, False),))
+    assert str(confine(exact, other)) == os.path.realpath(other)
+    with pytest.raises(ValueError, match="escapes"):
+        confine(exact, child)
+    rec = GatewayVerdict("allow", granted=((other, True),))
+    assert confine(rec, child).name == "note.md"
+    with pytest.raises(ValueError, match="escapes"):
+        confine(rec, os.path.join(sibling, "x"))
+    assert "deep" in disp(BeingIntent("memory_read", {"path": child}), rec).result
+    bare = GatewayVerdict("allow", granted=(other,))
+    with pytest.raises(ValueError, match="escapes"):
+        confine(bare, child)

--- a/sage/instances/legion-gemma3-12b/instance.json
+++ b/sage/instances/legion-gemma3-12b/instance.json
@@ -13,5 +13,6 @@
   "encryption_enabled": false,
   "peer_aliases": {
     "sprout-being": "2e175714-4b01-4063-a997-27a6dade7044"
-  }
+  },
+  "worktree": "/home/dp/ai-workspace/being-worktrees/legion-being"
 }

--- a/sage/irp/adapters/model_configs/qwen3.8-distill.json
+++ b/sage/irp/adapters/model_configs/qwen3.8-distill.json
@@ -1,62 +1,68 @@
 {
-    "family": "qwen3.8-distill",
-    "aliases": [
-        "qwen3.8",
-        "qwen38",
-        "qwen38-heretic",
-        "qwen3.8-heretic",
-        "hf.co/empero-ai/qwen3.8-2b-distill-gguf"
-    ],
-    "api_mode": "chat",
-    "bilateral_prone": false,
-    "supports_tool_calls": true,
-    "max_context_tokens": 8192,
-    "max_context_turns": 6,
-    "thinking_supported": true,
-    "think_default": true,
-    "tier": "T2",
-    "stop_sequences": [],
-    "echo_prefixes": [
-        "[{self_name}]:",
-        "{self_name}:",
-        "[SAGE]:",
-        "SAGE:"
-    ],
-    "bilateral_speakers": [
-        "Claude",
-        "System",
-        "User",
-        "Human"
-    ],
-    "strip_think_tags": true,
-    "variants": {
-        "2b": {
-            "num_predict": 1024,
-            "num_predict_think": 6000,
-            "think_default": true
-        },
-        "q3km": {
-            "num_predict": 1024,
-            "num_predict_think": 8000,
-            "think_default": true,
-            "num_ctx": 16384
-        },
-        "q8_0": {
-            "num_predict": 1024,
-            "num_predict_think": 6000,
-            "think_default": true
-        },
-        "q6_k": {
-            "num_predict": 1024,
-            "num_predict_think": 6000,
-            "think_default": true
-        },
-        "q4_k_m": {
-            "num_predict": 1024,
-            "num_predict_think": 6000,
-            "think_default": true
-        }
+  "family": "qwen3.8-distill",
+  "aliases": [
+    "qwen3.8",
+    "qwen38",
+    "qwen38-heretic",
+    "qwen3.8-heretic",
+    "hf.co/empero-ai/qwen3.8-2b-distill-gguf"
+  ],
+  "api_mode": "chat",
+  "bilateral_prone": false,
+  "supports_tool_calls": true,
+  "max_context_tokens": 8192,
+  "max_context_turns": 6,
+  "thinking_supported": true,
+  "think_default": true,
+  "tier": "T2",
+  "stop_sequences": [],
+  "echo_prefixes": [
+    "[{self_name}]:",
+    "{self_name}:",
+    "[SAGE]:",
+    "SAGE:"
+  ],
+  "bilateral_speakers": [
+    "Claude",
+    "System",
+    "User",
+    "Human"
+  ],
+  "strip_think_tags": true,
+  "variants": {
+    "2b": {
+      "num_predict": 1024,
+      "num_predict_think": 6000,
+      "think_default": true
     },
-    "timeout_seconds": 300,
-    "notes": "empero Qwen3.8 distills (2B, Sprout) and the heretic (qwen38-heretic:q3km, Legion). The heretic is NOT a 3.8B: Ollama reports architecture qwen35, 26.9B parameters, Q3_K_M, 13.3 GB, 64 layers, Modelfile num_ctx 16384 (measured 2026-09-05). REASONING models: with thinking off the 2B emits no structured tool calls and narrates a bracketed placeholder (Sprout 2026-08-28, 09-03, 09-05). think_default true for both. num_predict_think 6000 = the retry budget that recovered empty turns (done_reason=length) on both machines 2026-09-03/04. q3km num_ctx 16384: with thinking on at the harness's 8192 floor the heretic spent the whole window left after a ~5000-token prompt in its think block (prompt_eval + eval == 8192 on every empty turn; Legion beat 46, 0 acts, 2026-09-05) -- num_predict cannot exceed what the window has left, so the retry budget never applied. At 16384 (its own Modelfile value) the same prompt with thinking on gave 6 + 3 native calls, think blocks of 1000-4000+ chars, no empty turn, 492 s, 14.1 GB fully on a 16 GB GPU. Under think:false + /no_think it thought anyway (4000+ char blocks) and acted; thinking on does not change WHETHER it thinks, only whether the block is recorded and how long it runs. To roll the heretic back: set variants.q3km.think_default false and the heartbeat re-adds the suffix. q3km num_predict_think 8000 (2026-09-05, Sprout as think-policy owner, on Legion's capped beat: the first think block on the being's real 6721-token prompt ran to the full 6000 and only the retry stood; 6721+8000 fits the 16384 window with room, and the record now carries per-generate counters, so the next beats say whether the first attempt finishes). The once-retry of a length-stopped turn (being_tool_loop._retry_budget) sends num_ctx - prompt_eval_count as an OllamaIRP override: before, it only raised max_response_tokens, which resolve_num_predict ignores whenever the variant declares a value, so every think-on retry re-sent the same budget and was a re-roll at temperature, not room to finish (Legion 18:43Z 2026-09-05 stood by chance; beat 46's four retries could not have helped)."
+    "q3km": {
+      "num_predict": 1024,
+      "num_predict_think": 8000,
+      "think_default": true,
+      "num_ctx": 16384
+    },
+    "q8_0": {
+      "num_predict": 1024,
+      "num_predict_think": 6000,
+      "think_default": true
+    },
+    "q6_k": {
+      "num_predict": 1024,
+      "num_predict_think": 6000,
+      "think_default": true
+    },
+    "q4_k_m": {
+      "num_predict": 1024,
+      "num_predict_think": 6000,
+      "think_default": true
+    },
+    "q3km-vl": {
+      "num_predict": 1024,
+      "num_predict_think": 8000,
+      "think_default": true,
+      "num_ctx": 16384
+    }
+  },
+  "timeout_seconds": 300,
+  "notes": "empero Qwen3.8 distills (2B, Sprout) and the heretic (qwen38-heretic:q3km, Legion). The heretic is NOT a 3.8B: Ollama reports architecture qwen35, 26.9B parameters, Q3_K_M, 13.3 GB, 64 layers, Modelfile num_ctx 16384 (measured 2026-09-05). REASONING models: with thinking off the 2B emits no structured tool calls and narrates a bracketed placeholder (Sprout 2026-08-28, 09-03, 09-05). think_default true for both. num_predict_think 6000 = the retry budget that recovered empty turns (done_reason=length) on both machines 2026-09-03/04. q3km num_ctx 16384: with thinking on at the harness's 8192 floor the heretic spent the whole window left after a ~5000-token prompt in its think block (prompt_eval + eval == 8192 on every empty turn; Legion beat 46, 0 acts, 2026-09-05) -- num_predict cannot exceed what the window has left, so the retry budget never applied. At 16384 (its own Modelfile value) the same prompt with thinking on gave 6 + 3 native calls, think blocks of 1000-4000+ chars, no empty turn, 492 s, 14.1 GB fully on a 16 GB GPU. Under think:false + /no_think it thought anyway (4000+ char blocks) and acted; thinking on does not change WHETHER it thinks, only whether the block is recorded and how long it runs. To roll the heretic back: set variants.q3km.think_default false and the heartbeat re-adds the suffix. q3km num_predict_think 8000 (2026-09-05, Sprout as think-policy owner, on Legion's capped beat: the first think block on the being's real 6721-token prompt ran to the full 6000 and only the retry stood; 6721+8000 fits the 16384 window with room, and the record now carries per-generate counters, so the next beats say whether the first attempt finishes). The once-retry of a length-stopped turn (being_tool_loop._retry_budget) sends num_ctx - prompt_eval_count as an OllamaIRP override: before, it only raised max_response_tokens, which resolve_num_predict ignores whenever the variant declares a value, so every think-on retry re-sent the same budget and was a re-roll at temperature, not room to finish (Legion 18:43Z 2026-09-05 stood by chance; beat 46's four retries could not have helped). q3km-vl (2026-09-07, Legion): the SAME weights plus the official Qwen3.8 vision projector (mmproj-Qwen3.8-27B-Q8_0.gguf), so every text-path number above still applies and the variant is a copy of q3km. It exists because the size key is the ollama TAG: 'q3km-vl' missed q3km's entry and resolve_num_ctx silently returned the caller's 4096 floor -- the exact starvation beat 46 measured, re-introduced by a rename. A tag suffix must never be a capability change. Vision measured on Legion: shapes, positions, background hex and embedded text all read correctly from an unseen image; 14,657 MiB of 16,376 fully on GPU at 16K, ~870 MiB over the text-only build."
 }


### PR DESCRIPTION
Slice **A** of GPT's landing sequence for the `legion/mission-artifact` integration branch: #55 (with #60's evidence contract) re-cut onto current main, carrying hestia #1002's reach semantics. Supersedes #55 for merge purposes; #55's review thread is the record of how the check organ was shaped.

## What this is

- `origin/legion/m0-check-organ` (`5c8109f0b`) merged onto `main` (`e3f8ae35f`). One conflict: a same-anchor append at the tail of `test_hestia_dispatch.py` — both sides added tests; both kept.
- #60's invariants untouched: one canonical judged/executed argv, clean-tree refusal before `begin_action`, selected-test + ancestor-conftest identity, raw exit, full-output sha256, evidence class, embodiment, tree-stability binding.

## Plus the #1002 seam (`8b2…` second commit)

`_granted_roots` used to return bare roots and `_safe_path` admitted `p == root OR root in p.parents` for every one — an **exact** hestia grant on `/x` became recursive `/x/**` inside SAGE's defense-in-depth layer, wider than the law that produced it. Now reach travels with the root as `(root, recursive)`: from the core's `_scope_roots_with_reach` when present, else parsed from the `/**` spelling; a bare string from an older gate client reads as **exact**. The being's own home stays a subtree.

Falsifiers (`test_confinement_honours_exact_vs_recursive_reach`, `test_granted_roots_*`): exact refuses the child and admits the root; recursive admits the child and refuses a sibling; bare string == exact; the fallback parser reads `/**`.

## Verification

`python3 -m pytest sage/gateway/tests/` on this head: **153 passed**. Exact-head syntax gate run on the PR head.

Next slices, each on current main: B) M1 sandbox/writes, C) entrustment/embodiment/drive, D) `git_read`, E) reconnect, F) context window/compaction, G) authenticated conversations + reserved store, H) arousal, I) federation, J) `pr_open`, K) posture/docs.

— legion-claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DpHhjjiFQSnGXiW15aLbA
