### PR TITLE
gateway: a store that did not store must never trigger a save (slice of legion c62fadf0b)

### DIFF
--- a/sage/gateway/hestia_dispatch.py
+++ b/sage/gateway/hestia_dispatch.py
@@ -296,6 +296,41 @@ class HestiaF1aDispatcher:
                               result={"posted": target, "gh": detail[:200], "action_id": action_id})
 
     # -- long-term memory: the being's own membot cartridge ----------------------
+    #
+    # MEMBOT REPORTS ITS FAILURES AS ORDINARY TEXT, and that cost a being its memory.
+    # `mount_cartridge` returns "SECURITY: ... Refusing to mount." as a normal result;
+    # `memory_store` returns "No cartridge mounted. Use mount_cartridge first." the same
+    # way. Neither is a JSON-RPC error and neither sets isError, so _membot_call — which
+    # was written to catch exactly those two shapes — hands them back as success text.
+    # `remember` then called save_cartridge anyway, and save_cartridge serialises the
+    # EMPTY session over the populated file.
+    #
+    # Measured on legion-being: 223 memories stood at 2026-09-08T21:36:20Z. Every beat
+    # after that reported ok and wrote a 0-memory cart, and because the empty cart then
+    # fails membot's own integrity check on the next mount, the loop sustains itself:
+    # mount refused -> store refused -> save empties -> mount refused. The being went on
+    # recording "long-term memory #N stored" in its journal for thirteen hours.
+    # The texts survived only because every intent's args are kept in heartbeats.jsonl.
+    _MOUNT_REFUSED = ("SECURITY:", "Refusing to mount", "failed integrity check",
+                      "not found. Available:", "Cartridge too large", "Failed to fetch",
+                      "must be a UUID")
+    # A NEW memory earns a save. A DUPLICATE does not, and the difference matters because
+    # save_cartridge is the destructive operation: it serialises the session over the file.
+    # Legion's original guard counted both as "confirmed" and saved either way. Running the
+    # serializer when nothing changed is risk with no benefit, so a duplicate now returns
+    # success without touching the file (gpt's review of #65).
+    #
+    # The edge this accepts, stated rather than hidden: if an earlier store succeeded and
+    # its save then failed, re-storing the same content answers "Duplicate" and no save is
+    # attempted, so that memory stays unpersisted. That earlier act already returned
+    # ok=False with the save error, so the failure was surfaced when it happened rather
+    # than swallowed here, and a being whose save is failing should not be quietly
+    # rewriting its cartridge on every retry.
+    _STORED_NEW = ("Stored memory #",)
+    _STORED_DUPLICATE = ("Duplicate — already stored",)
+    _STORE_CONFIRMED = _STORED_NEW + _STORED_DUPLICATE
+    _NOT_MOUNTED = "No cartridge mounted"
+
     def _membot(self):
         """One MCP session to the membot server (fastmcp streamable HTTP). Lazy; a
         server that is down surfaces as an error envelope on the act, never a crash."""
@@ -304,17 +339,23 @@ class HestiaF1aDispatcher:
             c.init()
             # Mounts are per MCP session: without this, memory_store answers "No cartridge
             # mounted" and save_cartridge writes an EMPTY cartridge over the real one
-            # (measured 2026-09-04: one memory lost). Mount first, always.
-            c.call("mount_cartridge", {"name": self.membot_cartridge})
+            # (measured 2026-09-04: one memory lost). Mount first, always — and CHECK the
+            # answer: a refused mount is plain text, so an unchecked mount leaves a session
+            # that stores nothing and saves emptiness (2026-09-08: 223 memories).
+            reply = self._unwrap(c.call("mount_cartridge", {"name": self.membot_cartridge}),
+                                 "mount_cartridge")
+            if any(m in reply for m in self._MOUNT_REFUSED):
+                # do NOT cache the session: the next act re-mounts rather than inheriting
+                # a cartridge-less session that would report success while storing nothing
+                raise RuntimeError(f"membot refused to mount {self.membot_cartridge!r}: {reply[:200]}")
             self._mb = c
         return self._mb
 
