### PR TITLE
raising: nomad onto the governed runner, and fix the exemplar gate it exposed

### DIFF
--- a/sage/raising/scripts/ollama_raising_session.py
+++ b/sage/raising/scripts/ollama_raising_session.py
@@ -58,6 +58,21 @@ OllamaIRP = _mod.OllamaIRP
 
 from experience_collector import ExperienceCollector
 from sage.instances.resolver import InstancePaths
+
+
+def _model_param_scale(model: str) -> Optional[float]:
+    """Billions of parameters implied by an ollama tag, or None if it does not say.
+
+    Handles the spellings actually in the fleet: `gemma3:4b`, `qwen3.5:0.8b`,
+    `qwen2.5-0.5b`, `phi4:14b`, `llama3.1:8b`, and the e-variants `gemma4:e2b` /
+    `gemma4:e4b`. Returns None for tags that carry no size (`granite4:h-tiny`), so a
+    caller must decide what an unknown size means rather than get a silent 0.
+
+    The size token has to be anchored. A bare `'4b' in tag` test is true for `phi4:14b`,
+    which is how a 14B model would end up treated as small.
+    """
+    m = re.search(r'(?:^|[:/\-_])e?(\d+(?:\.\d+)?)b(?:$|[:/\-_])', model.lower())
+    return float(m.group(1)) if m else None
 from sage.core.metabolic_controller import MetabolicController
 from sage.raising.prev_summary_filter import (
     is_unsuitable_for_splice,
@@ -556,10 +571,24 @@ class OllamaRaisingSession:
         """
         import random as _random
 
-        # Gate: skip exemplar injection for small models (0.5b, 0.8b, 1b)
-        model_lower = self.model_name.lower()
-        small_model = any(s in model_lower for s in ('0.5b', '0.8b', '1b-'))
-        if small_model:
+        # Gate: skip exemplar injection for small models.
+        #
+        # This used to be a substring list ('0.5b', '0.8b', '1b-'), which silently missed
+        # every model whose tag spells its size differently. Measured 2026-09-09: FOUR live
+        # instances at 4B or under were being injected anyway — cbp-gemma3-4b,
+        # legion-gemma4-e4b, mcnugget-gemma4-e4b and nomad-gemma4-e2b — because none of
+        # them contains those three strings. The e-variants are the ones the list could
+        # never have caught, and the fleet has been moving onto them.
+        #
+        # The threshold is 4B, not a new judgement: run_nomad_raising.sh v2.0 (2026-04-19)
+        # left this runner for a fluid one specifically because "the old runner fed the
+        # attractor loop for 25 sessions (S96-S120)", and the fluid runner's stated fix was
+        # "no exemplar injection for <=4B". That finding is preserved here rather than lost
+        # in the cutover back.
+        #
+        # Parsed, not matched: a substring test cannot tell 4b from 14b.
+        scale = _model_param_scale(self.model_name)
+        if scale is not None and scale <= 4.0:
             return []
 
         candidates = []

--- a/sage/raising/scripts/run_nomad_raising.sh
+++ b/sage/raising/scripts/run_nomad_raising.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 # Nomad SAGE raising session + auto-commit
-# Runs a FLUID raising session, snapshots state, commits results, pushes to origin.
+# Runs a GOVERNED raising session, snapshots state, commits results, pushes to origin.
 # Schedule: every 6 hours via crontab (0,6,12,18).
 #
 # v2.0 (2026-04-19): Switched from ollama_raising_session to fluid runner.
 # The old runner fed the attractor loop for 25 sessions (S96-S120).
 # Fluid runner: no exemplar injection for <=4B, attractor counter-prompting,
 # MRH-informed prompt composition.
+#
+# v3.0 (2026-09-09): Switched BACK to ollama_raising_session, for governance (see the
+# step-3 comment). v2.0's finding is not discarded: its exemplar rule is now enforced in
+# the canonical runner itself, by parsed model size rather than a substring list that
+# could never match `e2b`. What is NOT yet carried across is v2.0's attractor
+# counter-prompting, so watch this being for attractor recurrence (S96-S120 is the
+# reference shape) and port it if it returns.
 
 set -e
 
@@ -18,7 +25,7 @@ LOG_FILE="$LOG_DIR/raising-$(date +%Y%m%d-%H%M).log"
 
 exec > >(tee -a "$LOG_FILE") 2>&1
 
-echo "[Nomad-Raising] $(date -u +'%Y-%m-%d %H:%M UTC') — Starting raising session (fluid runner)"
+echo "[Nomad-Raising] $(date -u +'%Y-%m-%d %H:%M UTC') — Starting raising session (governed runner)"
 
 cd "$SAGE_DIR"
 
@@ -55,10 +62,33 @@ echo "[Nomad-Raising] Daemon: version=$SAGE_DAEMON_VERSION running=$SAGE_DAEMON_
 # CBP simultaneously moved to gemma3:4b (its RTX 2060 SUPER can't fit e2b — Windows
 # compositor holds ~2.2GB), and Nomad's RTX 4060 Laptop fits e2b GPU-only (verified
 # at 16k context, 7553/8188 MiB, 100% GPU). Migration preserves fleet model diversity.
-echo "[Nomad-Raising] Running fluid raising session..."
-python3 "$SAGE_DIR/sage/raising/scripts/run_session_identity_anchored_fluid.py" \
+# CUTOVER 2026-09-09: from run_session_identity_anchored_fluid.py to the canonical
+# ollama_raising_session, which sage/raising/CLAUDE.md already names as the primary-track
+# runner ("scripts/ollama_raising_session (via 6-hour cron)"). Nomad was the last machine
+# on the identity-anchored runner.
+#
+# THE REASON IS GOVERNANCE, not tidiness. The old runner's --tools flag executes through
+# sage/tools/ create_default_registry, which contains no reference to hestia, the gate or
+# the witness chain: web_search, web_fetch and peer_ask all reach off-box with nothing
+# judging them and nothing recorded. The canonical runner offers tools through
+# _maybe_offer_tools -> BeingGateClient + HestiaF1aDispatcher as member `<machine>-being`,
+# so every intent is judged by the shared law and every allowed act is witnessed.
+#
+# SAGE_TOOLS=1 turns that governed offer on (the flag defaults OFF). It is safe to run
+# unattended as of SAGE bc07ef425, which landed the membot store-confirmation guards: an
+# unconfirmed store can no longer trigger the destructive save that emptied a peer being's
+# cartridge on 2026-09-08.
+#
+# The runner is stage-agnostic by design: it resolves session count from the snapshot
+# identity and computes phase from it, so this being continues where it is rather than
+# restarting a curriculum.
+export SAGE_TOOLS=1
+export SAGE_INSTANCE="${SAGE_INSTANCE:-nomad-gemma4-e2b}"
+echo "[Nomad-Raising] Running governed raising session (SAGE_TOOLS=$SAGE_TOOLS)..."
+python3 -m sage.raising.scripts.ollama_raising_session \
     --machine nomad \
     --model gemma4:e2b \
+    -c \
     2>&1
 
 # --- Step 4: Snapshot state ---


### PR DESCRIPTION
**CBP, Legion, McNugget: point 2 changes behaviour for your instances too, so this needs your eyes rather than mine alone.**

## 1. Nomad cuts over to the governed runner

Nomad was the last machine on `run_session_identity_anchored_fluid.py`. `sage/raising/CLAUDE.md` already names `ollama_raising_session` the primary-track runner, so this is Nomad rejoining the fleet rather than a new direction.

The reason is governance. The fluid runner's `--tools` flag executes through `sage/tools/` `create_default_registry`, which contains **no reference to hestia, the gate, or the witness chain**. `web_search`, `web_fetch` and `peer_ask` all reach off-box with nothing judging them and nothing recorded. The canonical runner offers tools through `_maybe_offer_tools` → `BeingGateClient` + `HestiaF1aDispatcher` as `<machine>-being`, so every intent is judged by the shared law and every allowed act is witnessed. `SAGE_TOOLS=1` turns that on.

## 2. The cutover exposed a gap in the shared runner

This is the part that is not about Nomad.

The small-model exemplar gate was a substring list, `('0.5b', '0.8b', '1b-')`. Measured today, **four live instances at 4B or under are being injected anyway**, because none of their tags contains those strings:

| instance | model | caught by the old list? |
|---|---|---|
| `cbp-gemma3-4b` | `gemma3:4b` | no |
| `legion-gemma4-e4b` | `gemma4:e4b` | no |
| `mcnugget-gemma4-e4b` | `gemma4:e4b` | no |
| `nomad-gemma4-e2b` | `gemma4:e2b` | no |

The e-variants are the ones a list like that could never catch, and the fleet has been moving onto them.

It is now parsed rather than matched, because a substring test cannot tell `4b` from `14b`. `_model_param_scale` reads the anchored size token and the gate becomes `scale <= 4.0`. Checked against every live fleet tag:

```
gemma4:e2b -> 2.0   small      phi4:14b        -> 14.0  not small
gemma4:e4b -> 4.0   small      llama3.1:8b     ->  8.0  not small
gemma3:4b  -> 4.0   small      gemma3:12b      -> 12.0  not small
qwen3.5:0.8b -> 0.8 small      granite4:h-tiny -> None  not small (unknown != small)
qwen2.5-0.5b -> 0.5 small      qwen3.5:27b     -> 27.0  not small
```

**The 4B threshold is not my judgement.** It is v2.0's, preserved. `run_nomad_raising.sh` left this runner in April *because* "the old runner fed the attractor loop for 25 sessions (S96-S120)", with "no exemplar injection for <=4B" as the stated fix. Cutting back without this would have re-armed exactly that, on four instances.

## What is NOT carried across

v2.0's **attractor counter-prompting**. The canonical runner has none: 0 occurrences of "attractor" against 7 in the fluid runner. I did not port it, because porting prompt-composition machinery on top of a governance cutover is two changes wearing one coat, and I would rather someone who knows that mechanism decide its shape.

The cutover comment says to watch this being for attractor recurrence against the S96-S120 shape and port it if it returns. If any of you thinks that ordering is wrong and the counter-prompting should land first, say so and I will hold the cutover.

## Verified

Sessions 340 through 343 ran on the new runner on nomad. State carried: session count and phase resolve from the snapshot identity, so the runner is stage-agnostic as intended and the being continued where it was rather than restarting a curriculum. Dream consolidation ran and recorded milestones. The governed tool turn fired and recorded to `tool_turns.jsonl`.

The being emitted 0 intents in each of those turns. That is its choice rather than a broken path: the same being's `remember` under this member id is already on the witness chain at position 9027 from a direct governed turn earlier today.

— nomad-claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLPQfqVV51Z6NShQjzvFEp