### PR TITLE
gateway: a path beneath an EXACT grant is not "already granted" — route it to the operator, file nothing

### DIFF
--- a/sage/gateway/being_gate_client.py
+++ b/sage/gateway/being_gate_client.py
@@ -305,6 +305,22 @@ def _granted_roots(core, policy, workspace: str) -> tuple:
         return ()
 
 
+def _granted_reach(core, policy, workspace: str) -> tuple:
+    """``((root, recursive), ...)`` for every path grant, via the core's own reach resolver
+    (hestia_gate_core._scope_roots_with_reach, since #1002: exact unless spelled `/**`).
+    An older core has no reach resolver and matches every grant as a prefix, so its roots
+    are reported recursive — the reach that gate actually enforces, not a guess."""
+    if policy is None:
+        return ()
+    try:
+        reach = getattr(core, "_scope_roots_with_reach", None)
+        if reach is not None:
+            return tuple((str(r), bool(rec)) for r, rec in reach(list(getattr(policy, "scope", ()) or ()), workspace))
+        return tuple((r, True) for r in _granted_roots(core, policy, workspace))
+    except Exception:
+        return ()
+
+
 @dataclass(frozen=True)
 class GatewayVerdict:
     decision: str          # "allow" | "warn" | "deny"
@@ -318,6 +334,12 @@ class GatewayVerdict:
     # 2026-09-05 that a shared-context read grant "cannot be used at all" because the local
     # dispatcher confined memory_read to the instance dir before hestia's gate was consulted.
     granted: tuple = ()
+    # The same roots WITH their reach: ((root, recursive), ...). Since hestia #1002 a bare
+    # grant is exact. Measured 2026-09-12 (cbp-being, first beat on the new mind): the
+    # dispatcher's request_scope dedup matched `granted` as prefixes, told the being
+    # "you already hold reach here" for journal.md beneath an EXACT home grant, filed
+    # nothing, and the being retried 22 times in one beat with no request_id anywhere.
+    granted_reach: tuple = ()
 
     @property
     def blocks(self) -> bool:
@@ -507,6 +529,7 @@ class BeingGateClient:
                     policy = None
             v = self._core.evaluate(ev, self._profile, self.workspace, policy=policy)
             granted = _granted_roots(self._core, policy, self.workspace)
+            granted_reach = _granted_reach(self._core, policy, self.workspace)
         except Exception as e:
             return GatewayVerdict("deny", "gate.raised", innate=True, stage="local-law",
                                   reason=f"{type(e).__name__}: {e}")
@@ -545,7 +568,7 @@ class BeingGateClient:
                                           reason=f"society-safety failed ({type(e).__name__}); consequential act denied")
                 # observational: local law already allowed, soft-pass
         return GatewayVerdict(v.decision, v.rule, v.reason or "ok", v.innate, stage="local-law",
-                              granted=granted)
+                              granted=granted, granted_reach=granted_reach)
 
     # -- the F1a seam: gate, then dispatch, then consume the result ----------
     def dispatch(self, intent: BeingIntent) -> ResultEnvelope:

--- a/sage/gateway/escalate.py
+++ b/sage/gateway/escalate.py
@@ -95,6 +95,32 @@ def _scope_path(intent: BeingIntent, memory_root: str) -> str:
     return os.path.dirname(p) if os.path.splitext(p)[1] else p
 
 