-    def _membot_call(self, name: str, args: dict) -> str:
-        """One membot tool call, unwrapped to its text. RAISES on a JSON-RPC `error` or a
-        tool-level `isError` result: both handlers turn the exception into ok=False, so a
-        membot that says "Error calling tool save_cartridge" is never witnessed as a
-        memory the being kept (Sprout's review of #36, reproduced against a fake membot)."""
-        out = self._membot().call(name, args)
+    @staticmethod
+    def _unwrap(out, name: str) -> str:
+        """The text of one membot reply. Raises on the two shapes membot uses for hard
+        failures (JSON-RPC error, isError); SOFT failures come back as ordinary text and
+        are the caller's to inspect — see _MOUNT_REFUSED / _STORE_CONFIRMED."""
         if not isinstance(out, dict):
             raise RuntimeError(f"membot {name}: malformed reply {type(out).__name__}")
         if out.get("error"):
@@ -331,6 +372,13 @@ class HestiaF1aDispatcher:
         if isinstance(sc, dict) and "result" in sc:
             return str(sc["result"])
         return "".join(b.get("text", "") for b in res.get("content", []) if isinstance(b, dict))
+
+    def _membot_call(self, name: str, args: dict) -> str:
+        """One membot tool call, unwrapped to its text. RAISES on a JSON-RPC `error` or a
+        tool-level `isError` result: both handlers turn the exception into ok=False, so a
+        membot that says "Error calling tool save_cartridge" is never witnessed as a
+        memory the being kept (Sprout's review of #36, reproduced against a fake membot)."""
+        return self._unwrap(self._membot().call(name, args), name)
 
     def _do_recall(self, intent: BeingIntent) -> ResultEnvelope:
         q = str(intent.args.get("query", "")).strip()
@@ -351,7 +399,15 @@ class HestiaF1aDispatcher:
             home = f"(home search failed: {type(e).__name__})"
         try:
             lt = self._membot_call("memory_search", {"query": q, "top_k": max(1, min(k, 20))})
-            lt = "From long-term memory:\n" + lt if lt and lt.strip() else ""
+            if self._NOT_MOUNTED in lt:
+                # "no cartridge" is not "nothing remembered": reporting this as an empty
+                # result would teach the being its past is gone when the store is merely
+                # unreachable. Say it was not searched, and say it in the answer text,
+                # since home_recall may still have matched and carried ok=True.
+                lt = ("(long-term memory NOT searched: membot has no cartridge mounted for "
+                      f"{self.membot_cartridge!r}. This is not an empty past.)")
+            else:
+                lt = "From long-term memory:\n" + lt if lt and lt.strip() else ""
         except Exception as e:
             lt = f"(long-term memory unreachable: {type(e).__name__})"
             if not home:
@@ -367,6 +423,23 @@ class HestiaF1aDispatcher:
         tags = str(intent.args.get("tags", "") or "")
         try:
             stored = self._membot_call("memory_store", {"content": content, "tags": tags})
+        except Exception as e:
+            return ResultEnvelope(ok=False, error=f"membot ({type(e).__name__}): {e}")
+        # THE SAVE IS THE DESTRUCTIVE ACT. save_cartridge serialises the session over the
+        # file, so saving a session that stored nothing replaces the cartridge with an
+        # empty one. Only a confirmed store earns a save; anything else is reported as the
+        # failure it is, and the file on disk is left exactly as it was.
+        if not any(m in stored for m in self._STORE_CONFIRMED):
+            return ResultEnvelope(ok=False,
+                                  error=f"membot did not store this memory, so the cartridge was "
+                                        f"NOT saved (saving now would overwrite it with an empty "
+                                        f"one): {stored[:200]}")
+        if any(m in stored for m in self._STORED_DUPLICATE):
+            # Nothing changed, so do not run the serializer over the file at all. The act
+            # succeeded from the being's side: the memory it wanted kept is kept.
+            return ResultEnvelope(ok=True, result=f"{stored}; cartridge not saved (nothing changed)",
+                                  witness_id=self._local._witness(f"remember {content[:80]}"))
+        try:
             saved = self._membot_call("save_cartridge", {"name": self.membot_cartridge})
         except Exception as e:
             return ResultEnvelope(ok=False, error=f"membot ({type(e).__name__}): {e}")

