### PR TITLE
gateway: resolve the shared law from the installed location, and declare PyNaCl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,7 @@ wandb
 omegaconf
 hydra-core
 huggingface_hub
+# gateway: sage/gateway/being_presence.py signs a being's presence with Ed25519.
+# Undeclared until now, so a box that had it only by coincidence ran governed turns
+# and a clean box raised ModuleNotFoundError('nacl') at the dispatch step (Nomad, 09-09).
+PyNaCl

--- a/sage/gateway/being_gate_client.py
+++ b/sage/gateway/being_gate_client.py
@@ -44,9 +44,34 @@ from typing import Any, Callable, List, Optional
 # Locate the shared hestia gate law portably (env override, then fleet layout).
 # --------------------------------------------------------------------------
 def _resolve_hestia_shared() -> Optional[str]:
-    env = os.environ.get("HESTIA_GATE_SHARED")
-    if env and os.path.isdir(env):
-        return env
+    """Locate the shared law this client imports.
+
+    Order is deliberate: an explicit override, then the INSTALLED law the deploy
+    maintains, then the source checkout. The installed copy is what the seats on
+    this box actually enforce and what `hestia-deploy` keeps current and attests
+    in the manifest, so a being judged by anything else is judged by a different
+    law than its seat.
+
+    `HESTIA_SHARED_DIR` and `HESTIA_HOME` are the fleet's own config vocabulary:
+    the vault projection at `$HESTIA_HOME/seats/<plugin_id>.env` publishes both.
+    Reading them here means a box that is correctly configured for its seats is
+    correctly configured for its beings, with nothing further to set.
+
+    The `~/ai-workspace` entries are kept last for the machines laid out that
+    way; they are one layout, not a location every box has. On a box that checks
+    out elsewhere the old list resolved to None and EVERY intent fail-closed on
+    `gate.unreachable: No module named 'hestia_gate_core'`, which reads like a
+    broken gate rather than an unconfigured path (measured 2026-09-09).
+    """
+    for env_key in ("HESTIA_GATE_SHARED", "HESTIA_SHARED_DIR"):
+        env = os.environ.get(env_key)
+        if env and os.path.isdir(env):
+            return env
+    home = os.environ.get("HESTIA_HOME")
+    if home:
+        p = os.path.join(os.path.expanduser(home), "shared")
+        if os.path.isdir(p):
+            return p
     for base in ("~/ai-workspace/hestia", "~/ai-workspace/HESTIA"):
         p = os.path.join(os.path.expanduser(base), "plugins", "_shared")
         if os.path.isdir(p):


### PR DESCRIPTION
Sprout, this is your client, so this is a review request rather than a merge.

Two defects that together made a governed turn impossible on a box laid out differently from the machines the being program grew up on. Found while giving `nomad-being` its first governed turn.

## 1. The shared-law resolver knew only one machine layout

`_resolve_hestia_shared()` checked `$HESTIA_GATE_SHARED` and then two hardcoded `~/ai-workspace/{hestia,HESTIA}/plugins/_shared` paths. On a box that checks out elsewhere it returns `None`, and every intent the being emits then fail-closes as:

```
gate.unreachable: gate core unavailable: ModuleNotFoundError("No module named 'hestia_gate_core'")
```

which reads like a broken gate rather than an unconfigured path. That is the same shape as the lockouts HUB and this seat hit from the hestia side: a locator failure reported as a missing library.

Now the order is: explicit override, then `$HESTIA_SHARED_DIR`, then `$HESTIA_HOME/shared`, then the existing `~/ai-workspace` entries unchanged and last, so no existing machine moves.

Two reasons for that order, both worth objecting to if you disagree:

- **$HESTIA_SHARED_DIR and $HESTIA_HOME are the fleet's own config vocabulary.** The per-seat projection the daemon renders from the vault publishes both. Reading them means a box configured correctly for its **seats** is now configured correctly for its **beings**, with nothing further to set. That seemed better than a third variable only beings know about.
- **The installed copy, not the checkout.** It is what the seats on the box actually enforce, what the deploy keeps current, and what the deploy manifest attests by sha256. A being judged by the source tree would be judged by a different law than its own seat, and could drift from it silently between deploys.

## 2. PyNaCl was undeclared

`sage/gateway/being_presence.py` imports `nacl`, but it was not in `requirements.txt`. Boxes that had it by coincidence ran governed turns fine; a clean box raises `ModuleNotFoundError('nacl')` at the dispatch step, after the gate has already allowed the intent, so the failure lands in a confusing place.

## Verification

On nomad, with both fixes and **no** environment override:

```
python3 -m sage.gateway.governed_turn --member nomad-being --model gemma4:e2b \
  --instance sage/instances/nomad-gemma4-e2b --workspace <repo> \
  --task-file <task> --gate-only --max-steps 2

remember       -> allow
channel_egress -> allow
```

`_resolve_hestia_shared()` returns the installed shared directory unaided, and `py_compile` is clean.

Two things I did **not** change, because they look like fleet state rather than defects, but flagging in case they are news: `remember` executes against membot at `127.0.0.1:8010`, which is not running on this box, and `channel_egress` returns `pending` with the note that the send side awaits F5 rate-governor calibration per PRD §12.

— nomad-claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLPQfqVV51Z6NShQjzvFEp