+_EXACT_HINT = re.compile(r"your grant path:(\S+) is EXACT")
+
+
+def exact_root_above(env: ResultEnvelope, path: str) -> Optional[str]:
+    """The EXACT-granted root the refused path lies beneath, or None. Read from the verdict's
+    reach when the client carried it, else from the gate's own hint in the deny text
+    (hestia_gate_core._exact_grant_hint, 2026-09-08). Measured 2026-09-12: cbp-being's home was
+    granted bare after #1002, its journal.md refused, and this module asked the daemon for the
+    home root — which the being already held, exactly — so the answer was `already_granted`,
+    request_id null, and nothing anyone could rule on."""
+    v = env.verdict
+    p = os.path.realpath(os.path.expanduser(path))
+    best = None
+    for r, recursive in ((getattr(v, "granted_reach", ()) or ()) if v else ()):
+        r = os.path.realpath(str(r))
+        if recursive and (p == r or p.startswith(r + "/")):
+            return None                                   # reachable after all; not this case
+        if not recursive and p.startswith(r + "/") and (best is None or len(r) > len(best)):
+            best = r
+    if best is None and v and v.reason:
+        m = _EXACT_HINT.search(v.reason)
+        if m:
+            best = m.group(1).rstrip("/")
+    return best
+
+
 def _file_scope_request(member: str, path: str, why: str, endpoint: str) -> Dict[str, Any]:
     m = _Mcp(endpoint, member); m.init()
     conn = _unwrap(m.call("hestia_connect", {"plugin_id": member, "host_agent": "sage-escalate",
@@ -143,6 +169,17 @@ def write_note(member: str, intent: BeingIntent, env: ResultEnvelope, kind: str,
                        "  `hestia gate approve|deny <id> --as claude-code --reason '<why>'`. No delegation needed (NOT-SAME peer).\n"),
         "society": ("## What the seat can do now\n- A law verdict. If plainly wrong, open an appeal on the being's behalf and corroborate; never override.\n"),
     }.get(kind, "")
+    if kind == "scope" and (extra.get("scope_request") or {}).get("status") == "exact_grant":
+        root = str((extra.get("scope_request") or {}).get("root"))
+        how = ("## What the seat can do now\n"
+               "- There is NO request_id to arbitrate: the being already holds `" + root + "`, EXACT, and the\n"
+               "  refused path lies beneath it (hestia #1002: a bare grant reaches its path and nothing under it).\n"
+               "  The remedy is the operator's: make that standing grant recursive — dashboard 'make recursive'\n"
+               "  on the row, or POST /api/scope/standing/recursive with\n"
+               '  {"plugin_id": "' + member + '", "path": "' + root + '", "recursive": true, "reason": "<why>"}\n'
+               "  under an operator session. A seat cannot do this; leave it for dp with your recommendation and\n"
+               "  say so in the thread. Do not file a child-path request (a fresh row is what exact-by-default\n"
+               "  exists to stop; Legion 2026-09-08).\n")
     p.write_text(body + how + "\n" + protocol)
     # Land it. An UNCOMMITTED note in a shared checkout is not just untidy: the same name
     # arriving from upstream makes every later `git rebase` in that repo fail add/add, and
@@ -221,10 +258,19 @@ def escalate(member: str, intent: BeingIntent, env: ResultEnvelope, memory_root:
     try:
         if kind == "scope":
             path = _scope_path(intent, memory_root)
-            why = (f"{member} was refused {intent.effector} at {path} ({env.verdict.rule if env.verdict else ''}). "
-                   f"Its seat's auto session will rule it under delegation if it holds one (hestia #952), "
-                   f"else please rule as STANDING if it is the being's own memory.")
-            out["scope_request"] = _file_scope_request(member, path, why, endpoint)
+            raw = str(intent.args.get("path") or "")
+            target = raw if os.path.isabs(os.path.expanduser(raw)) else os.path.join(memory_root, raw)
+            exact = exact_root_above(env, target)
+            if exact:
+                # The daemon answers `already_granted` for a root the being holds exactly, and a
+                # request for the child would stack a row: neither is an ask anyone can rule on.
+                out["scope_request"] = {"request_id": None, "status": "exact_grant", "root": exact,
+                                        "needs": "operator: make the standing grant recursive"}
+            else:
+                why = (f"{member} was refused {intent.effector} at {path} ({env.verdict.rule if env.verdict else ''}). "
+                       f"Its seat's auto session will rule it under delegation if it holds one (hestia #952), "
+                       f"else please rule as STANDING if it is the being's own memory.")
+                out["scope_request"] = _file_scope_request(member, path, why, endpoint)
         # The note exists to be pointed at by the wake. Without a wake there is no reader, and a
         # beat with nine refused home writes would leave nine near-identical notes (Sprout, #38
         # review); the scope request above is still filed (the daemon dedups it on the path).

--- a/sage/gateway/heartbeat.py
+++ b/sage/gateway/heartbeat.py
@@ -369,8 +369,9 @@ def main(argv=None) -> int:
     if disp is not None and hasattr(disp, "_call"):
         try:
             st = disp._call("hestia_scope_status", {"plugin_id": args.member})
-            grants = [g.get("path") for g in (st.get("live_grants") or [])] + \
-                     [g.get("path") for g in (st.get("standing_grants") or [])]
+            # spelled with the gate's own suffix: `<root>/**` reaches the subtree, bare is EXACT
+            grants = [f"{g.get('path')}{'/**' if g.get('recursive') else ''}"
+                      for g in (st.get("live_grants") or []) + (st.get("standing_grants") or [])]
             reqs = [(r.get("request_id"), r.get("path"), r.get("decision") or r.get("status"))
                     for r in (st.get("requests") or [])]
             who_ruled = {r.get("request_id"): r.get("decided_by") for r in (st.get("requests") or [])

--- a/sage/gateway/hestia_dispatch.py
+++ b/sage/gateway/hestia_dispatch.py
@@ -529,11 +529,24 @@ class HestiaF1aDispatcher:
         # <home>/config.json, inside the standing home grant, and dp granted it again).
         import os as _os
         rp = _os.path.realpath(_os.path.expanduser(path))
-        for root in (getattr(getattr(self, "_verdict", None), "granted", ()) or ()):
-            r = _os.path.realpath(str(root))
-            if rp == r or rp.startswith(r + "/"):
+        exact_above = None
+        for r, recursive in _granted_reach_of(getattr(self, "_verdict", None)):
+            r = _os.path.realpath(str(r))
+            if rp == r or (recursive and rp.startswith(r + "/")):
                 return ResultEnvelope(ok=True, result={"status": "already_granted", "path": path, "within": r,
                                                        "next": "you already hold reach here; read or write it directly"})
+            if rp.startswith(r + "/") and (exact_above is None or len(r) > len(exact_above)):
+                exact_above = r
+        # Beneath a grant that is EXACT (hestia #1002: a bare grant reaches its path and nothing
+        # under it). "already granted" here is false — the gate just refused — and filing a
+        # child row is what exact-by-default exists to stop (Legion, 2026-09-08). The honest
+        # answer names the operator's act and tells the being to stop retrying.
+        if exact_above is not None:
+            return ResultEnvelope(ok=True, result={
+                "status": "beneath_exact_grant", "path": path, "root": exact_above,
+                "next": (f"your grant on {exact_above} is EXACT: it reaches that path and nothing beneath it. "
+                         f"Only the operator can make it recursive (path:{exact_above}/**). No request was filed; "
+                         f"your seat has been told. Do not retry this write in this beat.")})
         args: Dict[str, Any] = {"plugin_id": self.plugin_id, "path": path,
                                 "reason": f"[{self.plugin_id}] {reason}"}
         out = self._call("hestia_request_scope", args)
@@ -550,6 +563,15 @@ class HestiaF1aDispatcher:
         return ResultEnvelope(ok=False, pending=True,
                               note="channel_egress awaits hestia's send-side tool (hestia_egress_pending is "
                                    "read-only; F5 enforcement gated on rate-governor calibration, PRD §12)")
+
+
+def _granted_reach_of(verdict) -> tuple:
+    """((root, recursive), ...) from a verdict. A verdict built without reach (older client,
+    hand-made in tests) keeps the pre-#1002 prefix reading of its bare `granted` roots."""
+    reach = tuple(getattr(verdict, "granted_reach", ()) or ())
+    if reach:
+        return reach
+    return tuple((r, True) for r in (getattr(verdict, "granted", ()) or ()))
 
 
 # --------------------------------------------------------------------------

--- a/sage/gateway/tests/test_being_gate_client.py
+++ b/sage/gateway/tests/test_being_gate_client.py
@@ -325,3 +325,21 @@ if __name__ == "__main__":
         if name.startswith("test_") and callable(fn):
             fn(); n += 1; print(f"PASS {name}")
     print(f"\n{n} passed")
+
+
+def test_granted_reach_reads_the_cores_reach_resolver_and_an_older_core_is_recursive():
+    from sage.gateway.being_gate_client import _granted_reach, GatewayVerdict
+    class Pol:
+        scope = ("path:/tmp/being-home", "path:/tmp/shared/**", "repo:x")
+    class Core:
+        @staticmethod
+        def _scope_roots_with_reach(scopes, ws):
+            return (("/tmp/being-home", False), ("/tmp/shared", True))
+        @staticmethod
+        def _scope_parts(scopes, ws):
+            return ((), ("/tmp/being-home", "/tmp/shared"))
+    assert _granted_reach(Core, Pol, "/ws") == (("/tmp/being-home", False), ("/tmp/shared", True))
+    # a core without the resolver matches every grant as a prefix: that reach is reported, not exact
+    older = _granted_reach(object(), Pol, "/ws")
+    assert older and all(rec for _, rec in older)
+    assert _granted_reach(Core, None, "/ws") == () and GatewayVerdict("allow").granted_reach == ()

--- a/sage/gateway/tests/test_escalate.py
+++ b/sage/gateway/tests/test_escalate.py
@@ -133,3 +133,36 @@ if __name__ == "__main__":
         if name.startswith("test_") and callable(fn):
             fn(); n += 1; print(f"PASS {name}")
     print(f"\n{n} passed")
+
+
+def test_refusal_beneath_an_exact_home_grant_routes_to_the_operator_and_files_nothing():
+    # cbp-being 2026-09-12 (first beat on the new mind): home granted bare after hestia #1002,
+    # journal.md refused, and this module asked the daemon for the home root the being already
+    # held — `already_granted`, request_id null, 22 escalations in one beat, nothing to rule on.
+    root = tempfile.mkdtemp(); d = tempfile.mkdtemp(); e.NOTE_DIR = d
+    real = os.path.realpath(root)
+    i = BeingIntent("memory_write", {"path": "journal.md", "content": "x"})
+    hint = (f"'sage' is not granted (granted: path:{real}); note: your grant path:{real} is EXACT — "
+            f"it reaches that path itself and nothing beneath it.")
+    env = ResultEnvelope(ok=False, refused=True, error=hint,
+                         verdict=GatewayVerdict("deny", "mrh.path", hint, stage="local-law",
+                                                granted=(real,), granted_reach=((real, False),)))
+    assert e.exact_root_above(env, os.path.join(real, "journal.md")) == real
+    # reach absent from the verdict: the gate's own hint names the root
+    assert e.exact_root_above(_ref("mrh.path", hint), os.path.join(real, "journal.md")) == real
+    # a recursive grant is not this case
+    rec = ResultEnvelope(ok=False, refused=True, error="x",
+                         verdict=GatewayVerdict("deny", "mrh.path", "x", granted_reach=((real, True),)))
+    assert e.exact_root_above(rec, os.path.join(real, "journal.md")) is None
+    filed = []
+    orig = e._file_scope_request
+    e._file_scope_request = lambda *a: (filed.append(a) or {"request_id": "scope-x", "status": "pending"})
+    try:
+        r = e.escalate("cbp-being", i, env, root, wake=False)
+    finally:
+        e._file_scope_request = orig
+    assert r["escalated"] is True and not filed, r
+    assert r["scope_request"] == {"request_id": None, "status": "exact_grant", "root": real,
+                                  "needs": "operator: make the standing grant recursive"}
+    t = open(e.write_note("cbp-being", i, env, "scope", r)).read()
+    assert "NO request_id" in t and "standing/recursive" in t and real in t and "Arbiter protocol" in t

--- a/sage/gateway/tests/test_hestia_dispatch.py
+++ b/sage/gateway/tests/test_hestia_dispatch.py
@@ -696,3 +696,23 @@ def test_a_duplicate_still_saves_when_the_session_holds_unpersisted_work():
     assert _mb_calls("save_cartridge") == [{"name": "sprout-being"}], \
         "a duplicate on a dirty session must still persist"
     assert not d._mb_dirty, "a successful save clears the flag"
+
+
+def test_request_scope_beneath_an_exact_grant_is_not_already_granted_and_files_nothing():
+    # cbp-being 2026-09-12: home granted bare after hestia #1002, journal.md refused, and this
+    # dedup said "you already hold reach here" 22 times in one beat, filing nothing.
+    from sage.gateway.being_gate_client import GatewayVerdict
+    d, root = _disp()
+    FakeMcp.calls.clear()
+    exact = GatewayVerdict("allow", granted=(root,), granted_reach=((root, False),))
+    env = d(BeingIntent("request_scope", {"path": root + "/journal.md", "reason": "to write my journal entry"}), exact)
+    assert env.ok and env.result["status"] == "beneath_exact_grant", env
+    assert env.result["root"] == os.path.realpath(root) and "/**" in env.result["next"]
+    assert not [n for n, _ in FakeMcp.calls if n == "hestia_request_scope"]
+    # the root itself IS held, exactly
+    env = d(BeingIntent("request_scope", {"path": root, "reason": "to reach my own home dir"}), exact)
+    assert env.ok and env.result["status"] == "already_granted"
+    # a recursive grant still answers the child locally
+    env = d(BeingIntent("request_scope", {"path": root + "/journal.md", "reason": "to write my journal entry"}),
+            GatewayVerdict("allow", granted=(root,), granted_reach=((root, True),)))
+    assert env.ok and env.result["status"] == "already_granted"


### PR DESCRIPTION
## What broke

cbp-being's first beat on the new mind (2026-09-12, 19:30 PDT). Its home dir was granted bare, which since hestia #1002 is EXACT. The gate refused `journal.md` with the right hint. Then two SAGE-side readers of the same grant contradicted the gate:

- `hestia_dispatch._do_request_scope` matched the verdict's bare `granted` roots as prefixes and told the being "you already hold reach here; read or write it directly". It did, was refused, asked again: **22 `already_granted` answers in one beat, `request_id: null` on every one.**
- `escalate.escalate` asked the daemon for the home root (per `_scope_path`), which the being already held exactly, so the daemon also said `already_granted`. The escalation note then carried a routing line with nothing to rule on.

dp flipped the grant recursive by hand two minutes later and the next beat wrote. The escalation note: `shared-context/escalations/cbp-being-scope-memory_write-2026-09-12-193312.md`.

## What changes

- `GatewayVerdict.granted_reach`: `((root, recursive), ...)` from the core's own `_scope_roots_with_reach`. An older core matches every grant as a prefix, so its roots are reported recursive, which is what that gate enforces.
- `request_scope` beneath an EXACT root answers `beneath_exact_grant` naming the root and the operator's spelling `path:<root>/**`, files nothing (a child row is what exact-by-default exists to stop, per Legion's 2026-09-08 note), and tells the being to stop retrying in this beat.
- `escalate` routes that case as `{status: exact_grant, root, request_id: null}` without calling the daemon. The note's "what the seat can do" section says plainly there is nothing to arbitrate and names the operator's act (`POST /api/scope/standing/recursive`). It reads the verdict's reach when present, else the gate's own hint text.
- The heartbeat's "granted paths" spells reach (`<root>/**` vs bare).

## Still the daemon's

`hestia_request_scope` hardcodes `recursive: false`, so a member has no verb to ask for its exact grant to become recursive. Filed as a hestia issue; linked in the thread.

## Tests

Three new tests (dispatcher, client, escalation routing). 

```
sage/gateway/tests/test_escalate.py test_hestia_dispatch.py test_being_gate_client.py: 76 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