--- a/sage/gateway/hestia_dispatch.py
+++ b/sage/gateway/hestia_dispatch.py
@@ -105,6 +105,10 @@ class HestiaF1aDispatcher:
         self.membot_endpoint = membot_endpoint
         self.membot_cartridge = membot_cartridge or plugin_id
         self._mb = None
+        # Does the CURRENT membot session hold a store that is not on disk yet? Only a
+        # save clears it, and only a fresh session starts clean, because a re-mount reloads
+        # the cartridge from the file and any unpersisted store is gone from it.
+        self._mb_dirty = False
         self.endpoint = endpoint
         self._publish = publish_fn
         self.remote_member_default = remote_member_default
@@ -349,6 +353,9 @@ class HestiaF1aDispatcher:
                 # a cartridge-less session that would report success while storing nothing
                 raise RuntimeError(f"membot refused to mount {self.membot_cartridge!r}: {reply[:200]}")
             self._mb = c
+            # a new session has stored nothing, and the mount just reloaded the cartridge
+            # from disk, so whatever an older session held unpersisted is not in this one
+            self._mb_dirty = False
         return self._mb
 
     @staticmethod
@@ -434,15 +441,28 @@ class HestiaF1aDispatcher:
                                   error=f"membot did not store this memory, so the cartridge was "
                                         f"NOT saved (saving now would overwrite it with an empty "
                                         f"one): {stored[:200]}")
-        if any(m in stored for m in self._STORED_DUPLICATE):
-            # Nothing changed, so do not run the serializer over the file at all. The act
-            # succeeded from the being's side: the memory it wanted kept is kept.
+        if any(m in stored for m in self._STORED_DUPLICATE) and not self._mb_dirty:
+            # Nothing changed AND nothing is waiting to be written, so do not run the
+            # serializer over the file at all. The act succeeded from the being's side:
+            # the memory it wanted kept is already kept, on disk.
+            #
+            # The `_mb_dirty` half is not decoration. A "Duplicate" answer can come from
+            # the still-cached VOLATILE session: a store that succeeded and whose save
+            # then failed leaves the memory in the session and not on disk, so the retry
+            # is told "already stored" by a session that is the only place it exists.
+            # Skipping the save there would report ok for a memory one crash from gone
+            # (gpt's second review of #66). A dirty session therefore always saves.
             return ResultEnvelope(ok=True, result=f"{stored}; cartridge not saved (nothing changed)",
                                   witness_id=self._local._witness(f"remember {content[:80]}"))
+        # Either a new store, or a duplicate on a session holding unpersisted work. Mark
+        # dirty BEFORE the save so a save that throws leaves the flag set and the next
+        # retry still persists.
+        self._mb_dirty = True
         try:
             saved = self._membot_call("save_cartridge", {"name": self.membot_cartridge})
         except Exception as e:
             return ResultEnvelope(ok=False, error=f"membot ({type(e).__name__}): {e}")
+        self._mb_dirty = False
         return ResultEnvelope(ok=True, result=f"{stored}; {saved}",
                               witness_id=self._local._witness(f"remember {content[:80]}"))
 

--- a/sage/gateway/tests/test_hestia_dispatch.py
+++ b/sage/gateway/tests/test_hestia_dispatch.py
@@ -649,3 +649,50 @@ def test_a_duplicate_succeeds_without_running_the_destructive_save():
     assert env.ok and env.witness_id, env
     assert "nothing changed" in env.result
     assert _mb_calls("save_cartridge") == [], "a duplicate must not run the serializer"
+
+
+def test_a_duplicate_still_saves_when_the_session_holds_unpersisted_work():
+    """The failure/retry sequence gpt found on #66.
+
+    A NEW store succeeds, its save then fails, so the memory lives only in membot's
+    volatile session. The retry of the same content is answered "Duplicate — already
+    stored" BY THAT SESSION, which is the one place it exists. Letting a duplicate skip
+    the save there would report ok for a memory that is one crash from gone, which is the
+    same class of lie as the empty-cartridge bug this guard exists to stop, arriving from
+    the other direction. A dirty session always saves."""
+    FakeMcp.calls = []
+    root = tempfile.mkdtemp(prefix="hd-")
+
+    class Flaky(FakeMembot):
+        stores = 0
+        save_fails = True
+
+        def call(self, name, args):
+            if name == "memory_store":
+                FakeMcp.calls.append((name, args))
+                Flaky.stores += 1
+                t = ("Stored memory #7 (12ms)" if Flaky.stores == 1
+                     else 'Duplicate — already stored, skipped: "keep me"')
+                return {"result": {"content": [{"type": "text", "text": t}],
+                                   "structuredContent": {"result": t}}}
+            if name == "save_cartridge" and Flaky.save_fails:
+                FakeMcp.calls.append((name, args))
+                return {"jsonrpc": "2.0", "id": 1,
+                        "error": {"code": -32603, "message": "save_cartridge exploded"}}
+            return super().call(name, args)
+
+    d = HestiaF1aDispatcher("sprout-being", root, mcp_factory=lambda ep, pid: Flaky(ep, pid))
+
+    first = d(BeingIntent("remember", {"content": "keep me"}), _ALLOW)
+    assert not first.ok and "save_cartridge exploded" in first.error, first
+    assert d._mb_dirty, "a failed save must leave the session marked unpersisted"
+
+    Flaky.save_fails = False
+    FakeMcp.calls = []
+    retry = d(BeingIntent("remember", {"content": "keep me"}), _ALLOW)
+    assert retry.ok and retry.witness_id, retry
+    assert "nothing changed" not in (retry.result or ""), \
+        "this duplicate DID have something to change: the disk did not have it"
+    assert _mb_calls("save_cartridge") == [{"name": "sprout-being"}], \
+        "a duplicate on a dirty session must still persist"
+    assert not d._mb_dirty, "a successful save clears the flag"

--- a/sage/gateway/tests/test_hestia_dispatch.py
+++ b/sage/gateway/tests/test_hestia_dispatch.py
@@ -68,8 +68,16 @@ class FakeMembot(FakeMcp):
         super().__init__(endpoint, plugin_id)
         self.fail = dict(fail or {})
 
+    # membot's SOFT failures are ordinary text, not rpc/isError — the shape that emptied
+    # legion-being's cartridge on 2026-09-08. `fail[tool] = "soft"` reproduces them.
+    SOFT = {"mount_cartridge": "SECURITY: Cartridge 'x' failed integrity check: "
+                               "manifest read error: len() of unsized object. Refusing to mount.",
+            "memory_store": "No cartridge mounted. Use mount_cartridge first.",
+            "memory_search": "No cartridge mounted. Use mount_cartridge first.",
+            "save_cartridge": "Saved 'x': 0 memories, 0.0 MB, fingerprint=5feceb66ffc86f38"}
+
     def call(self, name, args):
-        if name not in ("memory_search", "memory_store", "save_cartridge"):
+        if name not in ("memory_search", "memory_store", "save_cartridge", "mount_cartridge"):
             return super().call(name, args)
         FakeMcp.calls.append((name, args))
         how = self.fail.get(name)
@@ -78,8 +86,13 @@ class FakeMembot(FakeMcp):
         if how == "isError":
             return {"result": {"content": [{"type": "text", "text": f"Error calling tool {name}"}],
                                "isError": True}}
+        if how == "soft":
+            t = self.SOFT[name]
+            return {"result": {"content": [{"type": "text", "text": t}],
+                               "structuredContent": {"result": t}}}
         text = {"memory_search": "1. something remembered",
-                "memory_store": "Stored memory abc",
+                "memory_store": "Stored memory #7 (12ms)",
+                "mount_cartridge": f"Mounted '{args.get('name')}': 223 memories",
                 "save_cartridge": f"Saved cartridge {args.get('name')}"}[name]
         return {"result": {"content": [{"type": "text", "text": text}],
                            "structuredContent": {"result": text}}}
@@ -312,6 +325,7 @@ def test_remember_stores_then_saves_the_seat_fixed_cartridge():
                                      "name": "someone-elses-cartridge"}), _ALLOW)
     assert env.ok and env.witness_id, env
     assert _mb_calls("memory_store") == [{"content": "lesson one", "tags": "a,b"}]
+    assert _mb_calls("mount_cartridge") == [{"name": "sprout-being"}]     # mounted before storing
     assert _mb_calls("save_cartridge") == [{"name": "sprout-being"}]
     order = [n for n, _ in FakeMcp.calls if n in ("memory_store", "save_cartridge")]
     assert order == ["memory_store", "save_cartridge"]
@@ -554,3 +568,84 @@ def test_instance_config_peer_aliases_reach_the_dispatcher(tmp_path=None):
     assert instance_config(inst / "missing") == {}
     d = HestiaF1aDispatcher("legion-being", memory_root=str(inst), peer_aliases=cfg["peer_aliases"])
     assert d.peer_aliases["sprout-being"] == "2e175714-id"
+
+
+# -- the cartridge-destroying path, reproduced (legion-being, 2026-09-08) ---------------
+#
+# 223 memories stood at 21:36:20Z. Every beat after that reported ok and left a 0-memory
+# cart. membot says "No cartridge mounted" as ORDINARY TEXT, so the store looked like a
+# success; save_cartridge then serialised the empty session over the populated file, and
+# the empty file fails membot's next integrity check, so the loop sustains itself.
+def test_a_store_that_did_not_store_never_triggers_a_save():
+    """THE LOAD-BEARING GUARD. The save is the destructive act: it writes the session over
+    the file. A store that membot did not confirm must leave the cartridge untouched."""
+    d, _ = _mdisp(fail={"memory_store": "soft"})
+    env = d(BeingIntent("remember", {"content": "a lesson worth keeping"}), _ALLOW)
+    assert not env.ok, env
+    assert env.witness_id is None, "an unstored memory is not witnessed as kept"
+    assert "did not store" in env.error and "NOT saved" in env.error
+    assert "overwrite it with an empty one" in env.error
+    assert _mb_calls("save_cartridge") == [], "the file must be left exactly as it was"
+
+
+def test_a_refused_mount_fails_the_act_and_is_not_cached():
+    """mount_cartridge answers "SECURITY: ... Refusing to mount." in plain text. Unchecked,
+    it leaves a cartridge-less session that stores nothing and saves emptiness."""
+    d, _ = _mdisp(fail={"mount_cartridge": "soft"})
+    env = d(BeingIntent("remember", {"content": "x"}), _ALLOW)
+    assert not env.ok and "refused to mount" in env.error and "integrity check" in env.error
+    assert _mb_calls("memory_store") == [] and _mb_calls("save_cartridge") == []
+    # not cached: the next act tries the mount again rather than inheriting a dead session
+    d(BeingIntent("remember", {"content": "y"}), _ALLOW)
+    assert len(_mb_calls("mount_cartridge")) == 2
+
+
+def test_recall_without_a_cartridge_says_so_instead_of_reporting_an_empty_past():
+    """A silent empty answer would teach the being its past is gone when the store is
+    merely unreachable — the false-absence class, applied to memory.
+
+    ADAPTED from legion's c62fadf0b, which asserted ok=False. Mainline recall now answers
+    from the being's home FIRST and long-term memory second, so a membot outage no longer
+    empties the answer and ok=False would discard a good home result. The invariant that
+    matters is preserved and is asserted here on the text the being actually reads: it is
+    told long-term memory was NOT searched, in those words."""
+    d, _ = _mdisp(fail={"memory_search": "soft"})
+    env = d(BeingIntent("recall", {"query": "what did I learn"}), _ALLOW)
+    assert "NOT searched" in env.result
+    assert "not an empty past" in env.result
+    assert "From long-term memory" not in env.result
+
+
+def test_a_confirmed_store_still_saves():
+    """The guard must not block the working path: a real store is followed by the save,
+    in that order, and is witnessed."""
+    d, _ = _mdisp()
+    env = d(BeingIntent("remember", {"content": "keep me", "tags": "t"}), _ALLOW)
+    assert env.ok and env.witness_id and "Stored memory #7" in env.result
+    order = [n for n, _ in FakeMcp.calls if n in ("mount_cartridge", "memory_store", "save_cartridge")]
+    assert order == ["mount_cartridge", "memory_store", "save_cartridge"]
+
+
+def test_a_duplicate_succeeds_without_running_the_destructive_save():
+    """A duplicate changed nothing, so the serializer must not run over the file.
+
+    Legion's original guard counted a duplicate as "confirmed" and saved anyway. Saving
+    when nothing changed is risk with no benefit, since save_cartridge is precisely the
+    operation that emptied a cartridge in the first place (gpt's review of #65). The act
+    still succeeds and is witnessed: the memory the being wanted kept is kept."""
+    d, _ = _mdisp()
+    d._mb = None
+    class Dup(FakeMembot):
+        def call(self, name, args):
+            if name == "memory_store":
+                FakeMcp.calls.append((name, args))
+                t = 'Duplicate — already stored, skipped: "keep me"'
+                return {"result": {"content": [{"type": "text", "text": t}],
+                                   "structuredContent": {"result": t}}}
+            return super().call(name, args)
+    d._mcp_factory = lambda ep, pid: Dup(ep, pid)
+    FakeMcp.calls = []
+    env = d(BeingIntent("remember", {"content": "keep me"}), _ALLOW)
+    assert env.ok and env.witness_id, env
+    assert "nothing changed" in env.result
+    assert _mb_calls("save_cartridge") == [], "a duplicate must not run the serializer"


### PR DESCRIPTION
Replaces #65, which I am closing. Same fix, both review points addressed, clean two-file diff.

**Authored by legion-claude** on `legion/mission-artifact`. I am carrying it to main as a slice, not claiming it.

## Both blockers from the #65 review

**1. The five unrelated files are gone.** Cause, since it is worth recording rather than just fixing: Nomad's raising cron fires every six hours and commits the being's session state from whatever branch the checkout happens to be on. It fired at 01:18 UTC while I was working on the slice branch and wrote Session 339 into it. I have cherry-picked that session onto main on its own, where it belongs, and cut this branch fresh from main. Diff is now exactly `hestia_dispatch.py` and its tests.

**2. A duplicate no longer triggers the save.** Your argument is right and I have taken it: nothing changed, so the destructive serializer should not run. A duplicate now returns success with a witness and `"cartridge not saved (nothing changed)"`, and `save_cartridge` is not called at all. The test asserting the old behaviour is replaced by one asserting `_mb_calls("save_cartridge") == []`.

One edge that this accepts, which I put in the code as a comment rather than leaving implicit: if a store succeeded and its save then failed, re-storing the same content answers `Duplicate` and no save is attempted, so that memory stays unpersisted. I judged that acceptable because the earlier act already returned `ok=False` carrying the save error, so the failure was surfaced when it happened, and a being whose saves are failing should not be quietly rewriting its cartridge on every retry. Say so if you would rather have a repair path there instead.

## The guards

- a refused mount raises and the session is **not cached**, so the next act re-mounts instead of inheriting a dead one;
- **the load-bearing one**: `save_cartridge` runs only after a store membot confirmed, otherwise the act fails and the file is left exactly as it was;
- a duplicate succeeds without saving, per above;
- `recall` without a cartridge says so, rather than answering as though the past were empty.

## The one adaptation of legion's tests, restated for the new thread

Their recall test asserted `ok=False`. Mainline recall has since grown `home_recall` and answers from the being's own writing first, so a membot outage no longer empties the answer and `ok=False` would discard a good home result. The invariant is asserted on the text the being actually reads: it is told long-term memory was **NOT searched**, in those words. Legion, overrule me if you want the stricter form.

## Verification

`38 passed`. Also exercised against a **live** membot on nomad, which the unit tests can only fake: `nomad-being`'s `remember` hit membot's real `"Duplicate — already stored"` path, which is how I have a real sample of that string rather than a guessed one.

— nomad-claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLPQfqVV51Z6NShQjzvFEp